### PR TITLE
Fix left menu localization and add page subtitle translations

### DIFF
--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -23,7 +23,7 @@ const languages: Language[] = [
 ];
 
 export const LanguageSwitcher = () => {
-  const { i18n } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [open, setOpen] = useState(false);
 
   const handleLanguageChange = async (languageCode: string) => {
@@ -48,7 +48,7 @@ export const LanguageSwitcher = () => {
       <PopoverContent className="w-64 p-0 glass-card" align="end">
         <div className="px-4 py-3 border-b border-border-subtle bg-primary/5">
           <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-            Select Language
+            {t("languageSwitcher.selectLanguage")}
           </p>
         </div>
         <div className="p-1">

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -328,6 +328,7 @@
   },
   "parts": {
     "title": "Teileverwaltung",
+    "subtitle": "Verfolgen Sie Teile, Baugruppen und Komponenten über alle Aufträge",
     "3dModel": "3D-Modell",
     "actions": "Aktionen",
     "addPart": "Teil hinzufügen",
@@ -746,6 +747,7 @@
   },
   "resources": {
     "title": "Ressourcenverwaltung",
+    "subtitle": "Verwalten Sie Werkzeuge, Maschinen und Geräte für Ihre Arbeitsgänge",
     "active": "Aktiv",
     "addResource": "Ressource hinzufügen",
     "addResourcesOfType": "Ressourcen vom Typ {{type}} hinzufügen",
@@ -1300,5 +1302,27 @@
     "noActivitiesFound": "Keine Aktivitäten gefunden",
     "tryAdjustingFilters": "Versuchen Sie, Ihre Filter oder Suchanfrage anzupassen",
     "loadMore": "Mehr laden"
+  },
+  "integrations": {
+    "title": "Integrationen Marktplatz",
+    "subtitle": "Durchsuchen und installieren Sie vorgefertigte Integrationen für gängige ERP-Systeme oder erstellen Sie Ihre eigenen mit unseren Starter-Kits",
+    "marketplace": "Marktplatz",
+    "starterKits": "Starter-Kits",
+    "available": "Verfügbar",
+    "installed": "Installiert",
+    "install": "Installieren",
+    "configure": "Konfigurieren",
+    "remove": "Entfernen"
+  },
+  "templates": {
+    "title": "Unterschritt-Vorlagen",
+    "subtitle": "Verwalten Sie Unterschritt-Vorlagen und sehen Sie alle Unterschritte Ihrer Arbeitsgänge"
+  },
+  "languageSwitcher": {
+    "selectLanguage": "Sprache auswählen"
+  },
+  "jobCreate": {
+    "title": "Neuen Auftrag erstellen",
+    "subtitle": "Erstellen Sie Ihren Auftrag Schritt für Schritt: definieren Sie Details, fügen Sie Teile hinzu, konfigurieren Sie Arbeitsgänge und überprüfen Sie"
   }
 }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -452,6 +452,7 @@
   },
   "parts": {
     "title": "Parts Management",
+    "subtitle": "Track parts, assemblies, and components across all jobs",
     "3dModel": "3D Model",
     "actions": "Actions",
     "addPart": "Add Part",
@@ -870,6 +871,7 @@
   },
   "resources": {
     "title": "Resource Management",
+    "subtitle": "Manage tools, machines, and equipment for your operations",
     "active": "Active",
     "addResource": "Add Resource",
     "addResourcesOfType": "Add resources of type {{type}}",
@@ -1427,5 +1429,27 @@
     "noActivitiesFound": "No activities found",
     "tryAdjustingFilters": "Try adjusting your filters or search query",
     "loadMore": "Load More"
+  },
+  "integrations": {
+    "title": "Integration Marketplace",
+    "subtitle": "Browse and install pre-built integrations for common ERP systems, or build your own using our starter kits",
+    "marketplace": "Marketplace",
+    "starterKits": "Starter Kits",
+    "available": "Available",
+    "installed": "Installed",
+    "install": "Install",
+    "configure": "Configure",
+    "remove": "Remove"
+  },
+  "templates": {
+    "title": "Substep Templates",
+    "subtitle": "Manage substep templates and view all substeps across your operations"
+  },
+  "languageSwitcher": {
+    "selectLanguage": "Select Language"
+  },
+  "jobCreate": {
+    "title": "Create New Job",
+    "subtitle": "Build your job step-by-step: define details, add parts, configure operations, and review"
   }
 }

--- a/src/i18n/locales/nl/translation.json
+++ b/src/i18n/locales/nl/translation.json
@@ -605,6 +605,7 @@
   },
   "parts": {
     "title": "Onderdelenbeheer",
+    "subtitle": "Volg onderdelen, samenstellingen en componenten over alle orders",
     "3dModel": "3D-model",
     "actions": "Acties",
     "addPart": "Onderdeel toevoegen",
@@ -1023,6 +1024,7 @@
   },
   "resources": {
     "title": "Resourcebeheer",
+    "subtitle": "Beheer gereedschappen, machines en apparatuur voor uw bewerkingen",
     "active": "Actief",
     "addResource": "Resource toevoegen",
     "addResourcesOfType": "Resources van type {{type}} toevoegen",
@@ -1580,5 +1582,27 @@
     "noActivitiesFound": "Geen activiteiten gevonden",
     "tryAdjustingFilters": "Probeer uw filters of zoekopdracht aan te passen",
     "loadMore": "Meer laden"
+  },
+  "integrations": {
+    "title": "Integratie Marktplaats",
+    "subtitle": "Blader door en installeer vooraf gebouwde integraties voor veelvoorkomende ERP-systemen, of bouw uw eigen integratie met onze startkits",
+    "marketplace": "Marktplaats",
+    "starterKits": "Startkits",
+    "available": "Beschikbaar",
+    "installed": "Geïnstalleerd",
+    "install": "Installeren",
+    "configure": "Configureren",
+    "remove": "Verwijderen"
+  },
+  "templates": {
+    "title": "Substap Sjablonen",
+    "subtitle": "Beheer substapsjablonen en bekijk alle substappen in uw bewerkingen"
+  },
+  "languageSwitcher": {
+    "selectLanguage": "Taal selecteren"
+  },
+  "jobCreate": {
+    "title": "Nieuwe Order Aanmaken",
+    "subtitle": "Bouw uw order stap voor stap: definieer details, voeg onderdelen toe, configureer bewerkingen en controleer"
   }
 }

--- a/src/pages/admin/ActivityMonitor.tsx
+++ b/src/pages/admin/ActivityMonitor.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from "react";
+import { useTranslation } from "react-i18next";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
 import { formatDistanceToNow } from "date-fns";
@@ -68,6 +69,7 @@ interface ActivityStats {
 }
 
 export const ActivityMonitor: React.FC = () => {
+  const { t } = useTranslation();
   const [activities, setActivities] = useState<ActivityLog[]>([]);
   const [stats, setStats] = useState<ActivityStats | null>(null);
   const [loading, setLoading] = useState(true);
@@ -323,10 +325,10 @@ export const ActivityMonitor: React.FC = () => {
       {/* Header Section */}
       <div>
         <h1 className="text-4xl font-bold bg-gradient-to-r from-foreground via-foreground to-foreground/70 bg-clip-text text-transparent mb-2">
-          Activity Monitor
+          {t("activityMonitor.title")}
         </h1>
         <p className="text-muted-foreground text-lg">
-          Real-time platform activity feed with comprehensive audit trail
+          {t("activityMonitor.description")}
         </p>
       </div>
 

--- a/src/pages/admin/ConfigResources.tsx
+++ b/src/pages/admin/ConfigResources.tsx
@@ -194,7 +194,7 @@ export default function ConfigResources() {
             <h1 className="text-4xl font-bold bg-gradient-to-r from-foreground via-foreground to-foreground/70 bg-clip-text text-transparent mb-2">
               {t('resources.title')}
             </h1>
-            <p className="text-muted-foreground text-lg">{t('resources.description')}</p>
+            <p className="text-muted-foreground text-lg">{t('resources.subtitle')}</p>
           </div>
 
           <Dialog open={dialogOpen} onOpenChange={(open) => {

--- a/src/pages/admin/IntegrationsMarketplace.tsx
+++ b/src/pages/admin/IntegrationsMarketplace.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
 import { useAuth } from "@/contexts/AuthContext";
 import { supabase } from "@/integrations/supabase/client";
@@ -74,6 +75,7 @@ const categoryLabels: Record<string, string> = {
 };
 
 export default function IntegrationsMarketplace() {
+  const { t } = useTranslation();
   const { session } = useAuth();
   const [searchQuery, setSearchQuery] = useState("");
   const [categoryFilter, setCategoryFilter] = useState("all");
@@ -257,10 +259,10 @@ export default function IntegrationsMarketplace() {
     <div className="p-6 max-w-7xl mx-auto space-y-8">
       <div>
         <h1 className="text-4xl font-bold bg-gradient-to-r from-foreground via-foreground to-foreground/70 bg-clip-text text-transparent mb-2">
-          Integration Marketplace
+          {t("integrations.title")}
         </h1>
         <p className="text-muted-foreground text-lg">
-          Browse and install pre-built integrations for common ERP systems, or build your own using our starter kits
+          {t("integrations.subtitle")}
         </p>
       </div>
 

--- a/src/pages/admin/JobCreate.tsx
+++ b/src/pages/admin/JobCreate.tsx
@@ -306,7 +306,7 @@ export default function JobCreate() {
           {t("jobs.createNewJob")}
         </h1>
         <p className="text-muted-foreground text-lg">
-          Build your job step-by-step: define details, add parts, configure operations, and review
+          {t("jobCreate.subtitle")}
         </p>
       </div>
 

--- a/src/pages/admin/Parts.tsx
+++ b/src/pages/admin/Parts.tsx
@@ -402,7 +402,7 @@ export default function Parts() {
             {t("parts.title")}
           </h1>
           <p className="text-muted-foreground text-lg">
-            Track parts, assemblies, and components across all jobs
+            {t("parts.subtitle")}
           </p>
         </div>
 

--- a/src/pages/admin/StepsTemplatesView.tsx
+++ b/src/pages/admin/StepsTemplatesView.tsx
@@ -13,10 +13,10 @@ export default function StepsTemplatesView() {
     <div className="container mx-auto p-6 space-y-8">
         <div>
           <h1 className="text-4xl font-bold bg-gradient-to-r from-foreground via-foreground to-foreground/70 bg-clip-text text-transparent mb-2">
-            {t("Steps & Templates")}
+            {t("templates.title")}
           </h1>
           <p className="text-muted-foreground text-lg">
-            {t("Manage substep templates and view all substeps across your operations")}
+            {t("templates.subtitle")}
           </p>
         </div>
 


### PR DESCRIPTION
- Add useTranslation hook to LanguageSwitcher component for dynamic text
- Add missing subtitle translation keys to all language files (EN, NL, DE):
  - parts.subtitle, resources.subtitle, integrations.*, templates.*, languageSwitcher.selectLanguage, jobCreate.*
- Update components to use translation keys instead of hardcoded strings:
  - Parts.tsx, ActivityMonitor.tsx, IntegrationsMarketplace.tsx, JobCreate.tsx, ConfigResources.tsx, StepsTemplatesView.tsx
- Ensure all left menu items and page subtitles are properly localized
- Use "Order" terminology for Jobs in Dutch translation