### PR TITLE
Fix operator view active pane bugs

### DIFF
--- a/src/components/terminal/DetailPanel.tsx
+++ b/src/components/terminal/DetailPanel.tsx
@@ -82,7 +82,7 @@ export function DetailPanel({ job, onStart, onPause, onComplete, stepUrl, pdfUrl
                 </div>
 
                 <div className="flex gap-1.5">
-                    {job.status !== 'in_progress' ? (
+                    {!job.isCurrentUserClocked ? (
                         <Button onClick={onStart} size="sm" className="flex-1 bg-emerald-600 hover:bg-emerald-700 text-white h-8 text-xs">
                             <Play className="w-3.5 h-3.5 mr-1.5" /> Start
                         </Button>
@@ -91,7 +91,7 @@ export function DetailPanel({ job, onStart, onPause, onComplete, stepUrl, pdfUrl
                             <Pause className="w-3.5 h-3.5 mr-1.5" /> Pause
                         </Button>
                     )}
-                    {job.status === 'in_progress' && (
+                    {(job.status === 'in_progress' || job.isCurrentUserClocked) && !job.activeTimeEntryId && (
                         <Button
                             onClick={onComplete}
                             variant="outline"

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -73,6 +73,7 @@ export async function fetchOperationsWithDetails(tenantId: string): Promise<Oper
       )
     `)
     .eq("tenant_id", tenantId)
+    .neq("status", "completed")  // Exclude completed operations from terminal view
     .order("sequence");
 
   if (operationsError) {

--- a/src/pages/operator/OperatorTerminal.tsx
+++ b/src/pages/operator/OperatorTerminal.tsx
@@ -162,10 +162,15 @@ export default function OperatorTerminal() {
         const hasPdf = op.part.file_paths?.some(p => p.toLowerCase().endsWith('.pdf')) || false;
         const hasModel = op.part.file_paths?.some(p => p.toLowerCase().endsWith('.step') || p.toLowerCase().endsWith('.stp')) || false;
 
+        // Map operation status - skip completed operations (handled by filter below)
         let status: TerminalJob['status'] = 'expected';
         if (op.status === 'in_progress') status = 'in_progress';
-        else if (op.status === 'on_hold') status = 'on_hold'; // Map on_hold to something visible?
-        else if (op.status === 'not_started') status = 'in_buffer'; // Default to buffer for now
+        else if (op.status === 'on_hold') status = 'on_hold';
+        else if (op.status === 'not_started') status = 'in_buffer';
+        else if (op.status === 'completed') status = 'expected'; // Will be filtered out
+
+        // If there's an active time entry, the operation should be considered in_progress
+        if (op.active_time_entry) status = 'in_progress';
 
         // Calculate remaining hours
         const estimated = op.estimated_time || 0;


### PR DESCRIPTION
- Fix Start/Pause button to check isCurrentUserClocked instead of just job.status, ensuring the button toggles correctly when timing
- Add logic to set status to in_progress when there's an active time entry, regardless of database status field
- Filter out completed operations from the terminal view
- Complete button only shows when timer is stopped (no activeTimeEntryId)