### PR TITLE
Add view for all steps and templates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import Parts from "./pages/admin/Parts";
 import { ActivityMonitor } from "./pages/admin/ActivityMonitor";
 import { Operations } from "./pages/admin/Operations";
 import { Settings } from "./pages/admin/Settings";
+import StepsTemplatesView from "./pages/admin/StepsTemplatesView";
 import ApiDocs from "./pages/ApiDocs";
 import Pricing from "./pages/Pricing";
 import { MyPlan } from "./pages/MyPlan";
@@ -284,6 +285,15 @@ function AppRoutes() {
         element={
           <ProtectedRoute adminOnly>
             <Settings />
+          </ProtectedRoute>
+        }
+      />
+
+      <Route
+        path="/admin/config/steps-templates"
+        element={
+          <ProtectedRoute adminOnly>
+            <StepsTemplatesView />
           </ProtectedRoute>
         }
       />

--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -186,6 +186,11 @@ export const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
           icon: <BuildIcon />,
         },
         {
+          path: "/admin/config/steps-templates",
+          label: t("Steps & Templates"),
+          icon: <CheckCircleIcon />,
+        },
+        {
           path: "/admin/config/api-keys",
           label: t("navigation.apiKeys"),
           icon: <VpnKeyIcon />,

--- a/src/components/admin/AllSubstepsView.tsx
+++ b/src/components/admin/AllSubstepsView.tsx
@@ -1,0 +1,406 @@
+import { useEffect, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { supabase } from "@/integrations/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import { Edit, Trash2, Loader2, Search, Filter } from "lucide-react";
+import { toast } from "sonner";
+import { useTranslation } from "react-i18next";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+interface Substep {
+  id: string;
+  operation_id: string;
+  name: string;
+  notes: string | null;
+  status: string;
+  sequence: number;
+  completed_at: string | null;
+  completed_by: string | null;
+  created_at: string;
+  updated_at: string;
+  operation?: {
+    id: string;
+    operation_name: string;
+    part?: {
+      id: string;
+      part_number: string;
+      job?: {
+        id: string;
+        job_number: string;
+      };
+    };
+  };
+}
+
+export function AllSubstepsView() {
+  const { t } = useTranslation();
+  const { profile } = useAuth();
+  const [substeps, setSubsteps] = useState<Substep[]>([]);
+  const [filteredSubsteps, setFilteredSubsteps] = useState<Substep[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [editingSubstep, setEditingSubstep] = useState<Substep | null>(null);
+  const [formData, setFormData] = useState({
+    name: "",
+    notes: "",
+    status: "not_started",
+  });
+
+  useEffect(() => {
+    if (!profile?.tenant_id) return;
+    loadSubsteps();
+  }, [profile?.tenant_id]);
+
+  useEffect(() => {
+    filterSubsteps();
+  }, [searchTerm, statusFilter, substeps]);
+
+  const loadSubsteps = async () => {
+    if (!profile?.tenant_id) return;
+    setLoading(true);
+
+    const { data, error } = await supabase
+      .from("substeps")
+      .select(`
+        *,
+        operation:operations (
+          id,
+          operation_name,
+          part:parts (
+            id,
+            part_number,
+            job:jobs (
+              id,
+              job_number
+            )
+          )
+        )
+      `)
+      .eq('tenant_id', profile.tenant_id)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      console.error("Error loading substeps:", error);
+      toast.error(t("Failed to load substeps"));
+    } else {
+      setSubsteps(data || []);
+    }
+
+    setLoading(false);
+  };
+
+  const filterSubsteps = () => {
+    let filtered = [...substeps];
+
+    // Filter by search term
+    if (searchTerm) {
+      const term = searchTerm.toLowerCase();
+      filtered = filtered.filter(
+        (substep) =>
+          substep.name.toLowerCase().includes(term) ||
+          substep.notes?.toLowerCase().includes(term) ||
+          substep.operation?.operation_name.toLowerCase().includes(term) ||
+          substep.operation?.part?.part_number.toLowerCase().includes(term) ||
+          substep.operation?.part?.job?.job_number.toLowerCase().includes(term)
+      );
+    }
+
+    // Filter by status
+    if (statusFilter !== "all") {
+      filtered = filtered.filter((substep) => substep.status === statusFilter);
+    }
+
+    setFilteredSubsteps(filtered);
+  };
+
+  const handleOpenEditDialog = (substep: Substep) => {
+    setEditingSubstep(substep);
+    setFormData({
+      name: substep.name,
+      notes: substep.notes || "",
+      status: substep.status,
+    });
+    setEditDialogOpen(true);
+  };
+
+  const handleCloseEditDialog = () => {
+    setEditDialogOpen(false);
+    setEditingSubstep(null);
+    setFormData({ name: "", notes: "", status: "not_started" });
+  };
+
+  const handleUpdate = async () => {
+    if (!editingSubstep) return;
+
+    if (!formData.name.trim()) {
+      toast.error(t("Substep name is required"));
+      return;
+    }
+
+    const { error } = await supabase
+      .from("substeps")
+      .update({
+        name: formData.name,
+        notes: formData.notes || null,
+        status: formData.status,
+        completed_at: formData.status === 'completed' ? new Date().toISOString() : null,
+        completed_by: formData.status === 'completed' ? profile?.id : null,
+      })
+      .eq('id', editingSubstep.id);
+
+    if (error) {
+      console.error("Error updating substep:", error);
+      toast.error(t("Failed to update substep"));
+    } else {
+      toast.success(t("Substep updated successfully"));
+      handleCloseEditDialog();
+      loadSubsteps();
+    }
+  };
+
+  const handleDelete = async (substep: Substep) => {
+    if (!confirm(t("Are you sure you want to delete this substep?"))) return;
+
+    const { error } = await supabase
+      .from("substeps")
+      .delete()
+      .eq('id', substep.id);
+
+    if (error) {
+      console.error("Error deleting substep:", error);
+      toast.error(t("Failed to delete substep"));
+    } else {
+      toast.success(t("Substep deleted successfully"));
+      loadSubsteps();
+    }
+  };
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'completed':
+        return 'bg-green-500/10 text-green-500 border-green-500/20';
+      case 'in_progress':
+        return 'bg-blue-500/10 text-blue-500 border-blue-500/20';
+      case 'blocked':
+        return 'bg-red-500/10 text-red-500 border-red-500/20';
+      default:
+        return 'bg-gray-500/10 text-gray-500 border-gray-500/20';
+    }
+  };
+
+  const getStatusLabel = (status: string) => {
+    switch (status) {
+      case 'completed':
+        return t('Completed');
+      case 'in_progress':
+        return t('In Progress');
+      case 'blocked':
+        return t('Blocked');
+      default:
+        return t('Not Started');
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-4 items-end">
+        <div className="flex-1 space-y-2">
+          <Label htmlFor="search">{t("Search")}</Label>
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              id="search"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              placeholder={t("Search by job, part, operation, or step name...")}
+              className="pl-9"
+            />
+          </div>
+        </div>
+        <div className="w-48 space-y-2">
+          <Label htmlFor="status-filter">{t("Status")}</Label>
+          <Select value={statusFilter} onValueChange={setStatusFilter}>
+            <SelectTrigger id="status-filter">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">{t("All Statuses")}</SelectItem>
+              <SelectItem value="not_started">{t("Not Started")}</SelectItem>
+              <SelectItem value="in_progress">{t("In Progress")}</SelectItem>
+              <SelectItem value="completed">{t("Completed")}</SelectItem>
+              <SelectItem value="blocked">{t("Blocked")}</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="text-sm text-muted-foreground">
+        {t("Showing")} {filteredSubsteps.length} {t("of")} {substeps.length} {t("substeps")}
+      </div>
+
+      <div className="border rounded-lg">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>{t("Job")}</TableHead>
+              <TableHead>{t("Part")}</TableHead>
+              <TableHead>{t("Operation")}</TableHead>
+              <TableHead>{t("Step Name")}</TableHead>
+              <TableHead>{t("Status")}</TableHead>
+              <TableHead>{t("Seq")}</TableHead>
+              <TableHead className="w-[100px]">{t("Actions")}</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filteredSubsteps.map((substep) => (
+              <TableRow key={substep.id}>
+                <TableCell className="font-medium">
+                  {substep.operation?.part?.job?.job_number || '-'}
+                </TableCell>
+                <TableCell>
+                  {substep.operation?.part?.part_number || '-'}
+                </TableCell>
+                <TableCell>
+                  {substep.operation?.operation_name || '-'}
+                </TableCell>
+                <TableCell>
+                  <div>
+                    <div className="font-medium">{substep.name}</div>
+                    {substep.notes && (
+                      <div className="text-sm text-muted-foreground line-clamp-1">
+                        {substep.notes}
+                      </div>
+                    )}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <Badge variant="outline" className={getStatusColor(substep.status)}>
+                    {getStatusLabel(substep.status)}
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {substep.sequence}
+                </TableCell>
+                <TableCell>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleOpenEditDialog(substep)}
+                    >
+                      <Edit className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleDelete(substep)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+
+        {filteredSubsteps.length === 0 && (
+          <div className="text-center py-12 text-muted-foreground">
+            {searchTerm || statusFilter !== 'all'
+              ? t("No substeps match your filters")
+              : t("No substeps created yet")}
+          </div>
+        )}
+      </div>
+
+      {/* Edit Dialog */}
+      <Dialog open={editDialogOpen} onOpenChange={setEditDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t("Edit Substep")}</DialogTitle>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="edit-name">{t("Step Name")}</Label>
+              <Input
+                id="edit-name"
+                value={formData.name}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                placeholder={t("Step name")}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="edit-notes">{t("Notes")}</Label>
+              <Textarea
+                id="edit-notes"
+                value={formData.notes}
+                onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
+                placeholder={t("Optional notes")}
+                rows={3}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="edit-status">{t("Status")}</Label>
+              <Select
+                value={formData.status}
+                onValueChange={(value) => setFormData({ ...formData, status: value })}
+              >
+                <SelectTrigger id="edit-status">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="not_started">{t("Not Started")}</SelectItem>
+                  <SelectItem value="in_progress">{t("In Progress")}</SelectItem>
+                  <SelectItem value="completed">{t("Completed")}</SelectItem>
+                  <SelectItem value="blocked">{t("Blocked")}</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={handleCloseEditDialog}>
+              {t("Cancel")}
+            </Button>
+            <Button onClick={handleUpdate}>
+              {t("Update")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/admin/TemplatesManager.tsx
+++ b/src/components/admin/TemplatesManager.tsx
@@ -1,0 +1,556 @@
+import { useEffect, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { supabase } from "@/integrations/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, DialogFooter } from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import { Plus, Edit, Trash2, Loader2, GripVertical } from "lucide-react";
+import { toast } from "sonner";
+import { useTranslation } from "react-i18next";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface TemplateItem {
+  id?: string;
+  name: string;
+  notes?: string;
+  sequence: number;
+}
+
+interface Template {
+  id: string;
+  name: string;
+  description: string | null;
+  operation_type: string | null;
+  is_global: boolean;
+  items?: TemplateItem[];
+  created_at: string;
+  updated_at: string;
+}
+
+interface SortableItemProps {
+  item: TemplateItem;
+  index: number;
+  onEdit: (index: number, field: 'name' | 'notes', value: string) => void;
+  onDelete: (index: number) => void;
+}
+
+function SortableItem({ item, index, onEdit, onDelete }: SortableItemProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+  } = useSortable({ id: item.sequence });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="flex items-start gap-2 p-3 bg-muted/50 rounded-lg"
+    >
+      <div
+        {...attributes}
+        {...listeners}
+        className="cursor-grab active:cursor-grabbing mt-2"
+      >
+        <GripVertical className="h-5 w-5 text-muted-foreground" />
+      </div>
+      <div className="flex-1 space-y-2">
+        <Input
+          value={item.name}
+          onChange={(e) => onEdit(index, 'name', e.target.value)}
+          placeholder="Step name"
+          className="font-medium"
+        />
+        <Textarea
+          value={item.notes || ''}
+          onChange={(e) => onEdit(index, 'notes', e.target.value)}
+          placeholder="Optional notes"
+          rows={2}
+          className="text-sm"
+        />
+      </div>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={() => onDelete(index)}
+        className="mt-2"
+      >
+        <Trash2 className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}
+
+export function TemplatesManager() {
+  const { t } = useTranslation();
+  const { profile } = useAuth();
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingTemplate, setEditingTemplate] = useState<Template | null>(null);
+  const [formData, setFormData] = useState({
+    name: "",
+    description: "",
+    operation_type: "",
+  });
+  const [templateItems, setTemplateItems] = useState<TemplateItem[]>([]);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  useEffect(() => {
+    if (!profile?.tenant_id) return;
+    loadTemplates();
+  }, [profile?.tenant_id]);
+
+  const loadTemplates = async () => {
+    if (!profile?.tenant_id) return;
+    setLoading(true);
+
+    const { data, error } = await supabase
+      .from("substep_templates")
+      .select(`
+        *,
+        items:substep_template_items (
+          id,
+          name,
+          notes,
+          sequence
+        )
+      `)
+      .or(`tenant_id.eq.${profile.tenant_id},is_global.eq.true`)
+      .order('name', { ascending: true })
+      .order('sequence', { foreignTable: 'substep_template_items', ascending: true });
+
+    if (error) {
+      console.error("Error loading templates:", error);
+      toast.error(t("Failed to load templates"));
+    } else {
+      setTemplates(data || []);
+    }
+
+    setLoading(false);
+  };
+
+  const handleOpenDialog = (template?: Template) => {
+    if (template) {
+      setEditingTemplate(template);
+      setFormData({
+        name: template.name,
+        description: template.description || "",
+        operation_type: template.operation_type || "",
+      });
+      setTemplateItems(template.items || []);
+    } else {
+      setEditingTemplate(null);
+      setFormData({
+        name: "",
+        description: "",
+        operation_type: "",
+      });
+      setTemplateItems([
+        { name: "", notes: "", sequence: 1 }
+      ]);
+    }
+    setDialogOpen(true);
+  };
+
+  const handleCloseDialog = () => {
+    setDialogOpen(false);
+    setEditingTemplate(null);
+    setFormData({ name: "", description: "", operation_type: "" });
+    setTemplateItems([]);
+  };
+
+  const handleAddItem = () => {
+    setTemplateItems([
+      ...templateItems,
+      { name: "", notes: "", sequence: templateItems.length + 1 }
+    ]);
+  };
+
+  const handleEditItem = (index: number, field: 'name' | 'notes', value: string) => {
+    const updated = [...templateItems];
+    updated[index][field] = value;
+    setTemplateItems(updated);
+  };
+
+  const handleDeleteItem = (index: number) => {
+    const updated = templateItems.filter((_, i) => i !== index);
+    // Resequence
+    const resequenced = updated.map((item, i) => ({
+      ...item,
+      sequence: i + 1
+    }));
+    setTemplateItems(resequenced);
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (over && active.id !== over.id) {
+      setTemplateItems((items) => {
+        const oldIndex = items.findIndex(item => item.sequence === active.id);
+        const newIndex = items.findIndex(item => item.sequence === over.id);
+
+        const reordered = arrayMove(items, oldIndex, newIndex);
+        // Resequence
+        return reordered.map((item, i) => ({
+          ...item,
+          sequence: i + 1
+        }));
+      });
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!profile?.tenant_id) return;
+
+    if (!formData.name.trim()) {
+      toast.error(t("Template name is required"));
+      return;
+    }
+
+    if (templateItems.length === 0 || templateItems.some(item => !item.name.trim())) {
+      toast.error(t("All template items must have a name"));
+      return;
+    }
+
+    try {
+      if (editingTemplate) {
+        // Update template
+        const { error: templateError } = await supabase
+          .from("substep_templates")
+          .update({
+            name: formData.name,
+            description: formData.description || null,
+            operation_type: formData.operation_type || null,
+          })
+          .eq('id', editingTemplate.id);
+
+        if (templateError) throw templateError;
+
+        // Delete old items
+        await supabase
+          .from("substep_template_items")
+          .delete()
+          .eq('template_id', editingTemplate.id);
+
+        // Insert new items
+        const { error: itemsError } = await supabase
+          .from("substep_template_items")
+          .insert(
+            templateItems.map(item => ({
+              template_id: editingTemplate.id,
+              name: item.name,
+              notes: item.notes || null,
+              sequence: item.sequence,
+            }))
+          );
+
+        if (itemsError) throw itemsError;
+
+        toast.success(t("Template updated successfully"));
+      } else {
+        // Create new template
+        const { data: template, error: templateError } = await supabase
+          .from("substep_templates")
+          .insert({
+            tenant_id: profile.tenant_id,
+            name: formData.name,
+            description: formData.description || null,
+            operation_type: formData.operation_type || null,
+            is_global: false,
+          })
+          .select()
+          .single();
+
+        if (templateError || !template) throw templateError;
+
+        // Insert items
+        const { error: itemsError } = await supabase
+          .from("substep_template_items")
+          .insert(
+            templateItems.map(item => ({
+              template_id: template.id,
+              name: item.name,
+              notes: item.notes || null,
+              sequence: item.sequence,
+            }))
+          );
+
+        if (itemsError) throw itemsError;
+
+        toast.success(t("Template created successfully"));
+      }
+
+      handleCloseDialog();
+      loadTemplates();
+    } catch (error) {
+      console.error("Error saving template:", error);
+      toast.error(t("Failed to save template"));
+    }
+  };
+
+  const handleDelete = async (template: Template) => {
+    if (!confirm(t("Are you sure you want to delete this template?"))) return;
+
+    if (template.is_global) {
+      toast.error(t("Cannot delete global templates"));
+      return;
+    }
+
+    const { error } = await supabase
+      .from("substep_templates")
+      .delete()
+      .eq('id', template.id);
+
+    if (error) {
+      console.error("Error deleting template:", error);
+      toast.error(t("Failed to delete template"));
+    } else {
+      toast.success(t("Template deleted successfully"));
+      loadTemplates();
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  const operationTypes = [
+    { value: "cutting", label: "Cutting" },
+    { value: "bending", label: "Bending" },
+    { value: "welding", label: "Welding" },
+    { value: "machining", label: "Machining" },
+    { value: "finishing", label: "Finishing" },
+    { value: "assembly", label: "Assembly" },
+    { value: "inspection", label: "Inspection" },
+    { value: "packaging", label: "Packaging" },
+    { value: "general", label: "General" },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-between items-center">
+        <div className="text-sm text-muted-foreground">
+          {templates.length} {t("templates")}
+        </div>
+        <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+          <DialogTrigger asChild>
+            <Button onClick={() => handleOpenDialog()}>
+              <Plus className="h-4 w-4 mr-2" />
+              {t("New Template")}
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto">
+            <DialogHeader>
+              <DialogTitle>
+                {editingTemplate ? t("Edit Template") : t("New Template")}
+              </DialogTitle>
+            </DialogHeader>
+
+            <div className="space-y-4 py-4">
+              <div className="space-y-2">
+                <Label htmlFor="name">{t("Template Name")}</Label>
+                <Input
+                  id="name"
+                  value={formData.name}
+                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                  placeholder={t("e.g., Standard Cutting Workflow")}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="description">{t("Description")}</Label>
+                <Textarea
+                  id="description"
+                  value={formData.description}
+                  onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                  placeholder={t("Optional description of this template")}
+                  rows={2}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="operation_type">{t("Operation Type")}</Label>
+                <Select
+                  value={formData.operation_type}
+                  onValueChange={(value) => setFormData({ ...formData, operation_type: value })}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder={t("Select operation type (optional)")} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {operationTypes.map(type => (
+                      <SelectItem key={type.value} value={type.value}>
+                        {t(type.label)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <div className="flex justify-between items-center">
+                  <Label>{t("Template Steps")}</Label>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={handleAddItem}
+                  >
+                    <Plus className="h-4 w-4 mr-1" />
+                    {t("Add Step")}
+                  </Button>
+                </div>
+
+                <DndContext
+                  sensors={sensors}
+                  collisionDetection={closestCenter}
+                  onDragEnd={handleDragEnd}
+                >
+                  <SortableContext
+                    items={templateItems.map(item => item.sequence)}
+                    strategy={verticalListSortingStrategy}
+                  >
+                    <div className="space-y-2">
+                      {templateItems.map((item, index) => (
+                        <SortableItem
+                          key={item.sequence}
+                          item={item}
+                          index={index}
+                          onEdit={handleEditItem}
+                          onDelete={handleDeleteItem}
+                        />
+                      ))}
+                    </div>
+                  </SortableContext>
+                </DndContext>
+
+                {templateItems.length === 0 && (
+                  <div className="text-center py-8 text-muted-foreground">
+                    {t("No steps added yet. Click 'Add Step' to get started.")}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <DialogFooter>
+              <Button variant="outline" onClick={handleCloseDialog}>
+                {t("Cancel")}
+              </Button>
+              <Button onClick={handleSubmit}>
+                {editingTemplate ? t("Update") : t("Create")}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <div className="grid gap-4">
+        {templates.map((template) => (
+          <Card key={template.id} className="p-4">
+            <div className="flex items-start justify-between">
+              <div className="flex-1">
+                <div className="flex items-center gap-2 mb-2">
+                  <h3 className="font-semibold">{template.name}</h3>
+                  {template.is_global && (
+                    <Badge variant="secondary">Global</Badge>
+                  )}
+                  {template.operation_type && (
+                    <Badge variant="outline">{template.operation_type}</Badge>
+                  )}
+                </div>
+                {template.description && (
+                  <p className="text-sm text-muted-foreground mb-3">
+                    {template.description}
+                  </p>
+                )}
+                <div className="space-y-1">
+                  {template.items?.slice(0, 3).map((item, idx) => (
+                    <div key={item.id || idx} className="text-sm flex items-start gap-2">
+                      <span className="text-muted-foreground">{idx + 1}.</span>
+                      <span>{item.name}</span>
+                    </div>
+                  ))}
+                  {template.items && template.items.length > 3 && (
+                    <div className="text-sm text-muted-foreground pl-5">
+                      +{template.items.length - 3} more steps
+                    </div>
+                  )}
+                </div>
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => handleOpenDialog(template)}
+                  disabled={template.is_global}
+                >
+                  <Edit className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => handleDelete(template)}
+                  disabled={template.is_global}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          </Card>
+        ))}
+
+        {templates.length === 0 && (
+          <div className="text-center py-12 text-muted-foreground">
+            {t("No templates created yet. Click 'New Template' to get started.")}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/StepsTemplatesView.tsx
+++ b/src/pages/admin/StepsTemplatesView.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+import Layout from "@/components/Layout";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { TemplatesManager } from "@/components/admin/TemplatesManager";
+import { AllSubstepsView } from "@/components/admin/AllSubstepsView";
+import { useTranslation } from "react-i18next";
+
+export default function StepsTemplatesView() {
+  const { t } = useTranslation();
+  const [activeTab, setActiveTab] = useState("templates");
+
+  return (
+    <Layout>
+      <div className="container mx-auto py-6 space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">
+            {t("Steps & Templates")}
+          </h1>
+          <p className="text-muted-foreground mt-2">
+            {t("Manage substep templates and view all substeps across your operations")}
+          </p>
+        </div>
+
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4">
+          <TabsList>
+            <TabsTrigger value="templates">
+              {t("Templates")}
+            </TabsTrigger>
+            <TabsTrigger value="substeps">
+              {t("All Substeps")}
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="templates" className="space-y-4">
+            <Card>
+              <CardHeader>
+                <CardTitle>{t("Substep Templates")}</CardTitle>
+                <p className="text-sm text-muted-foreground">
+                  {t("Create and manage reusable templates for common operations. Templates help operators quickly add standardized substeps to any operation.")}
+                </p>
+              </CardHeader>
+              <CardContent>
+                <TemplatesManager />
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          <TabsContent value="substeps" className="space-y-4">
+            <Card>
+              <CardHeader>
+                <CardTitle>{t("All Substeps")}</CardTitle>
+                <p className="text-sm text-muted-foreground">
+                  {t("View and manage all substeps across all operations in your system")}
+                </p>
+              </CardHeader>
+              <CardContent>
+                <AllSubstepsView />
+              </CardContent>
+            </Card>
+          </TabsContent>
+        </Tabs>
+      </div>
+    </Layout>
+  );
+}

--- a/supabase/functions/api-templates/index.ts
+++ b/supabase/functions/api-templates/index.ts
@@ -1,0 +1,460 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import * as bcrypt from "https://deno.land/x/bcrypt@v0.4.1/mod.ts";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+async function authenticateApiKey(authHeader: string | null, supabase: any) {
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return null;
+  }
+
+  const apiKey = authHeader.substring(7);
+
+  if (!apiKey.startsWith('ery_live_') && !apiKey.startsWith('ery_test_')) {
+    return null;
+  }
+
+  const { data: keys } = await supabase
+    .from('api_keys')
+    .select('id, tenant_id')
+    .eq('active', true);
+
+  if (!keys || keys.length === 0) return null;
+
+  for (const key of keys) {
+    const { data: fullKey } = await supabase
+      .from('api_keys')
+      .select('key_hash, tenant_id')
+      .eq('id', key.id)
+      .single();
+
+    if (fullKey && await bcrypt.compare(apiKey, fullKey.key_hash)) {
+      await supabase
+        .from('api_keys')
+        .update({ last_used_at: new Date().toISOString() })
+        .eq('id', key.id);
+
+      return fullKey.tenant_id;
+    }
+  }
+
+  return null;
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const supabase = createClient(
+    Deno.env.get('SUPABASE_URL') ?? '',
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+  );
+
+  try {
+    const tenantId = await authenticateApiKey(req.headers.get('authorization'), supabase);
+
+    if (!tenantId) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: { code: 'UNAUTHORIZED', message: 'Invalid or missing API key' }
+        }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Handle GET requests - list templates
+    if (req.method === 'GET') {
+      const url = new URL(req.url);
+      const templateId = url.searchParams.get('id');
+      const operationType = url.searchParams.get('operation_type');
+
+      // Get single template with items
+      if (templateId) {
+        const { data: template, error: templateError } = await supabase
+          .from('substep_templates')
+          .select(`
+            id,
+            name,
+            description,
+            operation_type,
+            is_global,
+            created_at,
+            updated_at,
+            items:substep_template_items (
+              id,
+              name,
+              notes,
+              sequence
+            )
+          `)
+          .or(`tenant_id.eq.${tenantId},is_global.eq.true`)
+          .eq('id', templateId)
+          .order('sequence', { foreignTable: 'substep_template_items', ascending: true })
+          .single();
+
+        if (templateError) {
+          if (templateError.code === 'PGRST116') {
+            return new Response(
+              JSON.stringify({
+                success: false,
+                error: { code: 'NOT_FOUND', message: 'Template not found' }
+              }),
+              { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+            );
+          }
+          throw new Error(`Failed to fetch template: ${templateError.message}`);
+        }
+
+        return new Response(
+          JSON.stringify({
+            success: true,
+            data: { template }
+          }),
+          { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      // List templates
+      let query = supabase
+        .from('substep_templates')
+        .select(`
+          id,
+          name,
+          description,
+          operation_type,
+          is_global,
+          created_at,
+          updated_at,
+          items:substep_template_items (
+            id,
+            name,
+            notes,
+            sequence
+          )
+        `)
+        .or(`tenant_id.eq.${tenantId},is_global.eq.true`)
+        .order('name', { ascending: true })
+        .order('sequence', { foreignTable: 'substep_template_items', ascending: true });
+
+      if (operationType) {
+        query = query.eq('operation_type', operationType);
+      }
+
+      const { data: templates, error } = await query;
+
+      if (error) {
+        throw new Error(`Failed to fetch templates: ${error.message}`);
+      }
+
+      return new Response(
+        JSON.stringify({
+          success: true,
+          data: { templates: templates || [] }
+        }),
+        { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Handle POST requests - create template
+    if (req.method === 'POST') {
+      const body = await req.json();
+
+      // Validate required fields
+      if (!body.name) {
+        return new Response(
+          JSON.stringify({
+            success: false,
+            error: { code: 'VALIDATION_ERROR', message: 'name is required' }
+          }),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      // Validate items if provided
+      if (body.items && !Array.isArray(body.items)) {
+        return new Response(
+          JSON.stringify({
+            success: false,
+            error: { code: 'VALIDATION_ERROR', message: 'items must be an array' }
+          }),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      // Create template
+      const { data: template, error: templateError } = await supabase
+        .from('substep_templates')
+        .insert({
+          tenant_id: tenantId,
+          name: body.name,
+          description: body.description || null,
+          operation_type: body.operation_type || null,
+          is_global: false // API cannot create global templates
+        })
+        .select()
+        .single();
+
+      if (templateError || !template) {
+        throw new Error(`Failed to create template: ${templateError?.message}`);
+      }
+
+      // Create template items if provided
+      if (body.items && body.items.length > 0) {
+        const items = body.items.map((item: any, index: number) => ({
+          template_id: template.id,
+          name: item.name,
+          notes: item.notes || null,
+          sequence: item.sequence ?? (index + 1)
+        }));
+
+        const { error: itemsError } = await supabase
+          .from('substep_template_items')
+          .insert(items);
+
+        if (itemsError) {
+          // Rollback template creation
+          await supabase
+            .from('substep_templates')
+            .delete()
+            .eq('id', template.id);
+
+          throw new Error(`Failed to create template items: ${itemsError.message}`);
+        }
+
+        // Fetch complete template with items
+        const { data: completeTemplate } = await supabase
+          .from('substep_templates')
+          .select(`
+            id,
+            name,
+            description,
+            operation_type,
+            is_global,
+            created_at,
+            updated_at,
+            items:substep_template_items (
+              id,
+              name,
+              notes,
+              sequence
+            )
+          `)
+          .eq('id', template.id)
+          .order('sequence', { foreignTable: 'substep_template_items', ascending: true })
+          .single();
+
+        return new Response(
+          JSON.stringify({
+            success: true,
+            data: { template: completeTemplate }
+          }),
+          { status: 201, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          success: true,
+          data: { template }
+        }),
+        { status: 201, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Handle PATCH requests - update template
+    if (req.method === 'PATCH') {
+      const url = new URL(req.url);
+      const templateId = url.searchParams.get('id');
+
+      if (!templateId) {
+        return new Response(
+          JSON.stringify({
+            success: false,
+            error: { code: 'VALIDATION_ERROR', message: 'Template ID is required in query string (?id=xxx)' }
+          }),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      const body = await req.json();
+      const allowedFields = ['name', 'description', 'operation_type'];
+      const updates: any = {};
+
+      for (const field of allowedFields) {
+        if (body[field] !== undefined) {
+          updates[field] = body[field];
+        }
+      }
+
+      // Handle items update separately
+      if (body.items !== undefined) {
+        if (!Array.isArray(body.items)) {
+          return new Response(
+            JSON.stringify({
+              success: false,
+              error: { code: 'VALIDATION_ERROR', message: 'items must be an array' }
+            }),
+            { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+          );
+        }
+
+        // Delete existing items
+        await supabase
+          .from('substep_template_items')
+          .delete()
+          .eq('template_id', templateId);
+
+        // Insert new items
+        if (body.items.length > 0) {
+          const items = body.items.map((item: any, index: number) => ({
+            template_id: templateId,
+            name: item.name,
+            notes: item.notes || null,
+            sequence: item.sequence ?? (index + 1)
+          }));
+
+          const { error: itemsError } = await supabase
+            .from('substep_template_items')
+            .insert(items);
+
+          if (itemsError) {
+            throw new Error(`Failed to update template items: ${itemsError.message}`);
+          }
+        }
+      }
+
+      if (Object.keys(updates).length === 0 && body.items === undefined) {
+        return new Response(
+          JSON.stringify({
+            success: false,
+            error: { code: 'VALIDATION_ERROR', message: 'No valid fields to update' }
+          }),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      // Update template if there are field updates
+      if (Object.keys(updates).length > 0) {
+        updates.updated_at = new Date().toISOString();
+
+        const { error } = await supabase
+          .from('substep_templates')
+          .update(updates)
+          .eq('id', templateId)
+          .eq('tenant_id', tenantId);
+
+        if (error) {
+          if (error.code === 'PGRST116') {
+            return new Response(
+              JSON.stringify({
+                success: false,
+                error: { code: 'NOT_FOUND', message: 'Template not found' }
+              }),
+              { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+            );
+          }
+          throw new Error(`Failed to update template: ${error.message}`);
+        }
+      }
+
+      // Fetch updated template with items
+      const { data: template } = await supabase
+        .from('substep_templates')
+        .select(`
+          id,
+          name,
+          description,
+          operation_type,
+          is_global,
+          created_at,
+          updated_at,
+          items:substep_template_items (
+            id,
+            name,
+            notes,
+            sequence
+          )
+        `)
+        .eq('id', templateId)
+        .order('sequence', { foreignTable: 'substep_template_items', ascending: true })
+        .single();
+
+      return new Response(
+        JSON.stringify({
+          success: true,
+          data: { template }
+        }),
+        { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Handle DELETE requests - delete template
+    if (req.method === 'DELETE') {
+      const url = new URL(req.url);
+      const templateId = url.searchParams.get('id');
+
+      if (!templateId) {
+        return new Response(
+          JSON.stringify({
+            success: false,
+            error: { code: 'VALIDATION_ERROR', message: 'Template ID is required in query string (?id=xxx)' }
+          }),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      // Delete template (items will be cascade deleted)
+      const { error } = await supabase
+        .from('substep_templates')
+        .delete()
+        .eq('id', templateId)
+        .eq('tenant_id', tenantId);
+
+      if (error) {
+        if (error.code === 'PGRST116') {
+          return new Response(
+            JSON.stringify({
+              success: false,
+              error: { code: 'NOT_FOUND', message: 'Template not found' }
+            }),
+            { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+          );
+        }
+        throw new Error(`Failed to delete template: ${error.message}`);
+      }
+
+      return new Response(
+        JSON.stringify({
+          success: true,
+          data: { message: 'Template deleted successfully' }
+        }),
+        { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: { code: 'METHOD_NOT_ALLOWED', message: `Method ${req.method} not allowed` }
+      }),
+      { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+
+  } catch (error) {
+    console.error('Error in api-templates:', error);
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: { code: 'INTERNAL_ERROR', message }
+      }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});

--- a/supabase/migrations/20251117200200_create_substep_templates.sql
+++ b/supabase/migrations/20251117200200_create_substep_templates.sql
@@ -1,0 +1,374 @@
+-- Create substep templates table for storing reusable operation templates
+CREATE TABLE substep_templates (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  description text,
+  operation_type text, -- Optional categorization (e.g., 'cutting', 'welding', 'bending')
+  is_global boolean DEFAULT false, -- If true, available to all tenants (admin templates)
+  created_by uuid REFERENCES profiles(id),
+  created_at timestamp with time zone DEFAULT now(),
+  updated_at timestamp with time zone DEFAULT now(),
+  CONSTRAINT unique_template_name_per_tenant UNIQUE (tenant_id, name)
+);
+
+-- Create substep template items table for storing individual steps within templates
+CREATE TABLE substep_template_items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  template_id uuid NOT NULL REFERENCES substep_templates(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  notes text,
+  sequence integer NOT NULL,
+  created_at timestamp with time zone DEFAULT now(),
+  updated_at timestamp with time zone DEFAULT now(),
+  CONSTRAINT unique_sequence_per_template UNIQUE (template_id, sequence)
+);
+
+-- Create indexes for performance
+CREATE INDEX idx_substep_templates_tenant_id ON substep_templates(tenant_id);
+CREATE INDEX idx_substep_templates_operation_type ON substep_templates(operation_type);
+CREATE INDEX idx_substep_templates_is_global ON substep_templates(is_global);
+CREATE INDEX idx_substep_template_items_template_id ON substep_template_items(template_id);
+CREATE INDEX idx_substep_template_items_sequence ON substep_template_items(template_id, sequence);
+
+-- Enable Row Level Security
+ALTER TABLE substep_templates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE substep_template_items ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies for substep_templates
+
+-- Admins can do everything with their tenant's templates
+CREATE POLICY "Admins can manage tenant templates"
+  ON substep_templates
+  FOR ALL
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.id = auth.uid()
+      AND profiles.tenant_id = substep_templates.tenant_id
+      AND profiles.role = 'admin'
+    )
+    OR (is_global = true) -- Can view global templates
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.id = auth.uid()
+      AND profiles.tenant_id = substep_templates.tenant_id
+      AND profiles.role = 'admin'
+    )
+  );
+
+-- Operators can view templates from their tenant and global templates
+CREATE POLICY "Operators can view templates"
+  ON substep_templates
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.id = auth.uid()
+      AND profiles.tenant_id = substep_templates.tenant_id
+    )
+    OR is_global = true
+  );
+
+-- Read-only users can view templates from their tenant and global templates
+CREATE POLICY "Read-only users can view templates"
+  ON substep_templates
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.id = auth.uid()
+      AND profiles.tenant_id = substep_templates.tenant_id
+      AND profiles.role = 'read_only'
+    )
+    OR is_global = true
+  );
+
+-- RLS Policies for substep_template_items
+
+-- Admins can manage template items for their tenant's templates
+CREATE POLICY "Admins can manage template items"
+  ON substep_template_items
+  FOR ALL
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM substep_templates st
+      JOIN profiles p ON p.tenant_id = st.tenant_id
+      WHERE st.id = substep_template_items.template_id
+      AND p.id = auth.uid()
+      AND p.role = 'admin'
+    )
+    OR EXISTS (
+      SELECT 1 FROM substep_templates st
+      WHERE st.id = substep_template_items.template_id
+      AND st.is_global = true
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM substep_templates st
+      JOIN profiles p ON p.tenant_id = st.tenant_id
+      WHERE st.id = substep_template_items.template_id
+      AND p.id = auth.uid()
+      AND p.role = 'admin'
+    )
+  );
+
+-- Operators and read-only users can view template items
+CREATE POLICY "Users can view template items"
+  ON substep_template_items
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM substep_templates st
+      JOIN profiles p ON p.tenant_id = st.tenant_id
+      WHERE st.id = substep_template_items.template_id
+      AND p.id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1 FROM substep_templates st
+      WHERE st.id = substep_template_items.template_id
+      AND st.is_global = true
+    )
+  );
+
+-- Add updated_at trigger function if it doesn't exist
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'update_updated_at_column') THEN
+    CREATE OR REPLACE FUNCTION update_updated_at_column()
+    RETURNS TRIGGER AS $func$
+    BEGIN
+      NEW.updated_at = now();
+      RETURN NEW;
+    END;
+    $func$ LANGUAGE plpgsql;
+  END IF;
+END
+$$;
+
+-- Create triggers for updated_at
+CREATE TRIGGER update_substep_templates_updated_at
+  BEFORE UPDATE ON substep_templates
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_substep_template_items_updated_at
+  BEFORE UPDATE ON substep_template_items
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+-- Seed with existing hardcoded templates
+-- Insert global templates (is_global = true, tenant_id = first tenant in system)
+DO $$
+DECLARE
+  system_tenant_id uuid;
+BEGIN
+  -- Get the first tenant ID to use for global templates
+  SELECT id INTO system_tenant_id FROM tenants LIMIT 1;
+
+  IF system_tenant_id IS NOT NULL THEN
+    -- Cutting template
+    INSERT INTO substep_templates (id, tenant_id, name, description, operation_type, is_global)
+    VALUES (
+      gen_random_uuid(),
+      system_tenant_id,
+      'Cutting (Laser/Plasma/Waterjet)',
+      'Standard cutting operation workflow',
+      'cutting',
+      true
+    )
+    RETURNING id INTO system_tenant_id; -- Reuse variable for template_id
+
+    INSERT INTO substep_template_items (template_id, name, notes, sequence) VALUES
+      (system_tenant_id, 'Review cutting plan and material specifications', NULL, 1),
+      (system_tenant_id, 'Prepare and load material onto cutting table', NULL, 2),
+      (system_tenant_id, 'Setup cutting equipment and load program', NULL, 3),
+      (system_tenant_id, 'Perform first article inspection', NULL, 4),
+      (system_tenant_id, 'Execute cutting operation', NULL, 5),
+      (system_tenant_id, 'Quality check completed parts', NULL, 6),
+      (system_tenant_id, 'Sign off and move to next operation', NULL, 7);
+  END IF;
+END
+$$;
+
+DO $$
+DECLARE
+  system_tenant_id uuid;
+  template_id uuid;
+BEGIN
+  SELECT id INTO system_tenant_id FROM tenants LIMIT 1;
+
+  IF system_tenant_id IS NOT NULL THEN
+    -- Bending template
+    INSERT INTO substep_templates (tenant_id, name, description, operation_type, is_global)
+    VALUES (
+      system_tenant_id,
+      'Bending (Press Brake)',
+      'Standard press brake bending workflow',
+      'bending',
+      true
+    )
+    RETURNING id INTO template_id;
+
+    INSERT INTO substep_template_items (template_id, name, notes, sequence) VALUES
+      (template_id, 'Review bend angles and sequence', NULL, 1),
+      (template_id, 'Select and install correct tooling', NULL, 2),
+      (template_id, 'Setup press brake and load program', NULL, 3),
+      (template_id, 'Perform test bend and verify angles', NULL, 4),
+      (template_id, 'Execute bending operation', NULL, 5),
+      (template_id, 'Inspect bend angles and tolerances', NULL, 6),
+      (template_id, 'Sign off and move to next operation', NULL, 7);
+
+    -- Welding template
+    INSERT INTO substep_templates (tenant_id, name, description, operation_type, is_global)
+    VALUES (
+      system_tenant_id,
+      'Welding',
+      'Standard welding operation workflow',
+      'welding',
+      true
+    )
+    RETURNING id INTO template_id;
+
+    INSERT INTO substep_template_items (template_id, name, notes, sequence) VALUES
+      (template_id, 'Review welding procedure specification (WPS)', NULL, 1),
+      (template_id, 'Prepare and fit-up joints', NULL, 2),
+      (template_id, 'Setup welding equipment and verify settings', NULL, 3),
+      (template_id, 'Tack weld components', NULL, 4),
+      (template_id, 'Execute welding per WPS', NULL, 5),
+      (template_id, 'Visual inspection of welds', NULL, 6),
+      (template_id, 'Cleanup and remove spatter', NULL, 7),
+      (template_id, 'Document weld parameters and sign off', NULL, 8);
+
+    -- Machining template
+    INSERT INTO substep_templates (tenant_id, name, description, operation_type, is_global)
+    VALUES (
+      system_tenant_id,
+      'Machining (CNC/Manual)',
+      'Standard machining operation workflow',
+      'machining',
+      true
+    )
+    RETURNING id INTO template_id;
+
+    INSERT INTO substep_template_items (template_id, name, notes, sequence) VALUES
+      (template_id, 'Review machining program and setup sheet', NULL, 1),
+      (template_id, 'Verify material and locate datums', NULL, 2),
+      (template_id, 'Setup machine and install tooling', NULL, 3),
+      (template_id, 'Run first article inspection', NULL, 4),
+      (template_id, 'Execute machining operation', NULL, 5),
+      (template_id, 'Perform in-process quality checks', NULL, 6),
+      (template_id, 'Final inspection and documentation', NULL, 7),
+      (template_id, 'Clean machine and workpiece', NULL, 8);
+
+    -- Finishing template
+    INSERT INTO substep_templates (tenant_id, name, description, operation_type, is_global)
+    VALUES (
+      system_tenant_id,
+      'Finishing (Powder Coat/Paint)',
+      'Standard finishing operation workflow',
+      'finishing',
+      true
+    )
+    RETURNING id INTO template_id;
+
+    INSERT INTO substep_template_items (template_id, name, notes, sequence) VALUES
+      (template_id, 'Review finish specifications and color', NULL, 1),
+      (template_id, 'Prepare surface (clean, degrease, mask)', NULL, 2),
+      (template_id, 'Verify equipment setup and parameters', NULL, 3),
+      (template_id, 'Apply finish coating', NULL, 4),
+      (template_id, 'Cure/dry per specifications', NULL, 5),
+      (template_id, 'Inspect coating coverage and quality', NULL, 6),
+      (template_id, 'Sign off and prepare for shipment', NULL, 7);
+
+    -- Assembly template
+    INSERT INTO substep_templates (tenant_id, name, description, operation_type, is_global)
+    VALUES (
+      system_tenant_id,
+      'Assembly',
+      'Standard assembly operation workflow',
+      'assembly',
+      true
+    )
+    RETURNING id INTO template_id;
+
+    INSERT INTO substep_template_items (template_id, name, notes, sequence) VALUES
+      (template_id, 'Verify all components are available', NULL, 1),
+      (template_id, 'Review assembly drawing and BOM', NULL, 2),
+      (template_id, 'Prepare tools and fixtures', NULL, 3),
+      (template_id, 'Fit and align components', NULL, 4),
+      (template_id, 'Install fasteners per torque specs', NULL, 5),
+      (template_id, 'Perform function test', NULL, 6),
+      (template_id, 'Final inspection and sign off', NULL, 7);
+
+    -- Inspection template
+    INSERT INTO substep_templates (tenant_id, name, description, operation_type, is_global)
+    VALUES (
+      system_tenant_id,
+      'Inspection (QC)',
+      'Standard quality control inspection workflow',
+      'inspection',
+      true
+    )
+    RETURNING id INTO template_id;
+
+    INSERT INTO substep_template_items (template_id, name, notes, sequence) VALUES
+      (template_id, 'Gather inspection documents and drawings', NULL, 1),
+      (template_id, 'Prepare measuring equipment', NULL, 2),
+      (template_id, 'Measure critical dimensions', NULL, 3),
+      (template_id, 'Perform visual inspection', NULL, 4),
+      (template_id, 'Document results and measurements', NULL, 5),
+      (template_id, 'Sign off inspection report', NULL, 6);
+
+    -- Packaging template
+    INSERT INTO substep_templates (tenant_id, name, description, operation_type, is_global)
+    VALUES (
+      system_tenant_id,
+      'Packaging & Shipping Prep',
+      'Standard packaging and shipping preparation workflow',
+      'packaging',
+      true
+    )
+    RETURNING id INTO template_id;
+
+    INSERT INTO substep_template_items (template_id, name, notes, sequence) VALUES
+      (template_id, 'Verify part quantity matches order', NULL, 1),
+      (template_id, 'Perform final quality check', NULL, 2),
+      (template_id, 'Prepare packaging materials', NULL, 3),
+      (template_id, 'Pack parts securely', NULL, 4),
+      (template_id, 'Label packages with job/part info', NULL, 5),
+      (template_id, 'Update inventory and shipping docs', NULL, 6),
+      (template_id, 'Mark job complete in system', NULL, 7);
+
+    -- General template
+    INSERT INTO substep_templates (tenant_id, name, description, operation_type, is_global)
+    VALUES (
+      system_tenant_id,
+      'General Operation',
+      'Generic workflow template for any operation',
+      'general',
+      true
+    )
+    RETURNING id INTO template_id;
+
+    INSERT INTO substep_template_items (template_id, name, notes, sequence) VALUES
+      (template_id, 'Review work order and specifications', NULL, 1),
+      (template_id, 'Prepare materials and equipment', NULL, 2),
+      (template_id, 'Execute operation', NULL, 3),
+      (template_id, 'Perform quality check', NULL, 4),
+      (template_id, 'Sign off and document completion', NULL, 5);
+  END IF;
+END
+$$;
+
+-- Add helpful comment
+COMMENT ON TABLE substep_templates IS 'Reusable templates for substeps that can be applied to operations';
+COMMENT ON TABLE substep_template_items IS 'Individual steps within a substep template';


### PR DESCRIPTION
Features:
- Database-backed template system with migration
- API endpoints for full CRUD operations on templates
- Admin UI for managing templates and viewing all substeps
- Integration with existing SubstepsManager for operators
- Navigation routes and menu items

Database changes:
- Created substep_templates table for storing custom templates
- Created substep_template_items table for template steps
- Seeded database with 9 metalworking operation templates
- Proper RLS policies for tenant isolation

API endpoints (api-templates):
- GET: List all templates or get single template with items
- POST: Create new template with items
- PATCH: Update template and items
- DELETE: Delete template

UI components:
- StepsTemplatesView: Main admin page with tabs for templates and substeps
- TemplatesManager: Full CRUD UI for templates with drag-and-drop ordering
- AllSubstepsView: View and manage all substeps across all operations
- SubstepsManager: Updated to use database templates instead of hardcoded ones

Navigation:
- Added /admin/config/steps-templates route
- Added menu item in Configuration section