### PR TITLE
Fix operator view updates and onboarding modal persistence

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -184,7 +184,7 @@ function AppRoutes() {
         element={
           <ProtectedRoute>
             <Layout>
-              <OperatorTerminal />
+              <OperatorView />
             </Layout>
           </ProtectedRoute>
         }

--- a/src/components/operator/OperatorLayout.tsx
+++ b/src/components/operator/OperatorLayout.tsx
@@ -65,26 +65,34 @@ export const OperatorLayout = ({ children }: OperatorLayoutProps) => {
         {/* Top Header - Glass Morphism - Compact */}
         <header className="sticky top-0 z-50 w-full glass-card border-b border-border-subtle">
           <div className="flex items-center justify-between h-12 px-3 sm:px-4">
-            {/* Logo/Brand */}
-            <div className="flex items-center gap-2">
-              <Factory className="h-6 w-6 text-primary" strokeWidth={1.5} />
-              <span className="hidden sm:block text-sm font-bold hero-title">
-                {t('app.name')}
+            {/* Left: Tenant/Company Name */}
+            <div className="flex items-center gap-2 min-w-0">
+              <Building2 className="h-5 w-5 text-primary shrink-0" />
+              <span className="text-sm font-bold truncate max-w-[120px] sm:max-w-[200px]">
+                {tenant?.company_name || tenant?.name || t('app.name')}
               </span>
+            </div>
+
+            {/* Center: Active Operator - Always visible and prominent */}
+            <div className="flex items-center gap-2">
+              {activeOperator ? (
+                <div className="flex items-center gap-2 px-2 sm:px-3 py-1 rounded-full bg-green-500/10 border border-green-500/30">
+                  <div className="w-2 h-2 rounded-full bg-green-500 animate-pulse shrink-0" />
+                  <UserCheck className="h-3.5 w-3.5 text-green-500 shrink-0 hidden sm:block" />
+                  <span className="text-xs font-bold text-green-500 truncate max-w-[80px] sm:max-w-[120px]">
+                    {activeOperator.full_name}
+                  </span>
+                  <span className="text-[10px] text-green-500/70 font-mono hidden sm:block">
+                    {activeOperator.employee_id}
+                  </span>
+                </div>
+              ) : (
+                <OperatorSwitcher variant="button" className="h-8" />
+              )}
             </div>
 
             {/* Right Side Actions */}
             <div className="flex items-center gap-1.5">
-              {/* Active Operator Badge - Desktop */}
-              <div className="hidden sm:block">
-                <ActiveOperatorBadge />
-              </div>
-
-              {/* Operator Switcher - Mobile */}
-              <div className="sm:hidden">
-                <OperatorSwitcher variant="compact" />
-              </div>
-
               {/* Search Button */}
               <SearchTriggerButton onClick={() => setSearchOpen(true)} compact />
 

--- a/src/contexts/OperatorContext.tsx
+++ b/src/contexts/OperatorContext.tsx
@@ -40,14 +40,21 @@ export function OperatorProvider({ children }: { children: React.ReactNode }) {
 
   // Load active operator from localStorage on mount
   useEffect(() => {
+    // Wait for tenant to be loaded before validating stored operator
+    // If tenant is not yet loaded (undefined), don't do anything yet
+    if (tenant?.id === undefined) {
+      return;
+    }
+
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored) {
       try {
         const parsed = JSON.parse(stored);
         // Validate that the stored operator belongs to current tenant
-        if (parsed.tenant_id === tenant?.id) {
+        if (parsed.tenant_id === tenant.id) {
           setActiveOperator(parsed);
         } else {
+          // Only clear if we have a valid tenant and it doesn't match
           localStorage.removeItem(STORAGE_KEY);
         }
       } catch {

--- a/src/pages/operator/OperatorView.tsx
+++ b/src/pages/operator/OperatorView.tsx
@@ -145,7 +145,7 @@ export default function OperatorView() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { profile, tenant } = useAuth();
-  const { activeOperator, verifyAndSwitchOperator, clearActiveOperator } = useOperator();
+  const { activeOperator, isLoading: operatorLoading, verifyAndSwitchOperator, clearActiveOperator } = useOperator();
   const operatorId = activeOperator?.id || profile?.id;
 
   // Responsive breakpoints
@@ -153,8 +153,8 @@ export default function OperatorView() {
   const isTablet = useMediaQuery("(min-width: 640px) and (max-width: 1023px)");
   const isDesktop = useMediaQuery("(min-width: 1024px)");
 
-  // Operator login state
-  const [showOperatorLogin, setShowOperatorLogin] = useState(!activeOperator);
+  // Operator login state - initialize as false, will be set after operatorLoading completes
+  const [showOperatorLogin, setShowOperatorLogin] = useState(false);
   const [employeeId, setEmployeeId] = useState("");
   const [pin, setPin] = useState("");
   const [loginLoading, setLoginLoading] = useState(false);
@@ -192,10 +192,12 @@ export default function OperatorView() {
   const [isDragging, setIsDragging] = useState<boolean>(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Update operator login visibility when activeOperator changes
+  // Update operator login visibility when activeOperator changes (only after loading completes)
   useEffect(() => {
-    setShowOperatorLogin(!activeOperator);
-  }, [activeOperator]);
+    if (!operatorLoading) {
+      setShowOperatorLogin(!activeOperator);
+    }
+  }, [activeOperator, operatorLoading]);
 
   // Load jobs
   useEffect(() => {
@@ -853,7 +855,8 @@ export default function OperatorView() {
     );
   }
 
-  if (loading && !jobs.length) {
+  // Show loading spinner while operator context is loading or jobs are loading
+  if (operatorLoading || (loading && !jobs.length)) {
     return (
       <>
         <AnimatedBackground />

--- a/src/pages/operator/WorkQueue.tsx
+++ b/src/pages/operator/WorkQueue.tsx
@@ -4,7 +4,6 @@ import { useOperator } from "@/contexts/OperatorContext";
 import { supabase } from "@/integrations/supabase/client";
 import { fetchOperationsWithDetails, OperationWithDetails } from "@/lib/database";
 import OperationCard from "@/components/operator/OperationCard";
-import CurrentlyTimingWidget from "@/components/operator/CurrentlyTimingWidget";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Input } from "@/components/ui/input";
 import { Card } from "@/components/ui/card";
@@ -272,9 +271,6 @@ export default function WorkQueue() {
   return (
     <>
       <div className="space-y-4">
-        {/* Currently Timing Widget */}
-        <CurrentlyTimingWidget />
-
         {/* Stats Card */}
         <Card className="glass-card p-6">
           <div className="grid grid-cols-1 md:grid-cols-4 gap-6">


### PR DESCRIPTION
- Fix route: /operator/view now correctly renders OperatorView (not OperatorTerminal)
- Remove duplicate CurrentlyTimingWidget from WorkQueue (layout already provides it)
- Fix OperatorContext race condition: Wait for tenant to load before validating stored operator
- Update OperatorView to wait for operator context loading state before showing login
- Make CurrentlyTimingWidget collapsible with smooth animation
- Update OperatorLayout header: Show tenant/company name prominently, always show active operator info

These changes fix the duplicate content issue and improve the operator experience.