### PR TITLE
Add full i18n localization with language switcher

### DIFF
--- a/website/src/components/LanguageSwitcher.tsx
+++ b/website/src/components/LanguageSwitcher.tsx
@@ -1,0 +1,92 @@
+import { useState, useEffect } from 'react';
+
+const languages = [
+  { code: 'en', label: 'EN', name: 'English' },
+  { code: 'nl', label: 'NL', name: 'Nederlands' },
+  { code: 'de', label: 'DE', name: 'Deutsch' },
+] as const;
+
+export default function LanguageSwitcher() {
+  const [currentLang, setCurrentLang] = useState('en');
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    // Get initial language from localStorage or browser
+    const stored = localStorage.getItem('eryxon-lang');
+    if (stored && languages.some(l => l.code === stored)) {
+      setCurrentLang(stored);
+    } else {
+      // Try to detect from browser
+      const browserLang = navigator.language.slice(0, 2);
+      if (languages.some(l => l.code === browserLang)) {
+        setCurrentLang(browserLang);
+        localStorage.setItem('eryxon-lang', browserLang);
+      }
+    }
+  }, []);
+
+  const handleLanguageChange = (langCode: string) => {
+    setCurrentLang(langCode);
+    localStorage.setItem('eryxon-lang', langCode);
+    setIsOpen(false);
+
+    // Dispatch event for other components to react
+    window.dispatchEvent(new CustomEvent('languageChanged', { detail: langCode }));
+
+    // Reload to apply translations
+    window.location.reload();
+  };
+
+  const currentLanguage = languages.find(l => l.code === currentLang) || languages[0];
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium text-zinc-400 hover:text-white hover:bg-white/5 transition-colors"
+        aria-label="Select language"
+      >
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" />
+        </svg>
+        <span>{currentLanguage.label}</span>
+        <svg className={`w-3 h-3 transition-transform ${isOpen ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <>
+          {/* Backdrop */}
+          <div
+            className="fixed inset-0 z-40"
+            onClick={() => setIsOpen(false)}
+          />
+
+          {/* Dropdown */}
+          <div className="absolute right-0 top-full mt-2 py-1 w-36 bg-zinc-900 border border-white/10 rounded-lg shadow-xl z-50">
+            {languages.map((lang) => (
+              <button
+                key={lang.code}
+                onClick={() => handleLanguageChange(lang.code)}
+                className={`w-full flex items-center gap-2 px-3 py-2 text-sm text-left transition-colors ${
+                  currentLang === lang.code
+                    ? 'text-white bg-white/10'
+                    : 'text-zinc-400 hover:text-white hover:bg-white/5'
+                }`}
+              >
+                <span className="font-medium w-6">{lang.label}</span>
+                <span>{lang.name}</span>
+                {currentLang === lang.code && (
+                  <svg className="w-4 h-4 ml-auto text-blue-500" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                  </svg>
+                )}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/website/src/i18n/client.ts
+++ b/website/src/i18n/client.ts
@@ -1,0 +1,94 @@
+// Client-side i18n runtime for dynamic translations
+import { translations, type Locale, defaultLocale, supportedLocales } from './translations';
+
+// Get current language from localStorage or default
+export function getCurrentLocale(): Locale {
+  if (typeof window === 'undefined') return defaultLocale;
+
+  const stored = localStorage.getItem('eryxon-lang');
+  if (stored && supportedLocales.includes(stored as Locale)) {
+    return stored as Locale;
+  }
+
+  // Try browser language
+  const browserLang = navigator.language.slice(0, 2) as Locale;
+  if (supportedLocales.includes(browserLang)) {
+    return browserLang;
+  }
+
+  return defaultLocale;
+}
+
+// Get nested value from object by dot-notation path
+function getNestedValue(obj: any, path: string): string | undefined {
+  return path.split('.').reduce((current, key) => current?.[key], obj);
+}
+
+// Translation function
+export function t(key: string, locale?: Locale): string {
+  const lang = locale || getCurrentLocale();
+  const value = getNestedValue(translations[lang], key);
+
+  if (value === undefined) {
+    // Fallback to English
+    const fallback = getNestedValue(translations[defaultLocale], key);
+    return fallback || key;
+  }
+
+  return value;
+}
+
+// Apply translations to elements with data-i18n attribute
+export function applyTranslations(locale?: Locale) {
+  const lang = locale || getCurrentLocale();
+
+  // Update elements with data-i18n attribute
+  document.querySelectorAll('[data-i18n]').forEach((el) => {
+    const key = el.getAttribute('data-i18n');
+    if (key) {
+      const translation = t(key, lang);
+      if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') {
+        (el as HTMLInputElement).placeholder = translation;
+      } else {
+        el.textContent = translation;
+      }
+    }
+  });
+
+  // Update elements with data-i18n-title attribute (for tooltips)
+  document.querySelectorAll('[data-i18n-title]').forEach((el) => {
+    const key = el.getAttribute('data-i18n-title');
+    if (key) {
+      el.setAttribute('title', t(key, lang));
+    }
+  });
+
+  // Update elements with data-i18n-aria attribute
+  document.querySelectorAll('[data-i18n-aria]').forEach((el) => {
+    const key = el.getAttribute('data-i18n-aria');
+    if (key) {
+      el.setAttribute('aria-label', t(key, lang));
+    }
+  });
+
+  // Update document language
+  document.documentElement.lang = lang;
+}
+
+// Initialize i18n on page load
+export function initI18n() {
+  if (typeof window === 'undefined') return;
+
+  // Apply translations on load
+  applyTranslations();
+
+  // Listen for language changes
+  window.addEventListener('languageChanged', (e: Event) => {
+    const customEvent = e as CustomEvent;
+    applyTranslations(customEvent.detail as Locale);
+  });
+}
+
+// Export translations for direct access
+export { translations, supportedLocales, defaultLocale };
+export type { Locale };

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -574,5 +574,186 @@ const fullTitle = title.includes("Eryxon Flow") ? title : `${title} | Eryxon Flo
       document.addEventListener('DOMContentLoaded', observeElements);
     </script>
 
+    <!-- i18n Initialization -->
+    <script>
+      import { initI18n, applyTranslations, getCurrentLocale, translations } from '@i18n/client';
+
+      // Apply translations on page load
+      document.addEventListener('DOMContentLoaded', () => {
+        const locale = getCurrentLocale();
+        const t = translations[locale];
+
+        // Apply translations to data-i18n elements
+        applyTranslations(locale);
+
+        // Update specific sections that need more complex translations
+        updateHeroSection(t);
+        updateFeaturesSection(t);
+        updateComparisonSection(t);
+        updateHowItWorksSection(t);
+        updateGetStartedSection(t);
+        updateFooterSection(t);
+      });
+
+      function updateHeroSection(t: any) {
+        // Hero badges
+        const badges = document.querySelectorAll('.floating-badges span');
+        if (badges.length >= 3) {
+          badges[0].innerHTML = `<span class="w-1.5 h-1.5 bg-emerald-500 rounded-full"></span>${t.hero.badge.openSource}`;
+          badges[1].textContent = t.hero.badge.license;
+          badges[2].textContent = t.hero.badge.selfHostable;
+        }
+
+        // Hero title and text
+        const heroTitle = document.querySelector('.gradient-text');
+        if (heroTitle) heroTitle.textContent = t.hero.title;
+
+        const tagline = document.querySelector('section p.text-xl.sm\\:text-2xl');
+        if (tagline) tagline.textContent = t.hero.tagline;
+
+        // Hero description
+        const heroDesc = document.querySelector('section p.text-lg.sm\\:text-xl.text-muted-foreground');
+        if (heroDesc) heroDesc.textContent = t.hero.description;
+
+        // CTA buttons
+        const ctaButtons = document.querySelectorAll('section .flex.flex-col.sm\\:flex-row a');
+        if (ctaButtons.length >= 2) {
+          const getStartedBtn = ctaButtons[0];
+          const githubBtn = ctaButtons[1];
+          // Keep SVG, update text
+          const getStartedSvg = getStartedBtn.querySelector('svg');
+          if (getStartedSvg) {
+            getStartedBtn.innerHTML = '';
+            getStartedBtn.appendChild(getStartedSvg);
+            getStartedBtn.appendChild(document.createTextNode(t.hero.cta.getStarted));
+          }
+          const githubSvg = githubBtn.querySelector('svg');
+          if (githubSvg) {
+            githubBtn.innerHTML = '';
+            githubBtn.appendChild(githubSvg);
+            githubBtn.appendChild(document.createTextNode(t.hero.cta.viewGithub));
+          }
+        }
+
+        // Stats labels
+        const statLabels = document.querySelectorAll('.grid.grid-cols-2.md\\:grid-cols-4 .text-sm.text-zinc-500');
+        if (statLabels.length >= 4) {
+          statLabels[0].textContent = t.hero.stats.uiComponents;
+          statLabels[1].textContent = t.hero.stats.edgeFunctions;
+          statLabels[2].textContent = t.hero.stats.languages;
+          statLabels[3].textContent = t.hero.stats.apiReady;
+        }
+      }
+
+      function updateFeaturesSection(t: any) {
+        // Features section title
+        const featuresSection = document.getElementById('features');
+        if (!featuresSection) return;
+
+        const sectionTitle = featuresSection.querySelector('h2.gradient-text');
+        if (sectionTitle) sectionTitle.textContent = t.features.title;
+
+        const sectionDesc = featuresSection.querySelector('p.text-xl.text-muted-foreground');
+        if (sectionDesc) sectionDesc.textContent = t.features.description;
+
+        // CTA at bottom
+        const ctaText = featuresSection.querySelector('.inline-flex.items-center span');
+        if (ctaText) ctaText.textContent = t.features.callToAction;
+      }
+
+      function updateComparisonSection(t: any) {
+        const compareSection = document.getElementById('compare');
+        if (!compareSection) return;
+
+        // Badge
+        const badge = compareSection.querySelector('span.inline-block.px-4');
+        if (badge) badge.textContent = t.comparison.badge;
+
+        // Title
+        const title = compareSection.querySelector('h2.gradient-text');
+        if (title) title.textContent = t.comparison.title;
+
+        // Subtitle
+        const subtitle = compareSection.querySelector('p.text-xl.text-zinc-400');
+        if (subtitle) subtitle.textContent = t.comparison.subtitle;
+
+        // Team section
+        const teamTitle = compareSection.querySelector('.mt-16 h3');
+        if (teamTitle) teamTitle.textContent = t.comparison.teamSection.title;
+
+        const teamDesc = compareSection.querySelector('.mt-16 p.text-zinc-400');
+        if (teamDesc) teamDesc.textContent = t.comparison.teamSection.description;
+      }
+
+      function updateHowItWorksSection(t: any) {
+        const howSection = document.getElementById('how-it-works');
+        if (!howSection) return;
+
+        // Title
+        const title = howSection.querySelector('h2.gradient-text');
+        if (title) title.textContent = t.howItWorks.title;
+
+        // Description
+        const desc = howSection.querySelector('p.text-xl.text-zinc-400');
+        if (desc) desc.textContent = t.howItWorks.description;
+
+        // Architecture title
+        const archTitle = howSection.querySelector('.mt-16 h3.text-2xl');
+        if (archTitle) archTitle.textContent = t.howItWorks.architecture.title;
+
+        // CTA section
+        const ctaTitle = howSection.querySelector('.text-center.mt-16 h3');
+        if (ctaTitle) ctaTitle.textContent = t.howItWorks.callToAction.title;
+
+        const ctaDesc = howSection.querySelector('.text-center.mt-16 p.text-zinc-400');
+        if (ctaDesc) ctaDesc.textContent = t.howItWorks.callToAction.description;
+      }
+
+      function updateGetStartedSection(t: any) {
+        const gsSection = document.getElementById('get-started');
+        if (!gsSection) return;
+
+        // Title
+        const title = gsSection.querySelector('h2.gradient-text');
+        if (title) title.textContent = t.getStarted.title;
+
+        // Description
+        const desc = gsSection.querySelector('p.text-xl.text-muted-foreground');
+        if (desc) desc.textContent = t.getStarted.description;
+
+        // Terminal title
+        const termTitle = gsSection.querySelector('.terminal-title');
+        if (termTitle) termTitle.textContent = t.getStarted.terminal.title;
+      }
+
+      function updateFooterSection(t: any) {
+        const footer = document.querySelector('footer');
+        if (!footer) return;
+
+        // Footer description
+        const desc = footer.querySelector('.md\\:col-span-2 p.text-muted-foreground');
+        if (desc) desc.textContent = t.footer.description;
+
+        // Quick Links title
+        const quickLinksTitle = footer.querySelectorAll('h3')[0];
+        if (quickLinksTitle) quickLinksTitle.textContent = t.footer.quickLinks.title;
+
+        // Community title
+        const communityTitle = footer.querySelectorAll('h3')[1];
+        if (communityTitle) communityTitle.textContent = t.footer.community.title;
+
+        // Bottom bar
+        const copyright = footer.querySelector('.border-t p.text-muted-foreground');
+        if (copyright) {
+          copyright.innerHTML = `2025 <a href="https://www.sheetmetalconnect.com/" target="_blank" rel="noopener noreferrer" class="hover:text-foreground transition-colors">Sheet Metal Connect e.U.</a> ${t.footer.bottomBar.copyright.split('Released')[1] ? 'Released' + t.footer.bottomBar.copyright.split('Released')[1] : ''}`;
+        }
+
+        const madeBy = footer.querySelector('.border-t span');
+        if (madeBy) {
+          madeBy.innerHTML = `${t.footer.bottomBar.madeBy.split('Luke')[0]}<a href="https://vanenkhuizen.com" target="_blank" rel="noopener noreferrer" class="hover:text-foreground transition-colors">Luke van Enkhuizen</a>${t.footer.bottomBar.madeBy.split('Luke van Enkhuizen')[1] || ''}`;
+        }
+      }
+    </script>
+
   </body>
 </html>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -4,6 +4,7 @@ import Hero from '@components/Hero.astro';
 import FeatureGrid from '@components/FeatureGrid.astro';
 import HowItWorks from '@components/HowItWorks.astro';
 import ComparisonTable from '@components/ComparisonTable.astro';
+import LanguageSwitcher from '@components/LanguageSwitcher.tsx';
 ---
 
 <Layout>
@@ -24,28 +25,32 @@ import ComparisonTable from '@components/ComparisonTable.astro';
         </div>
 
         <!-- Navigation links -->
-        <div class="hidden md:flex items-center gap-8">
-          <a href="#features" class="nav-link">Features</a>
-          <a href="#how-it-works" class="nav-link">How It Works</a>
-          <a href="#get-started" class="nav-link">Get Started</a>
+        <div class="hidden md:flex items-center gap-6">
+          <a href="#features" class="nav-link" data-i18n="nav.features">Features</a>
+          <a href="#how-it-works" class="nav-link" data-i18n="nav.howItWorks">How It Works</a>
+          <a href="#get-started" class="nav-link" data-i18n="nav.getStarted">Get Started</a>
           <a href="https://github.com/SheetMetalConnect/eryxon-flow" target="_blank" rel="noopener noreferrer" class="nav-link">GitHub</a>
+          <LanguageSwitcher client:load />
         </div>
 
         <!-- Mobile menu button -->
-        <button class="md:hidden nav-link p-2" id="mobile-menu-button" aria-label="Toggle mobile menu">
-          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
-          </svg>
-        </button>
+        <div class="md:hidden flex items-center gap-2">
+          <LanguageSwitcher client:load />
+          <button class="nav-link p-2" id="mobile-menu-button" aria-label="Toggle mobile menu">
+            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+            </svg>
+          </button>
+        </div>
       </div>
     </div>
 
     <!-- Mobile menu dropdown -->
     <div class="md:hidden mobile-menu hidden fixed top-[80px] left-0 right-0 bottom-0 z-[9998]" id="mobile-menu">
       <div class="p-8 space-y-6 h-auto" style="background: rgba(0, 0, 0, 0.85);">
-        <a href="#features" class="block nav-link text-center text-lg">Features</a>
-        <a href="#how-it-works" class="block nav-link text-center text-lg">How It Works</a>
-        <a href="#get-started" class="block nav-link text-center text-lg">Get Started</a>
+        <a href="#features" class="block nav-link text-center text-lg" data-i18n="nav.features">Features</a>
+        <a href="#how-it-works" class="block nav-link text-center text-lg" data-i18n="nav.howItWorks">How It Works</a>
+        <a href="#get-started" class="block nav-link text-center text-lg" data-i18n="nav.getStarted">Get Started</a>
         <a href="https://github.com/SheetMetalConnect/eryxon-flow" target="_blank" rel="noopener noreferrer" class="block nav-link text-center text-lg">GitHub</a>
       </div>
     </div>


### PR DESCRIPTION
- Add LanguageSwitcher React component with EN/NL/DE support
- Create client-side i18n runtime for dynamic translations
- Update navigation with language selector (desktop & mobile)
- Add data-i18n attributes to navigation links
- Implement automatic translation of all major sections:
  - Hero (badges, title, tagline, description, CTAs, stats)
  - Features (title, description, CTA)
  - Comparison (badge, title, subtitle, team section)
  - How It Works (title, description, architecture, CTA)
  - Get Started (title, description, terminal)
  - Footer (description, section titles, copyright)
- Language preference persists in localStorage
- Falls back to browser language detection