### PR TITLE
Build operator dashboard with controls and tracking

### DIFF
--- a/src/components/operator/OperatorFooterBar.tsx
+++ b/src/components/operator/OperatorFooterBar.tsx
@@ -1,0 +1,278 @@
+import { useEffect, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { supabase } from "@/integrations/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Clock, Square, Pause, Play, AlertTriangle } from "lucide-react";
+import { stopTimeTracking, pauseTimeTracking, resumeTimeTracking } from "@/lib/database";
+import { toast } from "sonner";
+import { formatDistanceToNow } from "date-fns";
+import { useNavigate } from "react-router-dom";
+
+interface ActiveEntry {
+  id: string;
+  operation_id: string;
+  start_time: string;
+  is_paused: boolean;
+  operation: {
+    operation_name: string;
+    part: {
+      part_number: string;
+      job: {
+        job_number: string;
+      };
+    };
+  };
+}
+
+interface PauseData {
+  paused_at: string;
+}
+
+export default function OperatorFooterBar() {
+  const { profile } = useAuth();
+  const navigate = useNavigate();
+  const [activeEntry, setActiveEntry] = useState<ActiveEntry | null>(null);
+  const [currentPause, setCurrentPause] = useState<PauseData | null>(null);
+  const [, setTick] = useState(0);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!profile?.id) return;
+
+    loadActiveEntry();
+
+    // Update every second for elapsed time
+    const interval = setInterval(() => {
+      setTick((prev) => prev + 1);
+    }, 1000);
+
+    // Subscribe to time entries changes
+    const channel = supabase
+      .channel("operator-footer-time-entries")
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "time_entries",
+          filter: `operator_id=eq.${profile.id}`,
+        },
+        () => {
+          loadActiveEntry();
+        }
+      )
+      .subscribe();
+
+    return () => {
+      clearInterval(interval);
+      supabase.removeChannel(channel);
+    };
+  }, [profile?.id]);
+
+  const loadActiveEntry = async () => {
+    if (!profile?.id) return;
+
+    const { data, error } = await supabase
+      .from("time_entries")
+      .select(
+        `
+        id,
+        operation_id,
+        start_time,
+        is_paused,
+        operation:operations(
+          operation_name,
+          part:parts(
+            part_number,
+            job:jobs(job_number)
+          )
+        )
+      `
+      )
+      .eq("operator_id", profile.id)
+      .is("end_time", null)
+      .maybeSingle();
+
+    if (!error && data) {
+      setActiveEntry(data as any);
+
+      // If paused, load the current pause
+      if (data.is_paused) {
+        loadCurrentPause(data.id);
+      } else {
+        setCurrentPause(null);
+      }
+    } else {
+      setActiveEntry(null);
+      setCurrentPause(null);
+    }
+  };
+
+  const loadCurrentPause = async (timeEntryId: string) => {
+    const { data } = await supabase
+      .from("time_entry_pauses")
+      .select("paused_at")
+      .eq("time_entry_id", timeEntryId)
+      .is("resumed_at", null)
+      .maybeSingle();
+
+    if (data) {
+      setCurrentPause(data);
+    }
+  };
+
+  const handleStop = async () => {
+    if (!profile?.id || !activeEntry) return;
+
+    setLoading(true);
+    try {
+      await stopTimeTracking(activeEntry.operation_id, profile.id);
+      toast.success("Time tracking stopped");
+      loadActiveEntry();
+    } catch (error: any) {
+      toast.error(error.message || "Failed to stop time tracking");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handlePause = async () => {
+    if (!profile?.id || !activeEntry) return;
+
+    setLoading(true);
+    try {
+      await pauseTimeTracking(activeEntry.id);
+      toast.success("Time tracking paused");
+      loadActiveEntry();
+    } catch (error: any) {
+      toast.error(error.message || "Failed to pause time tracking");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleResume = async () => {
+    if (!profile?.id || !activeEntry) return;
+
+    setLoading(true);
+    try {
+      await resumeTimeTracking(activeEntry.id);
+      toast.success("Time tracking resumed");
+      loadActiveEntry();
+    } catch (error: any) {
+      toast.error(error.message || "Failed to resume time tracking");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleReportIssue = () => {
+    // Navigate to work queue which has the operation detail modal
+    navigate("/work-queue");
+    toast.info("Open the operation to report an issue");
+  };
+
+  // Don't render footer if no active entry
+  if (!activeEntry) return null;
+
+  const isPaused = activeEntry.is_paused;
+  const timeReference = isPaused && currentPause
+    ? new Date(currentPause.paused_at)
+    : new Date(activeEntry.start_time);
+
+  return (
+    <div className="fixed left-0 right-0 z-40 bg-gradient-to-r from-blue-600 to-purple-600 text-white shadow-lg border-t-4 border-blue-400" style={{ bottom: 'max(0px, env(safe-area-inset-bottom))' }}>
+      <div className="container mx-auto px-3 sm:px-4 py-2 sm:py-3">
+        <div className="flex items-center justify-between gap-2 sm:gap-4">
+          {/* Left: Operation Info */}
+          <div className="flex items-center gap-2 sm:gap-3 flex-1 min-w-0">
+            <div className={`p-1.5 sm:p-2 rounded-lg ${isPaused ? 'bg-yellow-500/20' : 'bg-white/20'} flex-shrink-0`}>
+              <Clock className={`h-5 w-5 sm:h-6 sm:w-6 ${isPaused ? 'text-yellow-300' : 'text-white'}`} />
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="font-semibold text-sm sm:text-lg truncate">
+                {activeEntry.operation.operation_name}
+              </div>
+              <div className="text-xs sm:text-sm text-white/90 truncate">
+                Job {activeEntry.operation.part.job.job_number} • {activeEntry.operation.part.part_number}
+              </div>
+              <div className="text-xs text-white/80 hidden sm:block">
+                {isPaused ? (
+                  <>Paused {formatDistanceToNow(timeReference, { addSuffix: true })}</>
+                ) : (
+                  <>Started {formatDistanceToNow(timeReference, { addSuffix: true })}</>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Right: Action Buttons */}
+          <div className="flex items-center gap-1 sm:gap-2 flex-shrink-0">
+            {/* Report Issue Button - Desktop only */}
+            <Button
+              onClick={handleReportIssue}
+              disabled={loading}
+              variant="outline"
+              size="sm"
+              className="gap-1 sm:gap-2 bg-orange-500 hover:bg-orange-600 text-white border-orange-400 hidden lg:flex"
+            >
+              <AlertTriangle className="h-4 w-4" />
+              <span>Report Issue</span>
+            </Button>
+
+            {/* Report Issue Button - Mobile icon only */}
+            <Button
+              onClick={handleReportIssue}
+              disabled={loading}
+              variant="outline"
+              size="sm"
+              className="bg-orange-500 hover:bg-orange-600 text-white border-orange-400 lg:hidden p-2"
+              title="Report Issue"
+            >
+              <AlertTriangle className="h-4 w-4" />
+            </Button>
+
+            {/* Pause/Resume Button */}
+            {isPaused ? (
+              <Button
+                onClick={handleResume}
+                disabled={loading}
+                size="sm"
+                className="gap-1 sm:gap-2 bg-green-500 hover:bg-green-600 text-white border-green-400"
+                title="Resume timing"
+              >
+                <Play className="h-4 w-4" />
+                <span className="hidden sm:inline">Resume</span>
+              </Button>
+            ) : (
+              <Button
+                onClick={handlePause}
+                disabled={loading}
+                variant="outline"
+                size="sm"
+                className="gap-1 sm:gap-2 bg-yellow-500 hover:bg-yellow-600 text-white border-yellow-400"
+                title="Pause timing"
+              >
+                <Pause className="h-4 w-4" />
+                <span className="hidden sm:inline">Pause</span>
+              </Button>
+            )}
+
+            {/* Stop Button */}
+            <Button
+              onClick={handleStop}
+              disabled={loading}
+              variant="outline"
+              size="sm"
+              className="gap-1 sm:gap-2 bg-red-500 hover:bg-red-600 text-white border-red-400"
+              title="Stop timing"
+            >
+              <Square className="h-4 w-4" />
+              <span className="hidden sm:inline">Stop</span>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/operator/OperatorLayout.tsx
+++ b/src/components/operator/OperatorLayout.tsx
@@ -26,7 +26,7 @@ import {
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 import { useThemeMode } from '@/theme/ThemeProvider';
-import CurrentlyTimingWidget from './CurrentlyTimingWidget';
+import OperatorFooterBar from './OperatorFooterBar';
 
 interface OperatorLayoutProps {
   children: React.ReactNode;
@@ -185,21 +185,6 @@ export const OperatorLayout: React.FC<OperatorLayoutProps> = ({ children }) => {
         </Toolbar>
       </AppBar>
 
-      {/* Currently Timing Widget - Sticky below header */}
-      <Box
-        sx={{
-          position: 'sticky',
-          top: { xs: 56, sm: 64 },
-          zIndex: theme.zIndex.appBar - 1,
-          backgroundColor: theme.palette.background.default,
-          borderBottom: `1px solid ${theme.palette.divider}`,
-        }}
-      >
-        <Box sx={{ px: { xs: 2, sm: 3 }, py: 1.5 }}>
-          <CurrentlyTimingWidget />
-        </Box>
-      </Box>
-
       {/* Main Content */}
       <Box
         component="main"
@@ -207,11 +192,14 @@ export const OperatorLayout: React.FC<OperatorLayoutProps> = ({ children }) => {
           flexGrow: 1,
           px: { xs: 2, sm: 3 },
           py: { xs: 2, sm: 3 },
-          pb: { xs: 10, sm: 3 }, // Extra padding for mobile bottom nav
+          pb: { xs: 12, sm: 10 }, // Extra padding for mobile bottom nav and footer bar
         }}
       >
         {children}
       </Box>
+
+      {/* Operator Footer Bar - Only shows when actively timing */}
+      <OperatorFooterBar />
 
       {/* Bottom Navigation - Mobile Only */}
       <Paper

--- a/supabase/migrations/20251117000000_add_pause_functionality.sql
+++ b/supabase/migrations/20251117000000_add_pause_functionality.sql
@@ -1,0 +1,52 @@
+-- Add pause tracking for time entries
+CREATE TABLE IF NOT EXISTS public.time_entry_pauses (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  time_entry_id UUID NOT NULL REFERENCES time_entries(id) ON DELETE CASCADE,
+  paused_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  resumed_at TIMESTAMPTZ,
+  duration INTEGER, -- Duration of pause in seconds
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Enable RLS
+ALTER TABLE public.time_entry_pauses ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies for time_entry_pauses
+CREATE POLICY "Users can view their own pauses"
+  ON public.time_entry_pauses
+  FOR SELECT
+  USING (
+    time_entry_id IN (
+      SELECT id FROM time_entries WHERE operator_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can insert their own pauses"
+  ON public.time_entry_pauses
+  FOR INSERT
+  WITH CHECK (
+    time_entry_id IN (
+      SELECT id FROM time_entries WHERE operator_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can update their own pauses"
+  ON public.time_entry_pauses
+  FOR UPDATE
+  USING (
+    time_entry_id IN (
+      SELECT id FROM time_entries WHERE operator_id = auth.uid()
+    )
+  );
+
+-- Add is_paused flag to time_entries for quick lookup
+ALTER TABLE public.time_entries
+ADD COLUMN IF NOT EXISTS is_paused BOOLEAN DEFAULT FALSE;
+
+-- Index for performance
+CREATE INDEX IF NOT EXISTS idx_time_entry_pauses_time_entry_id
+  ON public.time_entry_pauses(time_entry_id);
+
+CREATE INDEX IF NOT EXISTS idx_time_entry_pauses_resumed_at
+  ON public.time_entry_pauses(resumed_at)
+  WHERE resumed_at IS NULL;


### PR DESCRIPTION
Implemented an intuitive footer bar for operators that:
- Only shows when actively timing an operation
- Displays current operation details with elapsed/paused time
- Provides pause/resume functionality for flexible time tracking
- Includes quick access to NCR (issue) reporting
- Features prominent stop button to prevent forgotten clock-ins
- Responsive design optimized for mobile and desktop

Key Changes:
- Created OperatorFooterBar component replacing sticky header widget
- Added pause/resume time tracking functions to database.ts
- Created database migration for time_entry_pauses table
- Updated stopTimeTracking to exclude pause time from duration
- Enhanced OperatorLayout with footer positioning
- Mobile-optimized button layout with icons and labels

The footer bar uses a gradient design (blue to purple) to stand out and ensure operators never forget they're clocked in. Pause state is clearly indicated with yellow accent colors.