### PR TITLE
Fix sidebar styling in admin panel

### DIFF
--- a/src/components/AdminLayout.tsx
+++ b/src/components/AdminLayout.tsx
@@ -38,12 +38,14 @@ import {
   Activity,
   Flag,
   Info,
+  Factory,
 } from "lucide-react";
 import { Link, useLocation } from "react-router-dom";
 import { useState } from "react";
 import { cn } from "@/lib/utils";
 import { usePendingIssuesCount } from "@/hooks/usePendingIssuesCount";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import AnimatedBackground from "@/components/AnimatedBackground";
 
 interface AdminLayoutProps {
   children: React.ReactNode;
@@ -245,8 +247,12 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
       {/* Logo/Brand */}
       <div className="flex h-16 items-center border-b px-6">
         <div className="flex items-center gap-2">
-          <div className="h-8 w-8 rounded bg-primary" />
-          {!collapsed && <span className="text-lg font-bold">Eryxon Flow</span>}
+          <Factory className="h-8 w-8 text-primary" strokeWidth={1.5} />
+          {!collapsed && (
+            <span className="text-lg font-bold hero-title">
+              Eryxon Flow
+            </span>
+          )}
         </div>
       </div>
 
@@ -264,10 +270,11 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
             return (
               <Link key={item.path} to={item.path} onClick={() => setMobileOpen(false)}>
                 <Button
-                  variant={isItemActive ? "default" : "ghost"}
+                  variant="ghost"
                   className={cn(
-                    "w-full justify-start gap-3",
-                    collapsed && "justify-center px-2"
+                    "w-full justify-start gap-3 nav-item-hover",
+                    collapsed && "justify-center px-2",
+                    isItemActive && "nav-item-active"
                   )}
                   size="sm"
                 >
@@ -321,8 +328,11 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
                 return (
                   <Link key={item.path} to={item.path} onClick={() => setMobileOpen(false)}>
                     <Button
-                      variant={isItemActive ? "default" : "ghost"}
-                      className="w-full justify-start gap-3"
+                      variant="ghost"
+                      className={cn(
+                        "w-full justify-start gap-3 nav-item-hover",
+                        isItemActive && "nav-item-active"
+                      )}
                       size="sm"
                     >
                       <item.icon className="h-4 w-4 shrink-0" />
@@ -365,8 +375,11 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
                 return (
                   <Link key={item.path} to={item.path} onClick={() => setMobileOpen(false)}>
                     <Button
-                      variant={isItemActive ? "default" : "ghost"}
-                      className="w-full justify-start gap-3"
+                      variant="ghost"
+                      className={cn(
+                        "w-full justify-start gap-3 nav-item-hover",
+                        isItemActive && "nav-item-active"
+                      )}
                       size="sm"
                     >
                       <item.icon className="h-4 w-4 shrink-0" />
@@ -409,8 +422,11 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
                 return (
                   <Link key={item.path} to={item.path} onClick={() => setMobileOpen(false)}>
                     <Button
-                      variant={isItemActive ? "default" : "ghost"}
-                      className="w-full justify-start gap-3"
+                      variant="ghost"
+                      className={cn(
+                        "w-full justify-start gap-3 nav-item-hover",
+                        isItemActive && "nav-item-active"
+                      )}
                       size="sm"
                     >
                       <item.icon className="h-4 w-4 shrink-0" />
@@ -453,8 +469,11 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
                 return (
                   <Link key={item.path} to={item.path} onClick={() => setMobileOpen(false)}>
                     <Button
-                      variant={isItemActive ? "default" : "ghost"}
-                      className="w-full justify-start gap-3"
+                      variant="ghost"
+                      className={cn(
+                        "w-full justify-start gap-3 nav-item-hover",
+                        isItemActive && "nav-item-active"
+                      )}
                       size="sm"
                     >
                       <item.icon className="h-4 w-4 shrink-0" />
@@ -531,7 +550,9 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
   );
 
   return (
-    <div className="flex h-screen overflow-hidden bg-background">
+    <>
+      <AnimatedBackground />
+      <div className="relative flex h-screen overflow-hidden bg-background">
       {/* Mobile Menu Button */}
       <Button
         variant="ghost"
@@ -553,7 +574,7 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
       {/* Sidebar - Mobile */}
       <aside
         className={cn(
-          "fixed inset-y-0 left-0 z-50 w-64 border-r bg-card transition-transform lg:hidden",
+          "fixed inset-y-0 left-0 z-50 w-64 border-r sidebar-glass transition-transform lg:hidden",
           mobileOpen ? "translate-x-0" : "-translate-x-full"
         )}
       >
@@ -563,7 +584,7 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
       {/* Sidebar - Desktop */}
       <aside
         className={cn(
-          "hidden border-r bg-card transition-all lg:block",
+          "hidden border-r sidebar-glass transition-all lg:block",
           collapsed ? "w-16" : "w-64"
         )}
       >
@@ -578,6 +599,7 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
           {children}
         </div>
       </main>
-    </div>
+      </div>
+    </>
   );
 }

--- a/src/layouts/AdminLayout.tsx
+++ b/src/layouts/AdminLayout.tsx
@@ -38,6 +38,7 @@ import {
   Activity,
   Flag,
   Info,
+  Factory,
 } from "lucide-react";
 import { Link, useLocation } from "react-router-dom";
 import { useState } from "react";
@@ -46,6 +47,7 @@ import { usePendingIssuesCount } from "@/hooks/usePendingIssuesCount";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ROUTES } from "@/routes";
 import { useTranslation } from "react-i18next";
+import AnimatedBackground from "@/components/AnimatedBackground";
 
 interface AdminLayoutProps {
   children: React.ReactNode;
@@ -248,8 +250,12 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
       {/* Logo/Brand */}
       <div className="flex h-16 items-center border-b px-6">
         <div className="flex items-center gap-2">
-          <div className="h-8 w-8 rounded bg-primary" />
-          {!collapsed && <span className="text-lg font-bold">Eryxon MES</span>}
+          <Factory className="h-8 w-8 text-primary" strokeWidth={1.5} />
+          {!collapsed && (
+            <span className="text-lg font-bold hero-title">
+              Eryxon Flow
+            </span>
+          )}
         </div>
       </div>
 
@@ -267,10 +273,11 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
             return (
               <Link key={item.path} to={item.path} onClick={() => setMobileOpen(false)}>
                 <Button
-                  variant={isItemActive ? "default" : "ghost"}
+                  variant="ghost"
                   className={cn(
-                    "w-full justify-start gap-3",
-                    collapsed && "justify-center px-2"
+                    "w-full justify-start gap-3 nav-item-hover",
+                    collapsed && "justify-center px-2",
+                    isItemActive && "nav-item-active"
                   )}
                   size="sm"
                 >
@@ -324,8 +331,11 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
                 return (
                   <Link key={item.path} to={item.path} onClick={() => setMobileOpen(false)}>
                     <Button
-                      variant={isItemActive ? "default" : "ghost"}
-                      className="w-full justify-start gap-3"
+                      variant="ghost"
+                      className={cn(
+                        "w-full justify-start gap-3 nav-item-hover",
+                        isItemActive && "nav-item-active"
+                      )}
                       size="sm"
                     >
                       <item.icon className="h-4 w-4 shrink-0" />
@@ -368,8 +378,11 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
                 return (
                   <Link key={item.path} to={item.path} onClick={() => setMobileOpen(false)}>
                     <Button
-                      variant={isItemActive ? "default" : "ghost"}
-                      className="w-full justify-start gap-3"
+                      variant="ghost"
+                      className={cn(
+                        "w-full justify-start gap-3 nav-item-hover",
+                        isItemActive && "nav-item-active"
+                      )}
                       size="sm"
                     >
                       <item.icon className="h-4 w-4 shrink-0" />
@@ -412,8 +425,11 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
                 return (
                   <Link key={item.path} to={item.path} onClick={() => setMobileOpen(false)}>
                     <Button
-                      variant={isItemActive ? "default" : "ghost"}
-                      className="w-full justify-start gap-3"
+                      variant="ghost"
+                      className={cn(
+                        "w-full justify-start gap-3 nav-item-hover",
+                        isItemActive && "nav-item-active"
+                      )}
                       size="sm"
                     >
                       <item.icon className="h-4 w-4 shrink-0" />
@@ -456,8 +472,11 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
                 return (
                   <Link key={item.path} to={item.path} onClick={() => setMobileOpen(false)}>
                     <Button
-                      variant={isItemActive ? "default" : "ghost"}
-                      className="w-full justify-start gap-3"
+                      variant="ghost"
+                      className={cn(
+                        "w-full justify-start gap-3 nav-item-hover",
+                        isItemActive && "nav-item-active"
+                      )}
                       size="sm"
                     >
                       <item.icon className="h-4 w-4 shrink-0" />
@@ -534,7 +553,9 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
   );
 
   return (
-    <div className="flex h-screen overflow-hidden bg-background">
+    <>
+      <AnimatedBackground />
+      <div className="relative flex h-screen overflow-hidden bg-background">
       {/* Mobile Menu Button */}
       <Button
         variant="ghost"
@@ -556,7 +577,7 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
       {/* Sidebar - Mobile */}
       <aside
         className={cn(
-          "fixed inset-y-0 left-0 z-50 w-64 border-r bg-card transition-transform lg:hidden",
+          "fixed inset-y-0 left-0 z-50 w-64 border-r sidebar-glass transition-transform lg:hidden",
           mobileOpen ? "translate-x-0" : "-translate-x-full"
         )}
       >
@@ -566,7 +587,7 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
       {/* Sidebar - Desktop */}
       <aside
         className={cn(
-          "hidden border-r bg-card transition-all lg:block",
+          "hidden border-r sidebar-glass transition-all lg:block",
           collapsed ? "w-16" : "w-64"
         )}
       >
@@ -581,6 +602,7 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
           {children}
         </div>
       </main>
-    </div>
+      </div>
+    </>
   );
 }

--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -107,7 +107,7 @@
     --surface-hover: var(--neutral-900);
 
     /* Card - Glass morphism ready */
-    --card: var(--color-dark-surface);
+    --card: 0 0% 8% / 0.85;              /* Semi-transparent for glass effect */
     --card-foreground: var(--neutral-50);
     --card-border: 0 0% 100% / 0.1;      /* rgba(255,255,255,0.1) */
 
@@ -229,7 +229,7 @@
     /* ========================================================================
        SIDEBAR
        ======================================================================== */
-    --sidebar-background: var(--color-dark-surface);
+    --sidebar-background: 0 0% 8% / 0.7;            /* Semi-transparent for glass effect */
     --sidebar-foreground: var(--neutral-50);
     --sidebar-primary: var(--brand-accent);
     --sidebar-primary-foreground: 0 0% 100%;
@@ -237,6 +237,11 @@
     --sidebar-accent-foreground: var(--neutral-50);
     --sidebar-border: var(--neutral-700);
     --sidebar-ring: var(--brand-accent);
+
+    /* Navigation - Premium white/transparent */
+    --nav-active-bg: 0 0% 100% / 0.12;              /* White 12% opacity */
+    --nav-active-fg: 0 0% 100%;                     /* Pure white */
+    --nav-hover-bg: 0 0% 100% / 0.06;               /* White 6% opacity */
 
     /* ========================================================================
        GLASS MORPHISM EFFECTS
@@ -671,6 +676,46 @@
 
   .btn-primary:active {
     transform: scale(0.98);
+  }
+
+  /* Premium Navigation Styles - Transparent white with glow */
+  .nav-item-active {
+    position: relative;
+    background: hsl(var(--nav-active-bg)) !important;
+    color: hsl(var(--nav-active-fg)) !important;
+    border: none;
+    box-shadow: 0 0 20px rgba(255, 255, 255, 0.1),
+                inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  }
+
+  .nav-item-active::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(135deg,
+      rgba(255, 255, 255, 0.05) 0%,
+      rgba(255, 255, 255, 0) 100%);
+    pointer-events: none;
+  }
+
+  .nav-item-hover {
+    background: hsl(var(--nav-hover-bg));
+    transition: var(--transition-smooth);
+  }
+
+  .nav-item-hover:hover {
+    background: hsl(var(--nav-active-bg));
+    box-shadow: 0 0 15px rgba(255, 255, 255, 0.08);
+  }
+
+  /* Transparent sidebar with glass effect */
+  .sidebar-glass {
+    background: hsl(var(--sidebar-background)) !important;
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border-right: 1px solid hsl(var(--glass-border));
+    box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.03);
   }
 }
 


### PR DESCRIPTION
…sm design

This commit addresses the issue where the admin sidebar was displaying bright blue (#1e90ff) colors for active navigation items, which conflicted with the premium dark mode design system.

Changes:
- Updated design-system.css to add premium navigation color tokens:
  - --nav-active-bg: White 12% opacity (subtle highlight)
  - --nav-active-fg: Pure white text
  - --nav-hover-bg: White 6% opacity (hover state)
  - --sidebar-background: Semi-transparent for glass effect

- Added premium navigation CSS classes:
  - .nav-item-active: Transparent white with subtle glow
  - .nav-item-hover: Hover state with smooth transitions
  - .sidebar-glass: Transparent sidebar with backdrop blur

- Updated AdminLayout components:
  - Replaced variant="default" (bright blue) with custom nav classes
  - Added gradient "Eryxon Flow" branding with Factory icon
  - Added AnimatedBackground component for floating gradient orbs
  - Applied glass morphism to sidebar (70% opacity, 20px blur)

- Made cards semi-transparent (85% opacity) for consistent glass effect

The sidebar now matches the premium design seen in the /auth page with glass morphism, subtle white highlights, and animated backgrounds visible through transparent elements.

Related to PR #110 dark mode glass morphism improvements.