### PR TITLE
Fix unclickable active work dashboard table

### DIFF
--- a/src/components/terminal/JobRow.tsx
+++ b/src/components/terminal/JobRow.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { TerminalJob } from '@/types/terminal';
 import { Badge } from '@/components/ui/badge';
-import { FileText, Box, AlertTriangle } from 'lucide-react';
+import { FileText, Box, AlertTriangle, Clock, User } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { useTranslation } from 'react-i18next';
 
 interface JobRowProps {
     job: TerminalJob;
@@ -23,6 +24,8 @@ const getOperationBadgeColor = (opName: string) => {
 };
 
 export function JobRow({ job, isSelected, onClick, variant }: JobRowProps) {
+    const { t } = useTranslation();
+
     return (
         <tr
             onClick={onClick}
@@ -30,11 +33,33 @@ export function JobRow({ job, isSelected, onClick, variant }: JobRowProps) {
                 "cursor-pointer transition-colors border-b border-border hover:bg-accent/30",
                 isSelected && "bg-accent/50 ring-1 ring-primary",
                 variant === 'process' && "bg-status-active/5",
+                job.isCurrentUserClocked && "bg-primary/10 ring-1 ring-primary/50",
             )}
         >
-            {/* Job Number */}
+            {/* Job Number with clocking indicator */}
             <td className="px-2 py-1.5 text-sm font-medium text-foreground whitespace-nowrap">
-                {job.jobCode}
+                <div className="flex items-center gap-2">
+                    {job.isCurrentUserClocked && (
+                        <Badge
+                            className="bg-primary text-primary-foreground text-[10px] font-bold px-1.5 py-0 animate-pulse"
+                            title={t('terminal.youAreClockedOn')}
+                        >
+                            <Clock className="w-2.5 h-2.5 mr-0.5" />
+                            {t('terminal.you')}
+                        </Badge>
+                    )}
+                    {job.activeTimeEntryId && !job.isCurrentUserClocked && (
+                        <Badge
+                            variant="outline"
+                            className="text-[10px] px-1.5 py-0 border-muted-foreground/50"
+                            title={job.activeOperatorName}
+                        >
+                            <User className="w-2.5 h-2.5 mr-0.5" />
+                            {job.activeOperatorName?.split(' ')[0] || t('terminal.other')}
+                        </Badge>
+                    )}
+                    {job.jobCode}
+                </div>
             </td>
 
             {/* Part Number */}

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -107,6 +107,28 @@
       "data": "DATA"
     }
   },
+  "organizationSettings": {
+    "title": "Organization Settings",
+    "subtitle": "Manage your organization profile and preferences",
+    "companyInformation": "Company Information",
+    "updateOrgDetails": "Update your organization details",
+    "organizationName": "Organization Name",
+    "companyName": "Company Name",
+    "timezone": "Timezone",
+    "timezoneDescription": "Used for scheduling and due dates",
+    "billingEmail": "Billing Email",
+    "saveChanges": "Save Changes",
+    "settingsUpdated": "Organization settings updated",
+    "factoryHours": {
+      "title": "Factory Hours",
+      "description": "Configure your factory operating hours and automatic time tracking settings",
+      "openingTime": "Opening Time",
+      "closingTime": "Closing Time",
+      "autoStopTracking": "Auto-stop Time Tracking",
+      "autoStopDescription": "Automatically stop all active time entries at factory closing time",
+      "autoStopWarning": "Active time entries will be automatically stopped at {{time}} each day"
+    }
+  },
   "settings": {
     "title": "Settings",
     "subtitle": "Manage your application preferences and account settings",
@@ -226,7 +248,21 @@
     "totalJobs": "Total Jobs",
     "totalParts": "Total Parts",
     "activeCells": "Active Cells",
-    "completedToday": "Completed Today"
+    "completedToday": "Completed Today",
+    "startedAt": "Started At",
+    "stopClockingTitle": "Stop Time Tracking",
+    "stopClockingDescription": "Review the active time entry and stop the clocking if needed.",
+    "stopClocking": "Stop Clocking",
+    "clockingStopped": "Clocking Stopped",
+    "clockingStoppedDescription": "Time tracking for {{operator}} on {{operation}} has been stopped.",
+    "stopFailed": "Failed to Stop Clocking",
+    "stopAll": "Stop All",
+    "stopAllClockings": "Stop All Clockings",
+    "allClockingsStopped": "All Clockings Stopped",
+    "allClockingsStoppedDescription": "{{count}} time entries have been stopped.",
+    "stopAllFailed": "Failed to Stop All Clockings",
+    "pastClosingTimeWarning": "Factory closing time has passed",
+    "pastClosingTimeDescription": "There are {{count}} active time entries after closing time ({{time}}). Consider stopping them."
   },
   "workQueue": {
     "filtersAndControls": "Filters & Controls",
@@ -274,7 +310,8 @@
     "next": "Next",
     "save": "Save",
     "success": "Success",
-    "validationError": "Validation Error"
+    "validationError": "Validation Error",
+    "stopping": "Stopping..."
   },
   "onboarding": {
     "welcome": "Welcome to Eryxon MES",
@@ -1337,7 +1374,10 @@
     "inBuffer": "In Buffer",
     "expected": "Expected",
     "noActiveJobs": "No active jobs",
-    "jobsFound": "jobs found"
+    "jobsFound": "jobs found",
+    "you": "YOU",
+    "other": "Other",
+    "youAreClockedOn": "You are currently clocked on this operation"
   },
   "activityMonitor": {
     "title": "Activity Monitor",

--- a/src/i18n/locales/nl/translation.json
+++ b/src/i18n/locales/nl/translation.json
@@ -74,6 +74,28 @@
       "impressumText": "Impressum pagina"
     }
   },
+  "organizationSettings": {
+    "title": "Organisatie-instellingen",
+    "subtitle": "Beheer uw organisatieprofiel en voorkeuren",
+    "companyInformation": "Bedrijfsinformatie",
+    "updateOrgDetails": "Uw organisatiegegevens bijwerken",
+    "organizationName": "Organisatienaam",
+    "companyName": "Bedrijfsnaam",
+    "timezone": "Tijdzone",
+    "timezoneDescription": "Gebruikt voor planning en vervaldatums",
+    "billingEmail": "Factuur e-mail",
+    "saveChanges": "Wijzigingen opslaan",
+    "settingsUpdated": "Organisatie-instellingen bijgewerkt",
+    "factoryHours": {
+      "title": "Fabriekstijden",
+      "description": "Configureer uw fabriekswerktijden en automatische tijdregistratie-instellingen",
+      "openingTime": "Openingstijd",
+      "closingTime": "Sluitingstijd",
+      "autoStopTracking": "Automatisch stoppen tijdregistratie",
+      "autoStopDescription": "Automatisch alle actieve tijdregistraties stoppen bij sluitingstijd",
+      "autoStopWarning": "Actieve tijdregistraties worden automatisch gestopt om {{time}} elke dag"
+    }
+  },
   "settings": {
     "title": "Instellingen",
     "subtitle": "Beheer uw applicatievoorkeuren en accountinstellingen",
@@ -393,7 +415,21 @@
     "totalJobs": "Totaal opdrachten",
     "totalParts": "Totaal onderdelen",
     "activeCells": "Actieve productiecellen",
-    "completedToday": "Vandaag voltooid"
+    "completedToday": "Vandaag voltooid",
+    "startedAt": "Gestart om",
+    "stopClockingTitle": "Tijdregistratie stoppen",
+    "stopClockingDescription": "Bekijk de actieve tijdregistratie en stop de klokking indien nodig.",
+    "stopClocking": "Klokking stoppen",
+    "clockingStopped": "Klokking gestopt",
+    "clockingStoppedDescription": "Tijdregistratie voor {{operator}} op {{operation}} is gestopt.",
+    "stopFailed": "Klokking stoppen mislukt",
+    "stopAll": "Alles stoppen",
+    "stopAllClockings": "Alle klokkingen stoppen",
+    "allClockingsStopped": "Alle klokkingen gestopt",
+    "allClockingsStoppedDescription": "{{count}} tijdregistraties zijn gestopt.",
+    "stopAllFailed": "Alle klokkingen stoppen mislukt",
+    "pastClosingTimeWarning": "Fabriek sluitingstijd is verstreken",
+    "pastClosingTimeDescription": "Er zijn {{count}} actieve tijdregistraties na sluitingstijd ({{time}}). Overweeg deze te stoppen."
   },
   "workQueue": {
     "filtersAndControls": "Filters & besturing",
@@ -441,7 +477,8 @@
     "next": "Volgende",
     "save": "Opslaan",
     "success": "Succes",
-    "validationError": "Validatiefout"
+    "validationError": "Validatiefout",
+    "stopping": "Stoppen..."
   },
   "onboarding": {
     "welcome": "Welkom bij Eryxon MES",
@@ -1504,7 +1541,10 @@
     "inBuffer": "In buffer",
     "expected": "Verwacht",
     "noActiveJobs": "Geen actieve opdrachten",
-    "jobsFound": "opdrachten gevonden"
+    "jobsFound": "opdrachten gevonden",
+    "you": "JIJ",
+    "other": "Ander",
+    "youAreClockedOn": "Je bent momenteel ingeklokt op deze bewerking"
   },
   "activityMonitor": {
     "title": "Activiteitenmonitor",

--- a/src/pages/admin/OrganizationSettings.tsx
+++ b/src/pages/admin/OrganizationSettings.tsx
@@ -6,8 +6,10 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Loader2, Building2, Save } from 'lucide-react';
+import { Switch } from '@/components/ui/switch';
+import { Loader2, Building2, Save, Clock } from 'lucide-react';
 import { toast } from 'sonner';
+import { useTranslation } from 'react-i18next';
 
 const TIMEZONES = [
   'UTC',
@@ -24,6 +26,7 @@ const TIMEZONES = [
 ];
 
 export default function OrganizationSettings() {
+  const { t } = useTranslation();
   const { profile, tenant, refreshTenant } = useAuth();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -32,6 +35,9 @@ export default function OrganizationSettings() {
     company_name: '',
     timezone: 'UTC',
     billing_email: '',
+    factory_opening_time: '07:00',
+    factory_closing_time: '17:00',
+    auto_stop_tracking: false,
   });
 
   useEffect(() => {
@@ -52,11 +58,20 @@ export default function OrganizationSettings() {
 
       if (error) throw error;
 
+      // Format time from database format (HH:MM:SS) to input format (HH:MM)
+      const formatTime = (time: string | null) => {
+        if (!time) return '';
+        return time.substring(0, 5);
+      };
+
       setFormData({
         name: data.name || '',
         company_name: data.company_name || '',
         timezone: data.timezone || 'UTC',
         billing_email: data.billing_email || '',
+        factory_opening_time: formatTime(data.factory_opening_time) || '07:00',
+        factory_closing_time: formatTime(data.factory_closing_time) || '17:00',
+        auto_stop_tracking: data.auto_stop_tracking || false,
       });
     } catch (error: any) {
       console.error('Error loading tenant details:', error);
@@ -81,12 +96,15 @@ export default function OrganizationSettings() {
           company_name: formData.company_name,
           timezone: formData.timezone,
           billing_email: formData.billing_email,
+          factory_opening_time: formData.factory_opening_time + ':00',
+          factory_closing_time: formData.factory_closing_time + ':00',
+          auto_stop_tracking: formData.auto_stop_tracking,
         })
         .eq('id', tenant.id);
 
       if (error) throw error;
 
-      toast.success('Organization settings updated');
+      toast.success(t('organizationSettings.settingsUpdated'));
       await refreshTenant();
     } catch (error: any) {
       console.error('Error updating tenant:', error);
@@ -175,7 +193,7 @@ export default function OrganizationSettings() {
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="billing_email">Billing Email</Label>
+              <Label htmlFor="billing_email">{t('organizationSettings.billingEmail')}</Label>
               <Input
                 id="billing_email"
                 type="email"
@@ -189,9 +207,70 @@ export default function OrganizationSettings() {
               <Button type="submit" disabled={saving} className="cta-button gap-2">
                 {saving && <Loader2 className="h-4 w-4 animate-spin" />}
                 <Save className="h-4 w-4" />
-                Save Changes
+                {t('organizationSettings.saveChanges')}
               </Button>
             </div>
+          </CardContent>
+        </Card>
+
+        {/* Factory Hours Card */}
+        <Card className="glass-card">
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <Clock className="h-5 w-5" />
+              <CardTitle>{t('organizationSettings.factoryHours.title')}</CardTitle>
+            </div>
+            <CardDescription>
+              {t('organizationSettings.factoryHours.description')}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="factory_opening_time">{t('organizationSettings.factoryHours.openingTime')}</Label>
+                <Input
+                  id="factory_opening_time"
+                  type="time"
+                  value={formData.factory_opening_time}
+                  onChange={(e) => setFormData({ ...formData, factory_opening_time: e.target.value })}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="factory_closing_time">{t('organizationSettings.factoryHours.closingTime')}</Label>
+                <Input
+                  id="factory_closing_time"
+                  type="time"
+                  value={formData.factory_closing_time}
+                  onChange={(e) => setFormData({ ...formData, factory_closing_time: e.target.value })}
+                />
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between rounded-lg border p-4">
+              <div className="space-y-0.5">
+                <Label htmlFor="auto_stop_tracking" className="text-base">
+                  {t('organizationSettings.factoryHours.autoStopTracking')}
+                </Label>
+                <p className="text-sm text-muted-foreground">
+                  {t('organizationSettings.factoryHours.autoStopDescription')}
+                </p>
+              </div>
+              <Switch
+                id="auto_stop_tracking"
+                checked={formData.auto_stop_tracking}
+                onCheckedChange={(checked) => setFormData({ ...formData, auto_stop_tracking: checked })}
+              />
+            </div>
+
+            {formData.auto_stop_tracking && (
+              <div className="rounded-lg bg-warning/10 border border-warning/20 p-3">
+                <p className="text-sm text-warning">
+                  {t('organizationSettings.factoryHours.autoStopWarning', {
+                    time: formData.factory_closing_time,
+                  })}
+                </p>
+              </div>
+            )}
           </CardContent>
         </Card>
       </form>

--- a/src/pages/operator/OperatorTerminal.tsx
+++ b/src/pages/operator/OperatorTerminal.tsx
@@ -190,6 +190,9 @@ export default function OperatorTerminal() {
             hasModel,
             filePaths: op.part.file_paths || [],
             activeTimeEntryId: op.active_time_entry?.id,
+            activeOperatorId: op.active_time_entry?.operator_id,
+            activeOperatorName: op.active_time_entry?.operator?.full_name,
+            isCurrentUserClocked: op.active_time_entry?.operator_id === profile?.id,
             notes: op.notes,
             cellName: op.cell.name,
             cellColor: op.cell.color || "#3b82f6",
@@ -198,7 +201,7 @@ export default function OperatorTerminal() {
         };
     };
 
-    const allJobs = useMemo(() => operations.map(mapOperationToJob), [operations]);
+    const allJobs = useMemo(() => operations.map(mapOperationToJob), [operations, profile?.id]);
 
     // Filter by Cell
     const filteredJobs = useMemo(() => {

--- a/src/pages/operator/OperatorView.tsx
+++ b/src/pages/operator/OperatorView.tsx
@@ -681,30 +681,52 @@ export default function OperatorView() {
 
           {/* Timer Display */}
           {selectedOperation && (
-            <Box
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                gap: 0.75,
-                bgcolor: activeTimeEntry ? "primary.main" : "rgba(255, 255, 255, 0.08)",
-                color: activeTimeEntry ? "primary.contrastText" : "text.primary",
-                px: 1.25,
-                py: 0.375,
-                borderRadius: 1.5,
-                border: activeTimeEntry ? "none" : "1px solid rgba(255, 255, 255, 0.08)",
-              }}
-            >
-              <Timer sx={{ fontSize: 16 }} />
-              <Typography
+            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+              {/* Active clocking indicator */}
+              {activeTimeEntry && (
+                <Chip
+                  label={t("terminal.youAreClockedOn")}
+                  size="small"
+                  color="primary"
+                  variant="outlined"
+                  sx={{
+                    height: 22,
+                    fontSize: "0.6rem",
+                    fontWeight: "bold",
+                    borderWidth: 2,
+                    animation: "pulse 2s ease-in-out infinite",
+                    "@keyframes pulse": {
+                      "0%, 100%": { opacity: 1 },
+                      "50%": { opacity: 0.7 },
+                    },
+                  }}
+                />
+              )}
+              <Box
                 sx={{
-                  fontFamily: "monospace",
-                  fontWeight: "bold",
-                  fontSize: "0.9rem",
-                  minWidth: 72,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 0.75,
+                  bgcolor: activeTimeEntry ? "primary.main" : "rgba(255, 255, 255, 0.08)",
+                  color: activeTimeEntry ? "primary.contrastText" : "text.primary",
+                  px: 1.25,
+                  py: 0.375,
+                  borderRadius: 1.5,
+                  border: activeTimeEntry ? "none" : "1px solid rgba(255, 255, 255, 0.08)",
                 }}
               >
-                {formatElapsedTime(elapsedSeconds)}
-              </Typography>
+                <Timer sx={{ fontSize: 16 }} />
+                <Typography
+                  sx={{
+                    fontFamily: "monospace",
+                    fontWeight: "bold",
+                    fontSize: "0.9rem",
+                    minWidth: 72,
+                  }}
+                >
+                  {formatElapsedTime(elapsedSeconds)}
+                </Typography>
+              </Box>
             </Box>
           )}
 
@@ -1207,8 +1229,28 @@ export default function OperatorView() {
                             <Typography variant="caption" color="text.secondary" sx={{ fontSize: "0.55rem" }}>
                               {op.actual_time || 0}/{op.estimated_time}m
                             </Typography>
-                            {op.active_time_entry && (
-                              <Timer sx={{ fontSize: 10, color: "primary.main" }} />
+                            {op.active_time_entry && op.active_time_entry.operator_id === profile?.id && (
+                              <Chip
+                                icon={<Timer sx={{ fontSize: "10px !important" }} />}
+                                label={t("terminal.you")}
+                                size="small"
+                                color="primary"
+                                sx={{
+                                  height: 16,
+                                  fontSize: "0.5rem",
+                                  fontWeight: "bold",
+                                  "& .MuiChip-label": { px: 0.5 },
+                                  "& .MuiChip-icon": { ml: 0.25 },
+                                  animation: "pulse 2s ease-in-out infinite",
+                                  "@keyframes pulse": {
+                                    "0%, 100%": { opacity: 1 },
+                                    "50%": { opacity: 0.7 },
+                                  },
+                                }}
+                              />
+                            )}
+                            {op.active_time_entry && op.active_time_entry.operator_id !== profile?.id && (
+                              <Timer sx={{ fontSize: 10, color: "warning.main" }} />
                             )}
                           </Box>
                         </Box>

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -19,6 +19,9 @@ export interface TerminalJob {
     jobId: string; // Added for QRM routing
     filePaths: string[];
     activeTimeEntryId?: string;
+    activeOperatorId?: string; // ID of the operator currently clocked on
+    activeOperatorName?: string; // Name of the operator currently clocked on
+    isCurrentUserClocked?: boolean; // True if current user is clocked on this operation
     notes?: string | null;
     cellName?: string;
     cellColor?: string;

--- a/supabase/migrations/20251125100000_add_factory_hours_to_tenants.sql
+++ b/supabase/migrations/20251125100000_add_factory_hours_to_tenants.sql
@@ -1,0 +1,12 @@
+-- Add factory hours settings to tenants table
+-- These are used to automatically stop time tracking at factory closing time
+
+ALTER TABLE public.tenants
+ADD COLUMN IF NOT EXISTS factory_opening_time TIME DEFAULT '07:00:00',
+ADD COLUMN IF NOT EXISTS factory_closing_time TIME DEFAULT '17:00:00',
+ADD COLUMN IF NOT EXISTS auto_stop_tracking BOOLEAN DEFAULT false;
+
+-- Add comment to explain the columns
+COMMENT ON COLUMN public.tenants.factory_opening_time IS 'Factory opening time (used for scheduling)';
+COMMENT ON COLUMN public.tenants.factory_closing_time IS 'Factory closing time (used to auto-stop time tracking if enabled)';
+COMMENT ON COLUMN public.tenants.auto_stop_tracking IS 'If true, automatically stop time tracking at factory closing time';


### PR DESCRIPTION
…clocking indicators

- Dashboard Active Work table rows are now clickable with a dialog to stop clockings
- Added Stop All button to stop all active clockings at once
- Added factory hours settings (opening/closing time) in Organization Settings
- Added auto-stop tracking toggle and warning when past closing time
- Added visual indicators in terminal view showing which operations the current user is clocked on (with pulsing "YOU" badge)
- Added visual indicators in job view (OperatorView) for current user's active clockings
- Added database migration for factory hours columns on tenants table
- Added translations for all new features (EN/NL)