### PR TITLE
Fix file upload storage display bug

### DIFF
--- a/src/components/admin/PartDetailModal.tsx
+++ b/src/components/admin/PartDetailModal.tsx
@@ -11,14 +11,14 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Plus, Save, X, Upload, Eye, Trash2, Box, FileText, AlertTriangle, Package, ChevronRight, Wrench, Image as ImageIcon } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { STEPViewer } from "@/components/STEPViewer";
 import { PDFViewer } from "@/components/PDFViewer";
 import { useAuth } from "@/contexts/AuthContext";
 import { useFileUpload } from "@/hooks/useFileUpload";
-import { UploadProgress, StorageQuotaDisplay } from "@/components/UploadProgress";
+import { UploadProgress } from "@/components/UploadProgress";
 import {
   Select,
   SelectContent,
@@ -67,17 +67,9 @@ export default function PartDetailModal({ partId, onClose, onUpdate }: PartDetai
   const {
     progress: uploadProgress,
     isUploading,
-    storageQuota,
     uploadFiles,
-    deleteFile,
-    fetchStorageQuota,
     resetProgress,
   } = useFileUpload();
-
-  // Fetch storage quota on mount
-  useEffect(() => {
-    fetchStorageQuota();
-  }, [fetchStorageQuota]);
 
   const { data: part, isLoading } = useQuery({
     queryKey: ["part-detail", partId],
@@ -642,9 +634,6 @@ export default function PartDetailModal({ partId, onClose, onUpdate }: PartDetai
                 {t("parts.files")} ({part?.file_paths?.length || 0})
               </Label>
             </div>
-
-            {/* Storage Quota Display */}
-            <StorageQuotaDisplay quota={storageQuota} className="mb-4" />
 
             {/* File Upload */}
             <div className="border rounded-lg p-4 mb-3 bg-muted">

--- a/src/components/parts/ImageUpload.tsx
+++ b/src/components/parts/ImageUpload.tsx
@@ -26,7 +26,6 @@ export function ImageUpload({ partId, onUploadComplete, className }: ImageUpload
     uploadFiles,
     progress,
     isUploading,
-    storageQuota,
   } = useFileUpload();
 
   // Handle file selection
@@ -146,24 +145,6 @@ export function ImageUpload({ partId, onUploadComplete, className }: ImageUpload
 
   return (
     <div className={cn("space-y-4", className)}>
-      {/* Storage Quota Display */}
-      {storageQuota && (
-        <div className="space-y-2">
-          <div className="flex justify-between text-sm">
-            <span className="text-muted-foreground">
-              {t("parts.images.storageUsed")}
-            </span>
-            <span className="font-medium">
-              {storageQuota.currentMB.toFixed(2)} MB
-              {!storageQuota.isUnlimited && ` / ${storageQuota.maxMB} MB`}
-            </span>
-          </div>
-          {!storageQuota.isUnlimited && (
-            <Progress value={storageQuota.usedPercentage} className="h-2" />
-          )}
-        </div>
-      )}
-
       {/* Drag and Drop Zone */}
       <Card
         className={cn(


### PR DESCRIPTION
Storage usage display belongs on the My Plan page, not in individual upload components. Storage enforcement still works - uploads will be blocked if quota is exceeded.