### PR TITLE
fix: Simplify metrics widget to show velocity, inception, and LOC

### DIFF
--- a/.github/workflows/update-stats.yml
+++ b/.github/workflows/update-stats.yml
@@ -19,28 +19,36 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           user: SheetMetalConnect
           repo: eryxon-flow
-          
+
           # Output configuration
           filename: metrics.svg
           output_action: commit
           committer_message: "chore: update repository metrics [skip ci]"
-          
-          # Base metrics
-          base: header, activity, community, repositories, metadata
-          
-          # Plugins
+
+          # Minimal base - just header with repo info
+          base: header, repositories
+          base_indepth: yes
+          repositories_forks: no
+
+          # Isocalendar - visual commit activity
+          plugin_isocalendar: yes
+          plugin_isocalendar_duration: full-year
+
+          # Lines of code
           plugin_lines: yes
           plugin_lines_sections: base
           plugin_lines_repositories_limit: 1
-          
-          plugin_traffic: yes
-          
-          plugin_followup: yes
-          plugin_followup_sections: repositories
-          
-          plugin_introduction: yes
-          plugin_introduction_title: yes
-          
+          plugin_lines_history_limit: 1
+
+          # Commit habits - velocity stats
+          plugin_habits: yes
+          plugin_habits_from: 200
+          plugin_habits_days: 30
+          plugin_habits_charts: yes
+          plugin_habits_charts_type: classic
+          plugin_habits_trim: yes
+
           # Display options
           config_timezone: Europe/Vienna
-          config_display: large
+          config_display: regular
+          config_padding: 5%


### PR DESCRIPTION
- Remove traffic, followup, and introduction plugins (not needed)
- Add isocalendar for visual commit activity over full year
- Add habits plugin for commit velocity stats with charts
- Keep lines of code plugin for LOC count
- Use base_indepth for better repo stats including creation date
- Cleaner, more focused widget for internal project metrics