### PR TITLE
Fix React hooks order and modal overflow issues

### DIFF
--- a/src/components/admin/JobDetailModal.tsx
+++ b/src/components/admin/JobDetailModal.tsx
@@ -122,7 +122,7 @@ export default function JobDetailModal({ jobId, onClose, onUpdate }: JobDetailMo
 
   return (
     <Dialog open onOpenChange={onClose}>
-      <DialogContent className="glass-card max-w-4xl max-h-[90vh] overflow-y-auto">
+      <DialogContent className="glass-card max-w-3xl max-h-[85vh] overflow-y-auto">
         <DialogHeader>
           <div className="flex justify-between items-start gap-4">
             <DialogTitle className="text-xl flex items-center gap-2">

--- a/src/components/admin/PartDetailModal.tsx
+++ b/src/components/admin/PartDetailModal.tsx
@@ -493,7 +493,7 @@ export default function PartDetailModal({ partId, onClose, onUpdate }: PartDetai
 
   return (
     <Dialog open onOpenChange={onClose}>
-      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+      <DialogContent className="glass-card max-w-3xl max-h-[85vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{t("parts.partDetails")}: {part?.part_number}</DialogTitle>
         </DialogHeader>

--- a/src/pages/admin/Assignments.tsx
+++ b/src/pages/admin/Assignments.tsx
@@ -412,6 +412,15 @@ export default function Assignments() {
     },
   ], [t]);
 
+  // Calculate stats - must be before any conditional returns
+  const assignmentStats = useMemo(() => {
+    return {
+      totalAssignments: assignments.length,
+      availableParts: parts.length,
+      activeOperators: operators.length,
+    };
+  }, [assignments, parts, operators]);
+
   if (loading) {
     return (
       <div className="flex items-center justify-center h-96">
@@ -422,16 +431,6 @@ export default function Assignments() {
 
   const selectedPartData = parts.find((p) => p.id === selectedPart);
   const selectedOperatorData = operators.find((o) => o.id === selectedOperator);
-
-  // Calculate stats
-  const assignmentStats = useMemo(() => {
-    return {
-      totalAssignments: assignments.length,
-      availableParts: parts.length,
-      activeOperators: operators.length,
-      assignedParts: assignments.length,
-    };
-  }, [assignments, parts, operators]);
 
   return (
     <div className="p-4 space-y-4">

--- a/src/pages/admin/IssueQueue.tsx
+++ b/src/pages/admin/IssueQueue.tsx
@@ -437,7 +437,7 @@ export default function IssueQueue() {
         open={!!selectedIssue}
         onOpenChange={() => setSelectedIssue(null)}
       >
-        <DialogContent className="glass-card max-w-2xl">
+        <DialogContent className="glass-card max-w-2xl max-h-[85vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>{t("issues.reviewIssue")}</DialogTitle>
           </DialogHeader>


### PR DESCRIPTION
- Fix hooks order in Assignments page to prevent "rendered more hooks" error
- Add max-h-[85vh] overflow-y-auto to JobDetailModal, PartDetailModal, and IssueQueue modals to prevent content overflow