### PR TITLE
Add missing translations to primary user screens

### DIFF
--- a/src/components/operator/OperationDetailModal.tsx
+++ b/src/components/operator/OperationDetailModal.tsx
@@ -411,7 +411,7 @@ export default function OperationDetailModal({
           {(operation as any).metadata && (
             <EnhancedMetadataDisplay
               metadata={(operation as any).metadata}
-              title="Process Settings"
+              title={t("common.processSettings")}
               showTypeIndicator={true}
             />
           )}
@@ -420,7 +420,7 @@ export default function OperationDetailModal({
           {(operation.part as any).metadata && (
             <EnhancedMetadataDisplay
               metadata={(operation.part as any).metadata}
-              title="Part Specifications"
+              title={t("common.partSpecifications")}
               showTypeIndicator={true}
             />
           )}
@@ -545,7 +545,7 @@ export default function OperationDetailModal({
                           <AlertCircle className="h-4 w-4 text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0" />
                           <div>
                             <p className="text-sm font-medium text-amber-900 dark:text-amber-100 mb-1">
-                              Instructions:
+                              {t("common.instructions")}:
                             </p>
                             <p className="text-sm text-amber-800 dark:text-amber-200">
                               {opResource.notes}

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -130,6 +130,7 @@
     "inProgress": "In Bearbeitung",
     "completed": "Abgeschlossen",
     "notStarted": "Nicht gestartet",
+    "totalOperations": "Gesamte Arbeitsgänge",
     "materials": "Materialien",
     "allMaterials": "Alle Materialien",
     "status": "Status",
@@ -149,6 +150,7 @@
     "assignedToMe": "Mir zugewiesen",
     "showCompleted": "Abgeschlossene anzeigen",
     "cellVisibility": "Zellsichtbarkeit",
+    "cells": "Zellen",
     "searchPlaceholder": "Suche nach Auftrag, Teil, Arbeitsgang oder Kunde...",
     "switchToCompact": "Zur kompakten Ansicht wechseln",
     "switchToDetailed": "Zur detaillierten Ansicht wechseln",
@@ -169,7 +171,20 @@
     "next": "Weiter",
     "save": "Speichern",
     "success": "Erfolg",
-    "validationError": "Validierungsfehler"
+    "validationError": "Validierungsfehler",
+    "notAvailable": "N/V",
+    "start": "Starten",
+    "ops": "Arb.",
+    "selectJobToStart": "Wählen Sie einen Auftrag aus, um zu beginnen",
+    "pdfDrawing": "PDF-Zeichnung",
+    "3dModel": "3D-Modell",
+    "noFilesForPart": "Keine Dateien für dieses Teil verfügbar",
+    "currentOperation": "Aktueller Arbeitsgang",
+    "allOperations": "Alle Arbeitsgänge",
+    "jobOverdue": "Auftrag überfällig!",
+    "processSettings": "Prozesseinstellungen",
+    "partSpecifications": "Teilspezifikationen",
+    "instructions": "Anweisungen"
   },
   "onboarding": {
     "welcome": "Willkommen bei Eryxon MES",
@@ -453,6 +468,9 @@
     "min": "Min.",
     "assigned": "Zugewiesen",
     "noOperationsYet": "Noch keine Arbeitsgänge",
+    "operationPaused": "Arbeitsgang pausiert",
+    "failedToPause": "Pausieren fehlgeschlagen",
+    "failedToStart": "Starten fehlgeschlagen",
     "status": {
       "notStarted": "Nicht gestartet",
       "inProgress": "In Bearbeitung",
@@ -1166,6 +1184,13 @@
     "inBuffer": "Im Puffer",
     "expected": "Erwartet",
     "noActiveJobs": "Keine aktiven Aufträge",
-    "jobsFound": "Aufträge gefunden"
+    "jobsFound": "Aufträge gefunden",
+    "loadingTerminalData": "Terminaldaten werden geladen...",
+    "terminalView": "Terminalansicht:",
+    "selectCell": "Zelle auswählen",
+    "allCells": "Alle Zellen",
+    "noJobSelected": "Kein Auftrag ausgewählt",
+    "selectJobPrompt": "Wählen Sie einen Auftrag aus der Liste aus, um Details und Steuerelemente anzuzeigen.",
+    "failedToLoadData": "Daten konnten nicht geladen werden"
   }
 }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -130,6 +130,7 @@
     "inProgress": "In Progress",
     "completed": "Completed",
     "notStarted": "Not Started",
+    "totalOperations": "Total Operations",
     "materials": "Materials",
     "allMaterials": "All Materials",
     "status": "Status",
@@ -149,6 +150,7 @@
     "assignedToMe": "Assigned to Me",
     "showCompleted": "Show Completed",
     "cellVisibility": "Cell Visibility",
+    "cells": "Cells",
     "searchPlaceholder": "Search by job, part, operation, or customer...",
     "switchToCompact": "Switch to compact view",
     "switchToDetailed": "Switch to detailed view",
@@ -169,7 +171,20 @@
     "next": "Next",
     "save": "Save",
     "success": "Success",
-    "validationError": "Validation Error"
+    "validationError": "Validation Error",
+    "notAvailable": "N/A",
+    "start": "Start",
+    "ops": "ops",
+    "selectJobToStart": "Select a job to get started",
+    "pdfDrawing": "PDF Drawing",
+    "3dModel": "3D Model",
+    "noFilesForPart": "No files available for this part",
+    "currentOperation": "Current Operation",
+    "allOperations": "All Operations",
+    "jobOverdue": "Job overdue!",
+    "processSettings": "Process Settings",
+    "partSpecifications": "Part Specifications",
+    "instructions": "Instructions"
   },
   "onboarding": {
     "welcome": "Welcome to Eryxon MES",
@@ -453,6 +468,9 @@
     "min": "min",
     "assigned": "Assigned",
     "noOperationsYet": "No operations yet",
+    "operationPaused": "Operation paused",
+    "failedToPause": "Failed to pause",
+    "failedToStart": "Failed to start",
     "status": {
       "notStarted": "Not Started",
       "inProgress": "In Progress",
@@ -1166,6 +1184,13 @@
     "inBuffer": "In Buffer",
     "expected": "Expected",
     "noActiveJobs": "No active jobs",
-    "jobsFound": "jobs found"
+    "jobsFound": "jobs found",
+    "loadingTerminalData": "Loading Terminal Data...",
+    "terminalView": "Terminal View:",
+    "selectCell": "Select Cell",
+    "allCells": "All Cells",
+    "noJobSelected": "No Job Selected",
+    "selectJobPrompt": "Select a job from the list to view details and controls.",
+    "failedToLoadData": "Failed to load data"
   }
 }

--- a/src/i18n/locales/nl/translation.json
+++ b/src/i18n/locales/nl/translation.json
@@ -130,6 +130,7 @@
     "inProgress": "Bezig",
     "completed": "Voltooid",
     "notStarted": "Niet gestart",
+    "totalOperations": "Totale bewerkingen",
     "materials": "Materialen",
     "allMaterials": "Alle materialen",
     "status": "Status",
@@ -149,6 +150,7 @@
     "assignedToMe": "Aan mij toegewezen",
     "showCompleted": "Voltooide tonen",
     "cellVisibility": "Celzichtbaarheid",
+    "cells": "Cellen",
     "searchPlaceholder": "Zoeken op opdracht, onderdeel, bewerking of klant...",
     "switchToCompact": "Overschakelen naar compacte weergave",
     "switchToDetailed": "Overschakelen naar gedetailleerde weergave",
@@ -169,7 +171,20 @@
     "next": "Volgende",
     "save": "Opslaan",
     "success": "Succes",
-    "validationError": "Validatiefout"
+    "validationError": "Validatiefout",
+    "notAvailable": "N/B",
+    "start": "Starten",
+    "ops": "bew.",
+    "selectJobToStart": "Selecteer een opdracht om te beginnen",
+    "pdfDrawing": "PDF-tekening",
+    "3dModel": "3D-model",
+    "noFilesForPart": "Geen bestanden beschikbaar voor dit onderdeel",
+    "currentOperation": "Huidige bewerking",
+    "allOperations": "Alle bewerkingen",
+    "jobOverdue": "Opdracht te laat!",
+    "processSettings": "Procesinstellingen",
+    "partSpecifications": "Onderdeelspecificaties",
+    "instructions": "Instructies"
   },
   "onboarding": {
     "welcome": "Welkom bij Eryxon MES",
@@ -453,6 +468,9 @@
     "min": "min.",
     "assigned": "Toegewezen",
     "noOperationsYet": "Nog geen operaties",
+    "operationPaused": "Bewerking gepauzeerd",
+    "failedToPause": "Pauzeren mislukt",
+    "failedToStart": "Starten mislukt",
     "status": {
       "notStarted": "Niet gestart",
       "inProgress": "Bezig",
@@ -1168,6 +1186,13 @@
     "inBuffer": "In buffer",
     "expected": "Verwacht",
     "noActiveJobs": "Geen actieve opdrachten",
-    "jobsFound": "opdrachten gevonden"
+    "jobsFound": "opdrachten gevonden",
+    "loadingTerminalData": "Terminalgegevens laden...",
+    "terminalView": "Terminalweergave:",
+    "selectCell": "Selecteer cel",
+    "allCells": "Alle cellen",
+    "noJobSelected": "Geen opdracht geselecteerd",
+    "selectJobPrompt": "Selecteer een opdracht uit de lijst om details en besturingselementen te bekijken.",
+    "failedToLoadData": "Gegevens laden mislukt"
   }
 }

--- a/src/pages/operator/OperatorTerminal.tsx
+++ b/src/pages/operator/OperatorTerminal.tsx
@@ -63,7 +63,7 @@ export default function OperatorTerminal() {
 
         } catch (error) {
             console.error("Error loading data:", error);
-            toast.error("Failed to load data");
+            toast.error(t("terminal.failedToLoadData"));
         } finally {
             setLoading(false);
         }
@@ -223,10 +223,10 @@ export default function OperatorTerminal() {
         if (!selectedJob || !profile) return;
         try {
             await startTimeTracking(selectedJob.operationId, profile.id, profile.tenant_id);
-            toast.success(`Started: ${selectedJob.currentOp}`);
+            toast.success(`${t("operations.started")}: ${selectedJob.currentOp}`);
             // Data will reload via subscription
         } catch (error: any) {
-            toast.error(error.message || "Failed to start");
+            toast.error(error.message || t("operations.failedToStart"));
         }
     };
 
@@ -234,9 +234,9 @@ export default function OperatorTerminal() {
         if (!selectedJob || !profile) return;
         try {
             await stopTimeTracking(selectedJob.operationId, profile.id);
-            toast.success("Operation paused");
+            toast.success(t("operations.operationPaused"));
         } catch (error: any) {
-            toast.error(error.message || "Failed to pause");
+            toast.error(error.message || t("operations.failedToPause"));
         }
     };
 
@@ -244,10 +244,10 @@ export default function OperatorTerminal() {
         if (!selectedJob || !profile) return;
         try {
             await completeOperation(selectedJob.operationId, profile.tenant_id, profile.id);
-            toast.success("Operation completed");
+            toast.success(t("operations.operationComplete"));
             setSelectedJobId(null); // Deselect
         } catch (error: any) {
-            toast.error(error.message || "Failed to complete");
+            toast.error(error.message || t("operations.failedToComplete"));
         }
     };
 
@@ -257,7 +257,7 @@ export default function OperatorTerminal() {
                 <div className="absolute inset-0 bg-background/80 z-50 flex items-center justify-center backdrop-blur-sm">
                     <div className="flex flex-col items-center gap-4">
                         <div className="w-12 h-12 border-4 border-primary border-t-transparent rounded-full animate-spin"></div>
-                        <p className="text-primary font-medium animate-pulse">Loading Terminal Data...</p>
+                        <p className="text-primary font-medium animate-pulse">{t("terminal.loadingTerminalData")}</p>
                     </div>
                 </div>
             )}
@@ -267,13 +267,13 @@ export default function OperatorTerminal() {
                 {/* HEADER / CELL SELECTOR */}
                 <div className="h-14 border-b border-border bg-card/50 flex items-center px-4 justify-between shrink-0">
                     <div className="flex items-center gap-4">
-                        <span className="text-muted-foreground font-medium">Terminal View:</span>
+                        <span className="text-muted-foreground font-medium">{t("terminal.terminalView")}</span>
                         <Select value={selectedCellId} onValueChange={handleCellChange}>
                             <SelectTrigger className="w-[200px] bg-card border-input text-foreground">
-                                <SelectValue placeholder="Select Cell" />
+                                <SelectValue placeholder={t("terminal.selectCell")} />
                             </SelectTrigger>
                             <SelectContent className="bg-card border-border text-foreground">
-                                <SelectItem value="all">All Cells</SelectItem>
+                                <SelectItem value="all">{t("terminal.allCells")}</SelectItem>
                                 {cells.map(cell => (
                                     <SelectItem key={cell.id} value={cell.id}>{cell.name}</SelectItem>
                                 ))}
@@ -416,8 +416,8 @@ export default function OperatorTerminal() {
                         <div className="w-16 h-16 rounded-full bg-accent/10 mb-4 flex items-center justify-center">
                             <span className="text-3xl">👈</span>
                         </div>
-                        <h3 className="text-xl font-medium text-foreground mb-2">No Job Selected</h3>
-                        <p className="text-sm">Select a job from the list to view details and controls.</p>
+                        <h3 className="text-xl font-medium text-foreground mb-2">{t("terminal.noJobSelected")}</h3>
+                        <p className="text-sm">{t("terminal.selectJobPrompt")}</p>
                     </div>
                 )}
             </div>

--- a/src/pages/operator/OperatorView.tsx
+++ b/src/pages/operator/OperatorView.tsx
@@ -443,7 +443,7 @@ export default function OperatorView() {
             >
               {jobs.map((job) => (
                 <MenuItem key={job.id} value={job.id}>
-                  <strong>{job.job_number}</strong>&nbsp;- {job.customer || "N/A"}
+                  <strong>{job.job_number}</strong>&nbsp;- {job.customer || t("common.notAvailable")}
                 </MenuItem>
               ))}
             </Select>
@@ -459,7 +459,7 @@ export default function OperatorView() {
                 size="small"
               />
               <Chip
-                label={`${completedOps}/${totalOps} ops`}
+                label={`${completedOps}/${totalOps} ${t("common.ops")}`}
                 size="small"
                 color="primary"
                 variant="outlined"
@@ -560,7 +560,7 @@ export default function OperatorView() {
           <Paper sx={{ p: 6, textAlign: "center" }}>
             <Build sx={{ fontSize: 80, color: "text.secondary", mb: 2 }} />
             <Typography variant="h5" color="text.secondary">
-              {t("Select a job to get started")}
+              {t("common.selectJobToStart")}
             </Typography>
           </Paper>
         </Box>
@@ -597,7 +597,7 @@ export default function OperatorView() {
                         <Tab
                           icon={<Description fontSize="small" />}
                           iconPosition="start"
-                          label={t("PDF Drawing")}
+                          label={t("common.pdfDrawing")}
                           sx={{ minHeight: 40, py: 0 }}
                         />
                       )}
@@ -605,7 +605,7 @@ export default function OperatorView() {
                         <Tab
                           icon={<ViewInAr fontSize="small" />}
                           iconPosition="start"
-                          label={t("3D Model")}
+                          label={t("common.3dModel")}
                           sx={{ minHeight: 40, py: 0 }}
                         />
                       )}
@@ -646,7 +646,7 @@ export default function OperatorView() {
                 <Stack alignItems="center" spacing={1}>
                   <ViewInAr sx={{ fontSize: 60, opacity: 0.3 }} />
                   <Typography variant="body1">
-                    {t("No files available for this part")}
+                    {t("common.noFilesForPart")}
                   </Typography>
                 </Stack>
               </Box>
@@ -667,7 +667,7 @@ export default function OperatorView() {
             {selectedOperation && (
               <Paper sx={{ p: 2, flexShrink: 0 }}>
                 <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-                  {t("Current Operation")}
+                  {t("common.currentOperation")}
                 </Typography>
                 <Typography variant="h6" fontWeight="bold" gutterBottom>
                   {selectedOperation.operation_name}
@@ -748,7 +748,7 @@ export default function OperatorView() {
                 {isOverdue && (
                   <Alert severity="error" sx={{ mt: 1, py: 0.5 }}>
                     <Typography variant="caption">
-                      {t("Job overdue!")} Due: {format(dueDate!, "MMM dd")}
+                      {t("common.jobOverdue")} {t("operations.due")}: {format(dueDate!, "MMM dd")}
                     </Typography>
                   </Alert>
                 )}
@@ -766,7 +766,7 @@ export default function OperatorView() {
             >
               <Box sx={{ p: 1.5, borderBottom: 1, borderColor: "divider" }}>
                 <Typography variant="subtitle2" fontWeight="bold">
-                  {t("All Operations")} ({operations.length})
+                  {t("common.allOperations")} ({operations.length})
                 </Typography>
               </Box>
 
@@ -923,14 +923,14 @@ export default function OperatorView() {
                 <Tab
                   icon={<Description fontSize="small" />}
                   iconPosition="start"
-                  label={t("PDF Drawing")}
+                  label={t("common.pdfDrawing")}
                 />
               )}
               {stepUrl && (
                 <Tab
                   icon={<ViewInAr fontSize="small" />}
                   iconPosition="start"
-                  label={t("3D Model")}
+                  label={t("common.3dModel")}
                 />
               )}
             </Tabs>

--- a/src/pages/operator/WorkQueue.tsx
+++ b/src/pages/operator/WorkQueue.tsx
@@ -235,19 +235,19 @@ export default function WorkQueue() {
         <Card className="p-4">
           <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
             <div>
-              <p className="text-sm text-muted-foreground">Total Operations</p>
+              <p className="text-sm text-muted-foreground">{t("workQueue.totalOperations")}</p>
               <p className="text-2xl font-bold">{totalOperations}</p>
             </div>
             <div>
-              <p className="text-sm text-muted-foreground">In Progress</p>
+              <p className="text-sm text-muted-foreground">{t("workQueue.inProgress")}</p>
               <p className="text-2xl font-bold text-brand-primary">{inProgressOperations}</p>
             </div>
             <div>
-              <p className="text-sm text-muted-foreground">Completed</p>
+              <p className="text-sm text-muted-foreground">{t("workQueue.completed")}</p>
               <p className="text-2xl font-bold text-status-completed">{completedOperations}</p>
             </div>
             <div>
-              <p className="text-sm text-muted-foreground">Not Started</p>
+              <p className="text-sm text-muted-foreground">{t("workQueue.notStarted")}</p>
               <p className="text-2xl font-bold text-muted-foreground">
                 {totalOperations - inProgressOperations - completedOperations}
               </p>
@@ -261,7 +261,7 @@ export default function WorkQueue() {
             <div className="relative flex-1">
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
               <Input
-                placeholder="Search by job, part, operation, or customer..."
+                placeholder={t("workQueue.searchPlaceholder")}
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 className="pl-10"
@@ -290,7 +290,7 @@ export default function WorkQueue() {
           {/* Material Tabs */}
           <Tabs value={selectedMaterial} onValueChange={setSelectedMaterial}>
             <TabsList className="w-full justify-start overflow-x-auto">
-              <TabsTrigger value="all">All Materials</TabsTrigger>
+              <TabsTrigger value="all">{t("workQueue.allMaterials")}</TabsTrigger>
               {materials.map((material) => (
                 <TabsTrigger key={material} value={material}>
                   {material}
@@ -303,45 +303,45 @@ export default function WorkQueue() {
           {showFilters && (
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4 pt-4 border-t">
               <div>
-                <Label htmlFor="status-filter">Status</Label>
+                <Label htmlFor="status-filter">{t("workQueue.status")}</Label>
                 <Select value={statusFilter} onValueChange={setStatusFilter}>
                   <SelectTrigger id="status-filter">
-                    <SelectValue placeholder="All Statuses" />
+                    <SelectValue placeholder={t("workQueue.allStatuses")} />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="all">All Statuses</SelectItem>
-                    <SelectItem value="not_started">Not Started</SelectItem>
-                    <SelectItem value="in_progress">In Progress</SelectItem>
-                    <SelectItem value="completed">Completed</SelectItem>
+                    <SelectItem value="all">{t("workQueue.allStatuses")}</SelectItem>
+                    <SelectItem value="not_started">{t("workQueue.notStartedStatus")}</SelectItem>
+                    <SelectItem value="in_progress">{t("workQueue.inProgressStatus")}</SelectItem>
+                    <SelectItem value="completed">{t("workQueue.completedStatus")}</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
 
               <div>
-                <Label htmlFor="due-date-filter">Due Date</Label>
+                <Label htmlFor="due-date-filter">{t("workQueue.dueDate")}</Label>
                 <Select value={dueDateFilter} onValueChange={setDueDateFilter}>
                   <SelectTrigger id="due-date-filter">
-                    <SelectValue placeholder="All Dates" />
+                    <SelectValue placeholder={t("workQueue.allDates")} />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="all">All Dates</SelectItem>
-                    <SelectItem value="overdue">Overdue</SelectItem>
-                    <SelectItem value="today">Due Today</SelectItem>
-                    <SelectItem value="this_week">Due This Week</SelectItem>
+                    <SelectItem value="all">{t("workQueue.allDates")}</SelectItem>
+                    <SelectItem value="overdue">{t("workQueue.overdue")}</SelectItem>
+                    <SelectItem value="today">{t("workQueue.dueToday")}</SelectItem>
+                    <SelectItem value="this_week">{t("workQueue.dueThisWeek")}</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
 
               <div>
-                <Label htmlFor="sort-by">Sort By</Label>
+                <Label htmlFor="sort-by">{t("workQueue.sortBy")}</Label>
                 <Select value={sortBy} onValueChange={setSortBy}>
                   <SelectTrigger id="sort-by">
-                    <SelectValue placeholder="Sort by" />
+                    <SelectValue placeholder={t("workQueue.sortBy")} />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="sequence">Sequence</SelectItem>
-                    <SelectItem value="due_date">Due Date</SelectItem>
-                    <SelectItem value="estimated_time">Estimated Time</SelectItem>
+                    <SelectItem value="sequence">{t("workQueue.sequence")}</SelectItem>
+                    <SelectItem value="due_date">{t("workQueue.dueDateSort")}</SelectItem>
+                    <SelectItem value="estimated_time">{t("workQueue.estimatedTime")}</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
@@ -352,7 +352,7 @@ export default function WorkQueue() {
                   checked={assignedToMe}
                   onCheckedChange={setAssignedToMe}
                 />
-                <Label htmlFor="assigned-to-me">Assigned to Me</Label>
+                <Label htmlFor="assigned-to-me">{t("workQueue.assignedToMe")}</Label>
               </div>
 
               <div className="flex items-center space-x-2">
@@ -361,14 +361,14 @@ export default function WorkQueue() {
                   checked={showCompleted}
                   onCheckedChange={setShowCompleted}
                 />
-                <Label htmlFor="show-completed">Show Completed</Label>
+                <Label htmlFor="show-completed">{t("workQueue.showCompleted")}</Label>
               </div>
             </div>
           )}
 
           {/* Cell Visibility Toggles */}
           <div className="flex flex-wrap gap-2">
-            <span className="text-sm font-medium text-muted-foreground">Cells:</span>
+            <span className="text-sm font-medium text-muted-foreground">{t("workQueue.cells")}:</span>
             {cells.map((cell) => (
               <Button
                 key={cell.id}
@@ -405,13 +405,13 @@ export default function WorkQueue() {
                 >
                   <h3 className="font-semibold text-lg">{cell.name}</h3>
                   <p className="text-sm text-muted-foreground">
-                    {operations.length} operation{operations.length !== 1 ? "s" : ""}
+                    {operations.length} {operations.length !== 1 ? t("workQueue.operations") : t("workQueue.operation")}
                   </p>
                 </div>
                 <div className="p-4 space-y-3 max-h-[calc(100vh-16rem)] overflow-y-auto">
                   {operations.length === 0 ? (
                     <div className="text-center text-muted-foreground py-8">
-                      No operations
+                      {t("workQueue.noOperations")}
                     </div>
                   ) : (
                     operations.map((operation) => (


### PR DESCRIPTION
- Add missing translation keys to EN, DE, and NL locale files for:
  - WorkQueue component (filters, stats, search, cell visibility)
  - OperatorView component (job selection, file viewers, operation navigation)
  - OperatorTerminal component (loading states, cell selection, job actions)
  - OperationDetailModal component (process settings, part specs, instructions)

- Replace all hardcoded strings with translation keys:
  - Total Operations, In Progress, Completed, Not Started
  - Search placeholder, filter options, sort options
  - Cell visibility toggles
  - Terminal view labels and messages
  - File viewer labels (PDF Drawing, 3D Model)
  - Error and success messages
  - Operation status messages

- Ensure 100% translation coverage for primary user screens
- Use industry-standard terminology across all languages
- Maintain consistency with existing translation structure