### PR TITLE
Fix user invitation system not sending emails

### DIFF
--- a/supabase/functions/send-invitation/index.ts
+++ b/supabase/functions/send-invitation/index.ts
@@ -1,0 +1,326 @@
+/**
+ * Send Invitation Edge Function
+ *
+ * Creates an invitation record and sends an email to the invitee.
+ * Uses Resend for email delivery.
+ *
+ * Required environment variables:
+ * - RESEND_API_KEY: Your Resend API key
+ * - APP_URL: Your application URL (e.g., https://app.eryxon.com)
+ * - EMAIL_FROM: Sender email address (e.g., noreply@eryxon.com)
+ */
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.3'
+import { corsHeaders, handleCors } from '../_shared/cors.ts'
+
+interface InvitationRequest {
+  email: string
+  role: 'operator' | 'admin'
+  tenant_id?: string
+}
+
+interface ResendEmailPayload {
+  from: string
+  to: string
+  subject: string
+  html: string
+}
+
+Deno.serve(async (req: Request) => {
+  // Handle CORS preflight
+  const corsResponse = handleCors(req)
+  if (corsResponse) return corsResponse
+
+  // Only allow POST
+  if (req.method !== 'POST') {
+    return new Response(
+      JSON.stringify({ error: 'Method not allowed' }),
+      { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
+  }
+
+  try {
+    // Get authorization header
+    const authHeader = req.headers.get('Authorization')
+    if (!authHeader) {
+      return new Response(
+        JSON.stringify({ error: 'Missing authorization header' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Parse request body
+    const body: InvitationRequest = await req.json()
+    const { email, role = 'operator', tenant_id } = body
+
+    if (!email) {
+      return new Response(
+        JSON.stringify({ error: 'Email is required' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Validate email format
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+    if (!emailRegex.test(email)) {
+      return new Response(
+        JSON.stringify({ error: 'Invalid email format' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Initialize Supabase client with user's auth
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+    const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!
+
+    const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+      global: {
+        headers: { Authorization: authHeader }
+      }
+    })
+
+    // Get current user info for the email
+    const { data: { user }, error: userError } = await supabase.auth.getUser()
+    if (userError || !user) {
+      return new Response(
+        JSON.stringify({ error: 'Unable to verify user' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Get inviter's profile and tenant info
+    const { data: profile, error: profileError } = await supabase
+      .from('profiles')
+      .select('full_name, tenant_id, tenants(name, company_name)')
+      .eq('id', user.id)
+      .single()
+
+    if (profileError || !profile) {
+      return new Response(
+        JSON.stringify({ error: 'Unable to get user profile' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Create invitation using RPC
+    const { data: invitationId, error: invitationError } = await supabase.rpc('create_invitation', {
+      p_email: email.toLowerCase(),
+      p_role: role,
+      p_tenant_id: tenant_id || profile.tenant_id
+    })
+
+    if (invitationError) {
+      console.error('Error creating invitation:', invitationError)
+      return new Response(
+        JSON.stringify({ error: invitationError.message }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Get the invitation token
+    const { data: invitation, error: fetchError } = await supabase
+      .from('invitations')
+      .select('token')
+      .eq('id', invitationId)
+      .single()
+
+    if (fetchError || !invitation) {
+      console.error('Error fetching invitation:', fetchError)
+      return new Response(
+        JSON.stringify({ error: 'Failed to fetch invitation details' }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Get environment variables for email
+    const resendApiKey = Deno.env.get('RESEND_API_KEY')
+    const appUrl = Deno.env.get('APP_URL') || 'https://app.eryxon.com'
+    const emailFrom = Deno.env.get('EMAIL_FROM') || 'Eryxon Flow <noreply@eryxon.com>'
+
+    // Build invitation URL
+    const invitationUrl = `${appUrl}/accept-invitation/${invitation.token}`
+
+    // Get tenant info
+    const tenantInfo = profile.tenants as { name: string; company_name: string } | null
+    const organizationName = tenantInfo?.company_name || tenantInfo?.name || 'your organization'
+    const inviterName = profile.full_name || user.email || 'A team member'
+    const roleDisplay = role === 'admin' ? 'Administrator' : 'Operator'
+
+    // If Resend API key is configured, send email
+    if (resendApiKey) {
+      const emailHtml = `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>You're Invited to Join ${organizationName}</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f4f4f5;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #f4f4f5; padding: 40px 20px;">
+    <tr>
+      <td align="center">
+        <table width="100%" cellpadding="0" cellspacing="0" style="max-width: 600px; background-color: #ffffff; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);">
+          <!-- Header -->
+          <tr>
+            <td style="background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%); padding: 40px 40px; text-align: center;">
+              <h1 style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 600;">You're Invited!</h1>
+              <p style="margin: 10px 0 0 0; color: #94a3b8; font-size: 14px;">Join your team on Eryxon Flow</p>
+            </td>
+          </tr>
+
+          <!-- Content -->
+          <tr>
+            <td style="padding: 40px;">
+              <p style="margin: 0 0 20px 0; color: #374151; font-size: 16px; line-height: 1.6;">
+                Hello,
+              </p>
+              <p style="margin: 0 0 20px 0; color: #374151; font-size: 16px; line-height: 1.6;">
+                <strong>${inviterName}</strong> has invited you to join <strong>${organizationName}</strong> on Eryxon Flow as an <strong>${roleDisplay}</strong>.
+              </p>
+
+              <!-- Info Box -->
+              <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #f8fafc; border-radius: 8px; margin: 24px 0;">
+                <tr>
+                  <td style="padding: 20px;">
+                    <table width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td style="padding: 8px 0; color: #64748b; font-size: 14px;">Organization:</td>
+                        <td style="padding: 8px 0; color: #1e293b; font-size: 14px; font-weight: 500; text-align: right;">${organizationName}</td>
+                      </tr>
+                      <tr>
+                        <td style="padding: 8px 0; color: #64748b; font-size: 14px;">Role:</td>
+                        <td style="padding: 8px 0; color: #1e293b; font-size: 14px; font-weight: 500; text-align: right;">${roleDisplay}</td>
+                      </tr>
+                      <tr>
+                        <td style="padding: 8px 0; color: #64748b; font-size: 14px;">Invited by:</td>
+                        <td style="padding: 8px 0; color: #1e293b; font-size: 14px; font-weight: 500; text-align: right;">${inviterName}</td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+
+              <!-- CTA Button -->
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center" style="padding: 20px 0;">
+                    <a href="${invitationUrl}" style="display: inline-block; background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%); color: #ffffff; text-decoration: none; padding: 14px 32px; border-radius: 8px; font-size: 16px; font-weight: 600; box-shadow: 0 4px 12px rgba(59, 130, 246, 0.4);">
+                      Accept Invitation
+                    </a>
+                  </td>
+                </tr>
+              </table>
+
+              <p style="margin: 20px 0 0 0; color: #6b7280; font-size: 14px; line-height: 1.6;">
+                This invitation will expire in 7 days. If you didn't expect this invitation, you can safely ignore this email.
+              </p>
+
+              <!-- Link fallback -->
+              <p style="margin: 24px 0 0 0; padding: 16px; background-color: #f8fafc; border-radius: 8px; color: #64748b; font-size: 12px; line-height: 1.6; word-break: break-all;">
+                If the button doesn't work, copy and paste this link into your browser:<br>
+                <a href="${invitationUrl}" style="color: #3b82f6;">${invitationUrl}</a>
+              </p>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="background-color: #f8fafc; padding: 24px 40px; text-align: center; border-top: 1px solid #e2e8f0;">
+              <p style="margin: 0; color: #64748b; font-size: 12px;">
+                Eryxon Flow - Manufacturing Execution System
+              </p>
+              <p style="margin: 8px 0 0 0; color: #94a3b8; font-size: 11px;">
+                This email was sent to ${email}
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>
+`
+
+      const emailPayload: ResendEmailPayload = {
+        from: emailFrom,
+        to: email,
+        subject: `You're invited to join ${organizationName} on Eryxon Flow`,
+        html: emailHtml
+      }
+
+      try {
+        const resendResponse = await fetch('https://api.resend.com/emails', {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${resendApiKey}`,
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify(emailPayload)
+        })
+
+        if (!resendResponse.ok) {
+          const errorData = await resendResponse.text()
+          console.error('Resend API error:', errorData)
+          // Don't fail the request, invitation was created
+          return new Response(
+            JSON.stringify({
+              success: true,
+              invitation_id: invitationId,
+              email_sent: false,
+              email_error: 'Failed to send email, but invitation was created',
+              invitation_url: invitationUrl
+            }),
+            { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+          )
+        }
+
+        const resendData = await resendResponse.json()
+        console.log('Email sent successfully:', resendData)
+
+        return new Response(
+          JSON.stringify({
+            success: true,
+            invitation_id: invitationId,
+            email_sent: true,
+            email_id: resendData.id
+          }),
+          { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        )
+      } catch (emailError) {
+        console.error('Error sending email:', emailError)
+        // Don't fail the request, invitation was created
+        return new Response(
+          JSON.stringify({
+            success: true,
+            invitation_id: invitationId,
+            email_sent: false,
+            email_error: 'Failed to send email, but invitation was created',
+            invitation_url: invitationUrl
+          }),
+          { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        )
+      }
+    } else {
+      // No email service configured - return the invitation URL for manual sharing
+      console.log('No RESEND_API_KEY configured, returning invitation URL')
+      return new Response(
+        JSON.stringify({
+          success: true,
+          invitation_id: invitationId,
+          email_sent: false,
+          message: 'Email service not configured. Share the invitation link manually.',
+          invitation_url: invitationUrl
+        }),
+        { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+  } catch (error) {
+    console.error('Unexpected error:', error)
+    return new Response(
+      JSON.stringify({ error: error instanceof Error ? error.message : 'Internal server error' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
+  }
+})

--- a/supabase/migrations/20251127160000_invitations_system.sql
+++ b/supabase/migrations/20251127160000_invitations_system.sql
@@ -1,0 +1,321 @@
+-- ============================================================================
+-- INVITATION SYSTEM MIGRATION
+-- Creates the invitations table, RPC functions, and RLS policies
+-- ============================================================================
+
+-- Create invitations table if not exists
+CREATE TABLE IF NOT EXISTS public.invitations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  email TEXT NOT NULL,
+  role public.app_role NOT NULL DEFAULT 'operator',
+  token TEXT NOT NULL UNIQUE,
+  invited_by UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'accepted', 'expired', 'cancelled')),
+  expires_at TIMESTAMPTZ NOT NULL DEFAULT (NOW() + INTERVAL '7 days'),
+  accepted_at TIMESTAMPTZ,
+  accepted_by UUID REFERENCES public.profiles(id),
+  metadata JSONB,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Create indexes
+CREATE INDEX IF NOT EXISTS idx_invitations_tenant_id ON public.invitations(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_invitations_email ON public.invitations(email);
+CREATE INDEX IF NOT EXISTS idx_invitations_token ON public.invitations(token);
+CREATE INDEX IF NOT EXISTS idx_invitations_status ON public.invitations(status);
+CREATE INDEX IF NOT EXISTS idx_invitations_expires_at ON public.invitations(expires_at) WHERE status = 'pending';
+
+-- Enable RLS
+ALTER TABLE public.invitations ENABLE ROW LEVEL SECURITY;
+
+-- Drop existing policies first
+DROP POLICY IF EXISTS "Users can view invitations in their tenant" ON public.invitations;
+DROP POLICY IF EXISTS "Admins can create invitations" ON public.invitations;
+DROP POLICY IF EXISTS "Admins can update invitations" ON public.invitations;
+DROP POLICY IF EXISTS "Admins can delete invitations" ON public.invitations;
+DROP POLICY IF EXISTS "Public can view invitation by token" ON public.invitations;
+
+-- RLS Policies
+-- Admins can view all invitations in their tenant
+CREATE POLICY "Users can view invitations in their tenant"
+ON public.invitations FOR SELECT
+TO authenticated
+USING (tenant_id = get_user_tenant_id());
+
+-- Admins can create invitations
+CREATE POLICY "Admins can create invitations"
+ON public.invitations FOR INSERT
+TO authenticated
+WITH CHECK (
+  tenant_id = get_user_tenant_id()
+  AND has_role(auth.uid(), 'admin'::app_role)
+);
+
+-- Admins can update invitations in their tenant
+CREATE POLICY "Admins can update invitations"
+ON public.invitations FOR UPDATE
+TO authenticated
+USING (
+  tenant_id = get_user_tenant_id()
+  AND has_role(auth.uid(), 'admin'::app_role)
+);
+
+-- Admins can delete invitations
+CREATE POLICY "Admins can delete invitations"
+ON public.invitations FOR DELETE
+TO authenticated
+USING (
+  tenant_id = get_user_tenant_id()
+  AND has_role(auth.uid(), 'admin'::app_role)
+);
+
+-- ============================================================================
+-- RPC FUNCTIONS
+-- ============================================================================
+
+-- Function: create_invitation
+-- Creates a new invitation and returns the invitation ID
+CREATE OR REPLACE FUNCTION public.create_invitation(
+  p_email TEXT,
+  p_role public.app_role DEFAULT 'operator',
+  p_tenant_id UUID DEFAULT NULL
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = 'public'
+AS $$
+DECLARE
+  v_tenant_id UUID;
+  v_user_id UUID;
+  v_token TEXT;
+  v_invitation_id UUID;
+  v_existing_count INT;
+BEGIN
+  -- Get current user
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  -- Get tenant_id from parameter or current user
+  v_tenant_id := COALESCE(p_tenant_id, get_user_tenant_id());
+  IF v_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'No tenant found';
+  END IF;
+
+  -- Verify user is admin
+  IF NOT has_role(v_user_id, 'admin'::app_role) THEN
+    RAISE EXCEPTION 'Only admins can create invitations';
+  END IF;
+
+  -- Check for existing pending invitation
+  SELECT COUNT(*) INTO v_existing_count
+  FROM invitations
+  WHERE email = LOWER(p_email)
+    AND tenant_id = v_tenant_id
+    AND status = 'pending'
+    AND expires_at > NOW();
+
+  IF v_existing_count > 0 THEN
+    RAISE EXCEPTION 'An active invitation already exists for this email';
+  END IF;
+
+  -- Check if user already exists in tenant
+  SELECT COUNT(*) INTO v_existing_count
+  FROM profiles
+  WHERE LOWER(email) = LOWER(p_email)
+    AND tenant_id = v_tenant_id;
+
+  IF v_existing_count > 0 THEN
+    RAISE EXCEPTION 'A user with this email already exists in this organization';
+  END IF;
+
+  -- Generate unique token
+  v_token := encode(gen_random_bytes(32), 'hex');
+
+  -- Create invitation
+  INSERT INTO invitations (
+    tenant_id,
+    email,
+    role,
+    token,
+    invited_by,
+    status,
+    expires_at
+  ) VALUES (
+    v_tenant_id,
+    LOWER(p_email),
+    p_role,
+    v_token,
+    v_user_id,
+    'pending',
+    NOW() + INTERVAL '7 days'
+  )
+  RETURNING id INTO v_invitation_id;
+
+  RETURN v_invitation_id;
+END;
+$$;
+
+-- Function: get_invitation_by_token
+-- Returns invitation details by token (public - no auth required)
+CREATE OR REPLACE FUNCTION public.get_invitation_by_token(p_token TEXT)
+RETURNS TABLE (
+  id UUID,
+  tenant_id UUID,
+  tenant_name TEXT,
+  email TEXT,
+  role public.app_role,
+  status TEXT,
+  expires_at TIMESTAMPTZ,
+  invited_by_name TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = 'public'
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    i.id,
+    i.tenant_id,
+    t.name AS tenant_name,
+    i.email,
+    i.role,
+    i.status,
+    i.expires_at,
+    p.full_name AS invited_by_name
+  FROM invitations i
+  JOIN tenants t ON t.id = i.tenant_id
+  JOIN profiles p ON p.id = i.invited_by
+  WHERE i.token = p_token
+    AND i.status = 'pending'
+    AND i.expires_at > NOW();
+END;
+$$;
+
+-- Function: accept_invitation
+-- Marks an invitation as accepted
+CREATE OR REPLACE FUNCTION public.accept_invitation(
+  p_token TEXT,
+  p_user_id UUID
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = 'public'
+AS $$
+DECLARE
+  v_invitation_id UUID;
+BEGIN
+  -- Find and update the invitation
+  UPDATE invitations
+  SET
+    status = 'accepted',
+    accepted_at = NOW(),
+    accepted_by = p_user_id,
+    updated_at = NOW()
+  WHERE token = p_token
+    AND status = 'pending'
+    AND expires_at > NOW()
+  RETURNING id INTO v_invitation_id;
+
+  IF v_invitation_id IS NULL THEN
+    RAISE EXCEPTION 'Invalid or expired invitation';
+  END IF;
+
+  RETURN TRUE;
+END;
+$$;
+
+-- Function: cancel_invitation
+-- Cancels a pending invitation
+CREATE OR REPLACE FUNCTION public.cancel_invitation(p_invitation_id UUID)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = 'public'
+AS $$
+DECLARE
+  v_user_id UUID;
+  v_tenant_id UUID;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  v_tenant_id := get_user_tenant_id();
+
+  -- Verify user is admin
+  IF NOT has_role(v_user_id, 'admin'::app_role) THEN
+    RAISE EXCEPTION 'Only admins can cancel invitations';
+  END IF;
+
+  -- Cancel the invitation
+  UPDATE invitations
+  SET
+    status = 'cancelled',
+    updated_at = NOW()
+  WHERE id = p_invitation_id
+    AND tenant_id = v_tenant_id
+    AND status = 'pending';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Invitation not found or already processed';
+  END IF;
+
+  RETURN TRUE;
+END;
+$$;
+
+-- Function: cleanup_expired_invitations
+-- Marks expired invitations as expired (can be run by cron)
+CREATE OR REPLACE FUNCTION public.cleanup_expired_invitations()
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = 'public'
+AS $$
+DECLARE
+  v_count INTEGER;
+BEGIN
+  UPDATE invitations
+  SET
+    status = 'expired',
+    updated_at = NOW()
+  WHERE status = 'pending'
+    AND expires_at <= NOW();
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;
+
+-- Grant execute permissions
+GRANT EXECUTE ON FUNCTION public.create_invitation(TEXT, public.app_role, UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_invitation_by_token(TEXT) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.accept_invitation(TEXT, UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.cancel_invitation(UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.cleanup_expired_invitations() TO authenticated;
+
+-- Create updated_at trigger function if not exists
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$;
+
+-- Add updated_at trigger
+DROP TRIGGER IF EXISTS set_invitations_updated_at ON public.invitations;
+CREATE TRIGGER set_invitations_updated_at
+  BEFORE UPDATE ON public.invitations
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_updated_at();


### PR DESCRIPTION
- Add database migration for invitations table with tenant isolation
- Create RPC functions: create_invitation, get_invitation_by_token, accept_invitation, cancel_invitation, cleanup_expired_invitations
- Add Edge Function send-invitation to handle email delivery via Resend
- Update useInvitations hook to call Edge Function for invitation creation
- Add pending invitations management section to ConfigUsers page
- Support fallback to manual link sharing when email is not configured

The invitation flow now:
1. Admin creates invitation (stored in DB with unique token)
2. Email sent via Resend API (or link displayed for manual sharing)
3. Invitee clicks link, completes signup with tenant_id/role metadata
4. handle_new_user trigger creates profile in correct tenant