### PR TITLE
Update admin panels for quality reporting

### DIFF
--- a/src/hooks/useQualityMetrics.ts
+++ b/src/hooks/useQualityMetrics.ts
@@ -1,0 +1,380 @@
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/contexts/AuthContext";
+
+export interface QualityMetrics {
+  // Production totals
+  totalProduced: number;
+  totalGood: number;
+  totalScrap: number;
+  totalRework: number;
+
+  // Yield metrics
+  overallYield: number;
+  scrapRate: number;
+  reworkRate: number;
+
+  // Scrap by category
+  scrapByCategory: {
+    category: string;
+    count: number;
+    quantity: number;
+  }[];
+
+  // Scrap by reason (top reasons)
+  topScrapReasons: {
+    code: string;
+    description: string;
+    category: string;
+    count: number;
+    quantity: number;
+  }[];
+
+  // Issue metrics
+  issueMetrics: {
+    total: number;
+    pending: number;
+    approved: number;
+    rejected: number;
+    closed: number;
+    bySeverity: {
+      critical: number;
+      high: number;
+      medium: number;
+      low: number;
+    };
+  };
+}
+
+export interface ScrapReasonUsage {
+  id: string;
+  code: string;
+  description: string;
+  category: string;
+  active: boolean;
+  usageCount: number;
+  totalScrapQuantity: number;
+  lastUsed: string | null;
+}
+
+// Hook to fetch overall quality metrics for the tenant
+export function useQualityMetrics() {
+  const { profile } = useAuth();
+
+  return useQuery({
+    queryKey: ["quality-metrics", profile?.tenant_id],
+    queryFn: async (): Promise<QualityMetrics> => {
+      if (!profile?.tenant_id) {
+        throw new Error("No tenant ID");
+      }
+
+      // Fetch production quantities
+      const { data: quantities, error: quantitiesError } = await supabase
+        .from("operation_quantities")
+        .select(`
+          quantity_produced,
+          quantity_good,
+          quantity_scrap,
+          quantity_rework,
+          scrap_reason_id,
+          scrap_reason:scrap_reasons(code, description, category)
+        `)
+        .eq("tenant_id", profile.tenant_id);
+
+      if (quantitiesError) throw quantitiesError;
+
+      // Fetch issues
+      const { data: issues, error: issuesError } = await supabase
+        .from("issues")
+        .select("id, status, severity")
+        .eq("tenant_id", profile.tenant_id);
+
+      if (issuesError) throw issuesError;
+
+      // Calculate production totals
+      const totalProduced = quantities?.reduce((sum, q) => sum + (q.quantity_produced || 0), 0) || 0;
+      const totalGood = quantities?.reduce((sum, q) => sum + (q.quantity_good || 0), 0) || 0;
+      const totalScrap = quantities?.reduce((sum, q) => sum + (q.quantity_scrap || 0), 0) || 0;
+      const totalRework = quantities?.reduce((sum, q) => sum + (q.quantity_rework || 0), 0) || 0;
+
+      // Calculate yield metrics
+      const overallYield = totalProduced > 0 ? (totalGood / totalProduced) * 100 : 100;
+      const scrapRate = totalProduced > 0 ? (totalScrap / totalProduced) * 100 : 0;
+      const reworkRate = totalProduced > 0 ? (totalRework / totalProduced) * 100 : 0;
+
+      // Group scrap by category
+      const categoryMap = new Map<string, { count: number; quantity: number }>();
+      quantities?.forEach((q) => {
+        if (q.quantity_scrap > 0 && q.scrap_reason) {
+          const reason = q.scrap_reason as { category: string };
+          const existing = categoryMap.get(reason.category) || { count: 0, quantity: 0 };
+          categoryMap.set(reason.category, {
+            count: existing.count + 1,
+            quantity: existing.quantity + q.quantity_scrap,
+          });
+        }
+      });
+      const scrapByCategory = Array.from(categoryMap.entries()).map(([category, data]) => ({
+        category,
+        ...data,
+      })).sort((a, b) => b.quantity - a.quantity);
+
+      // Group scrap by reason
+      const reasonMap = new Map<string, { code: string; description: string; category: string; count: number; quantity: number }>();
+      quantities?.forEach((q) => {
+        if (q.quantity_scrap > 0 && q.scrap_reason_id && q.scrap_reason) {
+          const reason = q.scrap_reason as { code: string; description: string; category: string };
+          const existing = reasonMap.get(q.scrap_reason_id) || {
+            code: reason.code,
+            description: reason.description,
+            category: reason.category,
+            count: 0,
+            quantity: 0,
+          };
+          reasonMap.set(q.scrap_reason_id, {
+            ...existing,
+            count: existing.count + 1,
+            quantity: existing.quantity + q.quantity_scrap,
+          });
+        }
+      });
+      const topScrapReasons = Array.from(reasonMap.values())
+        .sort((a, b) => b.quantity - a.quantity)
+        .slice(0, 10);
+
+      // Calculate issue metrics
+      const issueMetrics = {
+        total: issues?.length || 0,
+        pending: issues?.filter((i) => i.status === "pending").length || 0,
+        approved: issues?.filter((i) => i.status === "approved").length || 0,
+        rejected: issues?.filter((i) => i.status === "rejected").length || 0,
+        closed: issues?.filter((i) => i.status === "closed").length || 0,
+        bySeverity: {
+          critical: issues?.filter((i) => i.severity === "critical").length || 0,
+          high: issues?.filter((i) => i.severity === "high").length || 0,
+          medium: issues?.filter((i) => i.severity === "medium").length || 0,
+          low: issues?.filter((i) => i.severity === "low").length || 0,
+        },
+      };
+
+      return {
+        totalProduced,
+        totalGood,
+        totalScrap,
+        totalRework,
+        overallYield,
+        scrapRate,
+        reworkRate,
+        scrapByCategory,
+        topScrapReasons,
+        issueMetrics,
+      };
+    },
+    enabled: !!profile?.tenant_id,
+    staleTime: 30000, // 30 seconds
+  });
+}
+
+// Hook to fetch scrap reason usage statistics
+export function useScrapReasonUsage() {
+  const { profile } = useAuth();
+
+  return useQuery({
+    queryKey: ["scrap-reason-usage", profile?.tenant_id],
+    queryFn: async (): Promise<ScrapReasonUsage[]> => {
+      if (!profile?.tenant_id) {
+        throw new Error("No tenant ID");
+      }
+
+      // Fetch all scrap reasons
+      const { data: reasons, error: reasonsError } = await supabase
+        .from("scrap_reasons")
+        .select("*")
+        .eq("tenant_id", profile.tenant_id)
+        .order("code");
+
+      if (reasonsError) throw reasonsError;
+
+      // Fetch usage counts
+      const { data: quantities, error: quantitiesError } = await supabase
+        .from("operation_quantities")
+        .select("scrap_reason_id, quantity_scrap, recorded_at")
+        .eq("tenant_id", profile.tenant_id)
+        .not("scrap_reason_id", "is", null);
+
+      if (quantitiesError) throw quantitiesError;
+
+      // Build usage map
+      const usageMap = new Map<string, { count: number; totalQuantity: number; lastUsed: string | null }>();
+      quantities?.forEach((q) => {
+        if (q.scrap_reason_id) {
+          const existing = usageMap.get(q.scrap_reason_id) || { count: 0, totalQuantity: 0, lastUsed: null };
+          usageMap.set(q.scrap_reason_id, {
+            count: existing.count + 1,
+            totalQuantity: existing.totalQuantity + (q.quantity_scrap || 0),
+            lastUsed: !existing.lastUsed || q.recorded_at > existing.lastUsed ? q.recorded_at : existing.lastUsed,
+          });
+        }
+      });
+
+      // Merge with reasons
+      return (reasons || []).map((r) => ({
+        id: r.id,
+        code: r.code,
+        description: r.description,
+        category: r.category,
+        active: r.active,
+        usageCount: usageMap.get(r.id)?.count || 0,
+        totalScrapQuantity: usageMap.get(r.id)?.totalQuantity || 0,
+        lastUsed: usageMap.get(r.id)?.lastUsed || null,
+      }));
+    },
+    enabled: !!profile?.tenant_id,
+    staleTime: 30000,
+  });
+}
+
+// Hook to fetch quality metrics for a specific job
+export function useJobQualityMetrics(jobId: string | undefined) {
+  const { profile } = useAuth();
+
+  return useQuery({
+    queryKey: ["job-quality-metrics", jobId],
+    queryFn: async () => {
+      if (!jobId || !profile?.tenant_id) {
+        return null;
+      }
+
+      // Get all operations for this job's parts
+      const { data: parts, error: partsError } = await supabase
+        .from("parts")
+        .select("id")
+        .eq("job_id", jobId);
+
+      if (partsError) throw partsError;
+      if (!parts || parts.length === 0) return null;
+
+      const partIds = parts.map((p) => p.id);
+
+      // Get all operation IDs for these parts
+      const { data: operations, error: opsError } = await supabase
+        .from("operations")
+        .select("id")
+        .in("part_id", partIds);
+
+      if (opsError) throw opsError;
+      if (!operations || operations.length === 0) return null;
+
+      const operationIds = operations.map((o) => o.id);
+
+      // Get production quantities for these operations
+      const { data: quantities, error: quantitiesError } = await supabase
+        .from("operation_quantities")
+        .select(`
+          quantity_produced,
+          quantity_good,
+          quantity_scrap,
+          quantity_rework
+        `)
+        .in("operation_id", operationIds);
+
+      if (quantitiesError) throw quantitiesError;
+
+      // Get issues for these operations
+      const { data: issues, error: issuesError } = await supabase
+        .from("issues")
+        .select("id, status, severity")
+        .in("operation_id", operationIds);
+
+      if (issuesError) throw issuesError;
+
+      // Calculate metrics
+      const totalProduced = quantities?.reduce((sum, q) => sum + (q.quantity_produced || 0), 0) || 0;
+      const totalGood = quantities?.reduce((sum, q) => sum + (q.quantity_good || 0), 0) || 0;
+      const totalScrap = quantities?.reduce((sum, q) => sum + (q.quantity_scrap || 0), 0) || 0;
+      const totalRework = quantities?.reduce((sum, q) => sum + (q.quantity_rework || 0), 0) || 0;
+      const yieldRate = totalProduced > 0 ? (totalGood / totalProduced) * 100 : 100;
+
+      return {
+        totalProduced,
+        totalGood,
+        totalScrap,
+        totalRework,
+        yieldRate,
+        issueCount: issues?.length || 0,
+        pendingIssues: issues?.filter((i) => i.status === "pending").length || 0,
+        criticalIssues: issues?.filter((i) => i.severity === "critical").length || 0,
+      };
+    },
+    enabled: !!jobId && !!profile?.tenant_id,
+    staleTime: 30000,
+  });
+}
+
+// Hook to fetch quality metrics for a specific part
+export function usePartQualityMetrics(partId: string | undefined) {
+  const { profile } = useAuth();
+
+  return useQuery({
+    queryKey: ["part-quality-metrics", partId],
+    queryFn: async () => {
+      if (!partId || !profile?.tenant_id) {
+        return null;
+      }
+
+      // Get all operation IDs for this part
+      const { data: operations, error: opsError } = await supabase
+        .from("operations")
+        .select("id")
+        .eq("part_id", partId);
+
+      if (opsError) throw opsError;
+      if (!operations || operations.length === 0) return null;
+
+      const operationIds = operations.map((o) => o.id);
+
+      // Get production quantities for these operations
+      const { data: quantities, error: quantitiesError } = await supabase
+        .from("operation_quantities")
+        .select(`
+          quantity_produced,
+          quantity_good,
+          quantity_scrap,
+          quantity_rework,
+          scrap_reason:scrap_reasons(code, description)
+        `)
+        .in("operation_id", operationIds);
+
+      if (quantitiesError) throw quantitiesError;
+
+      // Get issues for these operations
+      const { data: issues, error: issuesError } = await supabase
+        .from("issues")
+        .select("id, status, severity")
+        .in("operation_id", operationIds);
+
+      if (issuesError) throw issuesError;
+
+      // Calculate metrics
+      const totalProduced = quantities?.reduce((sum, q) => sum + (q.quantity_produced || 0), 0) || 0;
+      const totalGood = quantities?.reduce((sum, q) => sum + (q.quantity_good || 0), 0) || 0;
+      const totalScrap = quantities?.reduce((sum, q) => sum + (q.quantity_scrap || 0), 0) || 0;
+      const totalRework = quantities?.reduce((sum, q) => sum + (q.quantity_rework || 0), 0) || 0;
+      const yieldRate = totalProduced > 0 ? (totalGood / totalProduced) * 100 : 100;
+
+      return {
+        totalProduced,
+        totalGood,
+        totalScrap,
+        totalRework,
+        yieldRate,
+        issueCount: issues?.length || 0,
+        pendingIssues: issues?.filter((i) => i.status === "pending").length || 0,
+        criticalIssues: issues?.filter((i) => i.severity === "critical").length || 0,
+        hasQualityData: (quantities?.length || 0) > 0,
+      };
+    },
+    enabled: !!partId && !!profile?.tenant_id,
+    staleTime: 30000,
+  });
+}

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -1492,5 +1492,34 @@
   "jobCreate": {
     "title": "Create New Job",
     "subtitle": "Build your job step-by-step: define details, add parts, configure operations, and review"
+  },
+  "quality": {
+    "dashboardTitle": "Quality Overview",
+    "partsQuality": "Parts Quality Overview",
+    "yieldRate": "Yield Rate",
+    "totalProduced": "Produced",
+    "goodParts": "Good",
+    "scrap": "Scrap",
+    "rework": "Rework",
+    "openIssues": "Open Issues",
+    "critical": "Critical",
+    "topScrapReasons": "Top Scrap Reasons",
+    "scrapByCategory": "Scrap by Category",
+    "totalIssues": "Total Issues",
+    "criticalPending": "Critical Pending",
+    "highPending": "High Pending",
+    "resolved": "Resolved",
+    "resolutionRate": "Resolution Rate",
+    "bySeverity": "Issues by Severity",
+    "byStatus": "Issues by Status",
+    "totalReasons": "Total Reasons",
+    "activeReasons": "Active",
+    "usedReasons": "Used",
+    "unusedReasons": "Unused",
+    "timesUsed": "Times Used",
+    "totalScrapped": "Total Scrapped",
+    "noScrapData": "No scrap data recorded yet",
+    "usage": "Usage",
+    "scrapped": "Scrapped"
   }
 }

--- a/src/pages/admin/Parts.tsx
+++ b/src/pages/admin/Parts.tsx
@@ -4,8 +4,21 @@ import { ColumnDef } from "@tanstack/react-table";
 import { supabase } from "@/integrations/supabase/client";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import PartDetailModal from "@/components/admin/PartDetailModal";
-import { Package, ChevronRight, Box, FileText, Eye } from "lucide-react";
+import {
+  Package,
+  ChevronRight,
+  Box,
+  FileText,
+  Eye,
+  TrendingUp,
+  CheckCircle2,
+  Trash2,
+  AlertTriangle,
+  Activity,
+  RefreshCw
+} from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { STEPViewer } from "@/components/STEPViewer";
 import { PDFViewer } from "@/components/PDFViewer";
@@ -17,6 +30,8 @@ import {
 } from "@/components/ui/dialog";
 import { useToast } from "@/hooks/use-toast";
 import { DataTable, DataTableColumnHeader, DataTableFilterableColumn } from "@/components/ui/data-table";
+import { useQualityMetrics } from "@/hooks/useQualityMetrics";
+import { cn } from "@/lib/utils";
 
 interface PartData {
   id: string;
@@ -72,6 +87,9 @@ export default function Parts() {
       return data;
     },
   });
+
+  // Fetch quality metrics
+  const { data: qualityMetrics } = useQualityMetrics();
 
   const {
     data: parts,
@@ -407,6 +425,115 @@ export default function Parts() {
         </div>
 
         <hr className="title-divider" />
+
+        {/* Quality Metrics Dashboard */}
+        {qualityMetrics && (qualityMetrics.totalProduced > 0 || qualityMetrics.issueMetrics.total > 0) && (
+          <Card className="glass-card">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium flex items-center gap-2">
+                <Activity className="h-4 w-4 text-[hsl(var(--brand-primary))]" />
+                {t("quality.partsQuality", "Parts Quality Overview")}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="pt-0">
+              <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+                {/* Yield Rate */}
+                <div className="space-y-1">
+                  <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <TrendingUp className="h-3.5 w-3.5" />
+                    {t("quality.yieldRate", "Yield Rate")}
+                  </div>
+                  <div className={cn(
+                    "text-lg font-bold",
+                    qualityMetrics.overallYield >= 95 ? "text-[hsl(var(--color-success))]" :
+                    qualityMetrics.overallYield >= 85 ? "text-[hsl(var(--color-warning))]" :
+                    "text-[hsl(var(--color-error))]"
+                  )}>
+                    {qualityMetrics.overallYield.toFixed(1)}%
+                  </div>
+                </div>
+
+                {/* Good Parts */}
+                <div className="space-y-1">
+                  <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <CheckCircle2 className="h-3.5 w-3.5 text-[hsl(var(--color-success))]" />
+                    {t("quality.goodParts", "Good")}
+                  </div>
+                  <div className="text-lg font-bold text-[hsl(var(--color-success))]">
+                    {qualityMetrics.totalGood.toLocaleString()}
+                  </div>
+                </div>
+
+                {/* Scrap */}
+                <div className="space-y-1">
+                  <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <Trash2 className="h-3.5 w-3.5 text-[hsl(var(--color-error))]" />
+                    {t("quality.scrap", "Scrap")}
+                  </div>
+                  <div className={cn(
+                    "text-lg font-bold",
+                    qualityMetrics.totalScrap > 0 ? "text-[hsl(var(--color-error))]" : ""
+                  )}>
+                    {qualityMetrics.totalScrap.toLocaleString()}
+                    {qualityMetrics.scrapRate > 0 && (
+                      <span className="text-xs font-normal ml-1">({qualityMetrics.scrapRate.toFixed(1)}%)</span>
+                    )}
+                  </div>
+                </div>
+
+                {/* Rework */}
+                <div className="space-y-1">
+                  <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <RefreshCw className="h-3.5 w-3.5 text-[hsl(var(--color-warning))]" />
+                    {t("quality.rework", "Rework")}
+                  </div>
+                  <div className={cn(
+                    "text-lg font-bold",
+                    qualityMetrics.totalRework > 0 ? "text-[hsl(var(--color-warning))]" : ""
+                  )}>
+                    {qualityMetrics.totalRework.toLocaleString()}
+                    {qualityMetrics.reworkRate > 0 && (
+                      <span className="text-xs font-normal ml-1">({qualityMetrics.reworkRate.toFixed(1)}%)</span>
+                    )}
+                  </div>
+                </div>
+
+                {/* Issues */}
+                <div className="space-y-1">
+                  <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <AlertTriangle className="h-3.5 w-3.5 text-[hsl(var(--color-warning))]" />
+                    {t("quality.openIssues", "Open Issues")}
+                  </div>
+                  <div className={cn(
+                    "text-lg font-bold",
+                    qualityMetrics.issueMetrics.pending > 0 ? "text-[hsl(var(--color-warning))]" : ""
+                  )}>
+                    {qualityMetrics.issueMetrics.pending}
+                    <span className="text-xs font-normal text-muted-foreground ml-1">
+                      / {qualityMetrics.issueMetrics.total}
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              {/* Scrap by Category */}
+              {qualityMetrics.scrapByCategory.length > 0 && (
+                <div className="mt-4 pt-4 border-t border-white/10">
+                  <div className="text-xs text-muted-foreground mb-2">
+                    {t("quality.scrapByCategory", "Scrap by Category")}
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {qualityMetrics.scrapByCategory.map((cat) => (
+                      <Badge key={cat.category} variant="outline" className="text-xs capitalize">
+                        {cat.category}: {cat.quantity}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )}
 
         <div className="glass-card p-6">
           <DataTable


### PR DESCRIPTION
- Create useQualityMetrics hook for fetching scrap, yield, and issue data
- Add quality overview dashboard to Jobs page with yield rate, scrap counts, issues
- Add quality metrics section to Parts page with production stats
- Enhance IssueQueue with comprehensive analytics (severity/status breakdown, resolution rate)
- Update ConfigScrapReasons with usage statistics (times used, total scrapped, top reasons)
- Add quality-related translations