### PR TITLE
Fix 404 error on user management admin page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -110,7 +110,7 @@ function AppRoutes() {
       />
 
       <Route
-        path="/admin/stages"
+        path="/admin/config/stages"
         element={
           <ProtectedRoute adminOnly>
             <ConfigStages />
@@ -119,7 +119,7 @@ function AppRoutes() {
       />
 
       <Route
-        path="/admin/users"
+        path="/admin/config/users"
         element={
           <ProtectedRoute adminOnly>
             <ConfigUsers />


### PR DESCRIPTION
The navigation menu in AdminLayout was linking to /admin/config/users and /admin/config/stages, but the routes in App.tsx were defined as /admin/users and /admin/stages. This mismatch caused 404 errors when clicking these menu items.

Updated both routes to use the /admin/config/* path pattern for consistency with other config routes (api-keys and webhooks).