### PR TITLE
Debug work queue page not loading

### DIFF
--- a/src/pages/operator/WorkQueue.tsx
+++ b/src/pages/operator/WorkQueue.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useAuth } from "@/contexts/AuthContext";
 import { supabase } from "@/integrations/supabase/client";
 import { fetchOperationsWithDetails, OperationWithDetails } from "@/lib/database";
@@ -33,6 +34,7 @@ const getStageClass = (cellName: string) => {
 };
 
 export default function WorkQueue() {
+  const { t } = useTranslation();
   const { profile } = useAuth();
   const [operations, setOperations] = useState<OperationWithDetails[]>([]);
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION
The WorkQueue page was not loading because it used the t() translation function without importing useTranslation from react-i18next. This caused a ReferenceError that prevented the page from rendering.

Changes:
- Added import { useTranslation } from "react-i18next"
- Added const { t } = useTranslation() hook in component