### PR TITLE
Review and fix PDF materials resources PR

### DIFF
--- a/supabase/migrations/20251117153200_add_materials_table.sql
+++ b/supabase/migrations/20251117153200_add_materials_table.sql
@@ -1,7 +1,7 @@
 -- Create materials table
 CREATE TABLE IF NOT EXISTS materials (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  tenant_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
   name TEXT NOT NULL,
   description TEXT,
   color TEXT,

--- a/supabase/migrations/20251117153634_add_resources_system.sql
+++ b/supabase/migrations/20251117153634_add_resources_system.sql
@@ -1,7 +1,7 @@
 -- Create resources table for reusable resources (tooling, fixtures, molds, etc.)
 CREATE TABLE IF NOT EXISTS resources (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  tenant_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
   name TEXT NOT NULL,
   type TEXT NOT NULL, -- 'tooling', 'fixture', 'mold', 'material', 'other'
   description TEXT,


### PR DESCRIPTION
…tions

The materials and resources migrations were incorrectly referencing auth.users(id) for the tenant_id foreign key. This caused migration failures since tenant_id values in the system are organization UUIDs that reference the tenants table, not auth user IDs.

Changes:
- Fixed materials table: tenant_id now references public.tenants(id)
- Fixed resources table: tenant_id now references public.tenants(id)

This resolves the P1 issue identified in PR #19 code review where the migration would fail with foreign key violations when trying to INSERT existing materials from the parts table.