### PR TITLE
Fix table columns and add localization support

### DIFF
--- a/src/components/terminal/JobRow.tsx
+++ b/src/components/terminal/JobRow.tsx
@@ -32,19 +32,19 @@ export function JobRow({ job, isSelected, onClick, variant }: JobRowProps) {
                 variant === 'process' && "bg-emerald-500/5",
             )}
         >
-            {/* PONr - Part Number */}
+            {/* Job Number */}
             <td className="px-2 py-1.5 text-sm font-medium text-foreground whitespace-nowrap">
-                {job.description}
-            </td>
-
-            {/* Omschrijving - Job Description/Code */}
-            <td className="px-2 py-1.5 text-sm text-foreground whitespace-nowrap">
                 {job.jobCode}
             </td>
 
-            {/* Naar cel - Operation Badge */}
+            {/* Part Number */}
+            <td className="px-2 py-1.5 text-sm text-foreground whitespace-nowrap">
+                {job.description}
+            </td>
+
+            {/* Operation */}
             <td className="px-2 py-1.5">
-                <Badge 
+                <Badge
                     className={cn(
                         "text-white text-xs font-semibold px-2 py-0.5 whitespace-nowrap",
                         getOperationBadgeColor(job.currentOp)
@@ -54,36 +54,40 @@ export function JobRow({ job, isSelected, onClick, variant }: JobRowProps) {
                 </Badge>
             </td>
 
-            {/* Action Icon */}
-            <td className="px-2 py-1.5 text-center">
-                {variant === 'process' ? (
-                    <Pause className="w-4 h-4 text-foreground inline" />
-                ) : (
-                    <Play className="w-4 h-4 text-foreground inline" />
-                )}
-            </td>
-
-            {/* Uren - Remaining Hours */}
-            <td className="px-2 py-1.5 text-sm font-mono text-foreground text-right whitespace-nowrap">
-                {job.hours}
-            </td>
-
-            {/* Huidige bewerking - Cell/Workstation */}
+            {/* Cell (Next Cell) */}
             <td className="px-2 py-1.5 text-sm text-foreground whitespace-nowrap">
-                {job.cellName || '-'}
+                <span
+                    className="inline-block px-2 py-0.5 rounded text-xs font-medium"
+                    style={{
+                        backgroundColor: job.cellColor ? `${job.cellColor}20` : 'transparent',
+                        color: job.cellColor || 'inherit'
+                    }}
+                >
+                    {job.cellName || '-'}
+                </span>
             </td>
 
-            {/* Materiaaldikte - Material */}
+            {/* Material */}
             <td className="px-2 py-1.5 text-sm text-foreground whitespace-nowrap">
                 {job.material || '-'}
             </td>
 
-            {/* Geplande einddatum - Due Date */}
+            {/* Quantity */}
+            <td className="px-2 py-1.5 text-sm text-foreground text-center whitespace-nowrap">
+                {job.quantity}
+            </td>
+
+            {/* Remaining Hours */}
+            <td className="px-2 py-1.5 text-sm font-mono text-foreground text-right whitespace-nowrap">
+                {job.hours}h
+            </td>
+
+            {/* Due Date */}
             <td className="px-2 py-1.5 text-sm text-foreground whitespace-nowrap">
                 {new Date(job.dueDate).toLocaleDateString('nl-NL', { day: '2-digit', month: '2-digit', year: 'numeric' })}
             </td>
 
-            {/* Backorder status - Icons & Badges */}
+            {/* Files - Icons & Badges */}
             <td className="px-2 py-1.5">
                 <div className="flex items-center gap-1.5 justify-center">
                     {job.hasPdf && (

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -1136,5 +1136,23 @@
     "thisMonth": "Dieser Monat",
     "lastMonth": "Letzter Monat",
     "custom": "Benutzerdefinierter Bereich"
+  },
+  "terminal": {
+    "columns": {
+      "jobNumber": "Auftragsnr.",
+      "partNumber": "Teilenr.",
+      "operation": "Bearbeitung",
+      "cell": "Zelle",
+      "material": "Material",
+      "quantity": "Menge",
+      "hours": "Stunden",
+      "dueDate": "Fälligkeitsdatum",
+      "files": "Dateien"
+    },
+    "inProcess": "In Bearbeitung",
+    "inBuffer": "Im Puffer",
+    "expected": "Erwartet",
+    "noActiveJobs": "Keine aktiven Aufträge",
+    "jobsFound": "Aufträge gefunden"
   }
 }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -1136,5 +1136,23 @@
     "thisMonth": "This Month",
     "lastMonth": "Last Month",
     "custom": "Custom Range"
+  },
+  "terminal": {
+    "columns": {
+      "jobNumber": "Job #",
+      "partNumber": "Part #",
+      "operation": "Operation",
+      "cell": "Cell",
+      "material": "Material",
+      "quantity": "Qty",
+      "hours": "Hours",
+      "dueDate": "Due Date",
+      "files": "Files"
+    },
+    "inProcess": "In Process",
+    "inBuffer": "In Buffer",
+    "expected": "Expected",
+    "noActiveJobs": "No active jobs",
+    "jobsFound": "jobs found"
   }
 }

--- a/src/i18n/locales/nl/translation.json
+++ b/src/i18n/locales/nl/translation.json
@@ -1138,5 +1138,23 @@
     "thisMonth": "Deze maand",
     "lastMonth": "Vorige maand",
     "custom": "Aangepast bereik"
+  },
+  "terminal": {
+    "columns": {
+      "jobNumber": "Opdrachtnr.",
+      "partNumber": "Onderdeelnr.",
+      "operation": "Bewerking",
+      "cell": "Cel",
+      "material": "Materiaal",
+      "quantity": "Aantal",
+      "hours": "Uren",
+      "dueDate": "Vervaldatum",
+      "files": "Bestanden"
+    },
+    "inProcess": "In bewerking",
+    "inBuffer": "In buffer",
+    "expected": "Verwacht",
+    "noActiveJobs": "Geen actieve opdrachten",
+    "jobsFound": "opdrachten gevonden"
   }
 }

--- a/src/pages/operator/OperatorTerminal.tsx
+++ b/src/pages/operator/OperatorTerminal.tsx
@@ -12,6 +12,7 @@ import { JobRow } from "@/components/terminal/JobRow";
 import { DetailPanel } from "@/components/terminal/DetailPanel";
 import { toast } from "sonner";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useTranslation } from "react-i18next";
 
 // Define the interface locally if not exported, matching the one in JobRow
 import { TerminalJob } from '@/types/terminal';
@@ -28,6 +29,7 @@ interface Cell {
 }
 
 export default function OperatorTerminal() {
+    const { t } = useTranslation();
     const { profile } = useAuth();
     const [operations, setOperations] = useState<OperationWithDetails[]>([]);
     const [cells, setCells] = useState<Cell[]>([]);
@@ -277,35 +279,35 @@ export default function OperatorTerminal() {
                         </Select>
                     </div>
                     <div className="text-xs text-muted-foreground">
-                        {filteredJobs.length} jobs found
+                        {filteredJobs.length} {t("terminal.jobsFound")}
                     </div>
                 </div>
 
                 {/* 1. IN PROCESS */}
                 <div className="flex-1 flex flex-col min-h-0 border-b border-border bg-accent/5 overflow-hidden">
                     <div className="px-4 py-2 bg-emerald-950/10 border-l-4 border-emerald-500 flex items-center justify-between dark:bg-emerald-950/30 shrink-0">
-                        <h2 className="text-base font-bold text-emerald-600 dark:text-emerald-400">In bewerking ({inProcessJobs.length})</h2>
+                        <h2 className="text-base font-bold text-emerald-600 dark:text-emerald-400">{t("terminal.inProcess")} ({inProcessJobs.length})</h2>
                     </div>
                     <div className="flex-1 overflow-auto">
                         <table className="w-full text-left border-collapse">
                             <thead className="bg-muted/50 sticky top-0 z-10">
                                 <tr className="border-b border-border">
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">PONr</th>
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Omschrijving</th>
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Naar cel</th>
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground text-center"></th>
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground text-right">Uren</th>
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Huidige bewerking</th>
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Materiaaldikte</th>
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Geplande einddatum</th>
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Backorder status</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">{t("terminal.columns.jobNumber")}</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">{t("terminal.columns.partNumber")}</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">{t("terminal.columns.operation")}</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">{t("terminal.columns.cell")}</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">{t("terminal.columns.material")}</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground text-center">{t("terminal.columns.quantity")}</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground text-right">{t("terminal.columns.hours")}</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">{t("terminal.columns.dueDate")}</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground text-center">{t("terminal.columns.files")}</th>
                                 </tr>
                             </thead>
                             <tbody>
                                 {inProcessJobs.length === 0 ? (
                                     <tr>
                                         <td colSpan={9} className="text-center py-8 text-muted-foreground italic">
-                                            No active jobs
+                                            {t("terminal.noActiveJobs")}
                                         </td>
                                     </tr>
                                 ) : (
@@ -327,21 +329,21 @@ export default function OperatorTerminal() {
                 {/* 2. IN BUFFER */}
                 <div className="flex-1 flex flex-col min-h-0 border-b border-border overflow-hidden">
                     <div className="px-4 py-2 bg-blue-950/10 border-l-4 border-blue-500 flex items-center justify-between dark:bg-blue-950/30 shrink-0">
-                        <h2 className="text-base font-bold text-blue-600 dark:text-blue-400">In buffer ({inBufferJobs.length})</h2>
+                        <h2 className="text-base font-bold text-blue-600 dark:text-blue-400">{t("terminal.inBuffer")} ({inBufferJobs.length})</h2>
                     </div>
                     <div className="flex-1 overflow-auto">
                         <table className="w-full text-left border-collapse">
                             <thead className="bg-muted/50 sticky top-0 z-10">
                                 <tr className="border-b border-border">
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">PONr</th>
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Omschrijving</th>
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Naar cel</th>
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground text-center"></th>
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground text-right">Uren</th>
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Huidige bewerking</th>
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Materiaaldikte</th>
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Geplande einddatum</th>
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Backorder status</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">{t("terminal.columns.jobNumber")}</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">{t("terminal.columns.partNumber")}</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">{t("terminal.columns.operation")}</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">{t("terminal.columns.cell")}</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">{t("terminal.columns.material")}</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground text-center">{t("terminal.columns.quantity")}</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground text-right">{t("terminal.columns.hours")}</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">{t("terminal.columns.dueDate")}</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground text-center">{t("terminal.columns.files")}</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -362,21 +364,21 @@ export default function OperatorTerminal() {
                 {/* 3. EXPECTED */}
                 <div className="flex-1 flex flex-col min-h-0 bg-accent/5 overflow-hidden">
                     <div className="px-4 py-2 bg-amber-950/10 border-l-4 border-amber-500 flex items-center justify-between dark:bg-amber-950/30 shrink-0">
-                        <h2 className="text-base font-bold text-amber-600 dark:text-amber-400">Verwacht ({expectedJobs.length})</h2>
+                        <h2 className="text-base font-bold text-amber-600 dark:text-amber-400">{t("terminal.expected")} ({expectedJobs.length})</h2>
                     </div>
                     <div className="flex-1 overflow-auto">
                         <table className="w-full text-left border-collapse">
                             <thead className="bg-muted/50 sticky top-0 z-10">
                                 <tr className="border-b border-border">
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">PONr</th>
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Omschrijving</th>
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Naar cel</th>
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground text-center"></th>
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground text-right">Uren</th>
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Huidige bewerking</th>
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Materiaaldikte</th>
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Geplande einddatum</th>
-                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Backorder status</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">{t("terminal.columns.jobNumber")}</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">{t("terminal.columns.partNumber")}</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">{t("terminal.columns.operation")}</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">{t("terminal.columns.cell")}</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">{t("terminal.columns.material")}</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground text-center">{t("terminal.columns.quantity")}</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground text-right">{t("terminal.columns.hours")}</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">{t("terminal.columns.dueDate")}</th>
+                                    <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground text-center">{t("terminal.columns.files")}</th>
                                 </tr>
                             </thead>
                             <tbody>


### PR DESCRIPTION
- Reordered table columns to match actual data logically:
  * Job Number, Part Number, Operation, Cell, Material, Quantity, Hours, Due Date, Files
- Fixed incorrect column mappings (e.g., PONr was showing part number instead of job number)
- Added comprehensive localization support for all terminal table columns
- Added translations for English, Dutch, and German
- Replaced hardcoded Dutch column headers with translation keys
- Enhanced cell display with color-coded badges
- Updated JobRow component to reflect new column structure

Column changes:
- "PONr" → "Job #" / "Opdrachtnr." (now shows job_number, not part_number)
- "Omschrijving" → "Part #" / "Onderdeelnr." (now shows part_number, not job_number)
- "Naar cel" → "Operation" / "Bewerking" (operation name)
- Added "Cell" / "Cel" column (next cell for the operation)
- "Materiaaldikte" → "Material" / "Materiaal" (material type, not thickness)
- Added "Quantity" / "Aantal" column
- "Uren" → "Hours" / "Uren" (remaining hours with 'h' suffix)
- "Geplande einddatum" → "Due Date" / "Vervaldatum" (due date)
- "Backorder status" → "Files" / "Bestanden" (file availability icons)