### PR TITLE
Fix critical foreign key constraint in materials and resources tables

### DIFF
--- a/supabase/migrations/20251117153200_add_materials_table.sql
+++ b/supabase/migrations/20251117153200_add_materials_table.sql
@@ -1,7 +1,7 @@
 -- Create materials table
 CREATE TABLE IF NOT EXISTS materials (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  tenant_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  tenant_id UUID NOT NULL,
   name TEXT NOT NULL,
   description TEXT,
   color TEXT,

--- a/supabase/migrations/20251117153634_add_resources_system.sql
+++ b/supabase/migrations/20251117153634_add_resources_system.sql
@@ -1,7 +1,7 @@
 -- Create resources table for reusable resources (tooling, fixtures, molds, etc.)
 CREATE TABLE IF NOT EXISTS resources (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  tenant_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  tenant_id UUID NOT NULL,
   name TEXT NOT NULL,
   type TEXT NOT NULL, -- 'tooling', 'fixture', 'mold', 'material', 'other'
   description TEXT,


### PR DESCRIPTION
- Remove incorrect REFERENCES auth.users(id) constraint from tenant_id
- tenant_id should not have a foreign key as it's a tenant identifier
- This fixes foreign key violations when inserting data
- Prevents cascade deletes when user accounts are removed
- Aligns with existing schema pattern used in other tables

Addresses issues identified in PR #14 review