### PR TITLE
Add open source licensing and feature flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,9 @@ docker run -p 8080:80 \
 
 ## License
 
-**Business Source License 1.1 (BSL 1.1)**
+**Business Source License 1.1 (BSL 1.1)** - Source Available
+
+This is an **open source repository** under the BSL 1.1 license, which allows source code access while preventing competitive SaaS offerings.
 
 **TL;DR:** Use it, modify it, self-host it - all free. Just don't host it and charge others for access.
 
@@ -171,6 +173,24 @@ docker run -p 8080:80 \
 - 🔄 Converts to Apache 2.0 after 4 years
 
 See [LICENSE](LICENSE) for full terms.
+
+### External Components (Feature Flags)
+
+Some features require external services that must be deployed separately:
+
+| Feature | Service | Description | Feature Flag |
+|---------|---------|-------------|--------------|
+| Advanced CAD (PMI/MBD) | `services/eryxon3d` | Server-side CAD processing with PMI extraction | `advancedCAD` |
+
+These external components are:
+- **Disabled by default** - must be explicitly enabled via feature flags in Organization Settings
+- **Self-hosted** - you deploy and control the service
+- **Optional** - core MES functionality works without them
+
+To enable an external feature:
+1. Deploy the required service (see `services/` directory)
+2. Configure environment variables (see `.env.example`)
+3. Enable the feature flag in Admin → Settings → Organization Settings
 
 ---
 

--- a/src/components/admin/FeatureFlagsSettings.tsx
+++ b/src/components/admin/FeatureFlagsSettings.tsx
@@ -14,6 +14,7 @@ import {
   AlertCircle,
   CalendarClock,
   UserCheck,
+  Box,
 } from 'lucide-react';
 import {
   useFeatureFlags,
@@ -33,6 +34,7 @@ const ICON_MAP: Record<string, React.ComponentType<{ className?: string }>> = {
   AlertCircle,
   CalendarClock,
   UserCheck,
+  Box,
 };
 
 // Category labels and order
@@ -41,6 +43,11 @@ const CATEGORIES = [
   { key: 'analytics', labelKey: 'featureFlags.categories.analytics' },
   { key: 'admin', labelKey: 'featureFlags.categories.admin' },
 ] as const;
+
+// External services category (shown separately with warning)
+
+// Feature flags that require external services
+const EXTERNAL_SERVICE_FLAGS = ['advancedCAD'] as const;
 
 interface FeatureFlagItemProps {
   meta: FeatureFlagMeta;
@@ -52,6 +59,7 @@ interface FeatureFlagItemProps {
 function FeatureFlagItem({ meta, enabled, onToggle, disabled }: FeatureFlagItemProps) {
   const { t } = useTranslation();
   const Icon = ICON_MAP[meta.icon] || Activity;
+  const isExternalService = EXTERNAL_SERVICE_FLAGS.includes(meta.key as typeof EXTERNAL_SERVICE_FLAGS[number]);
 
   return (
     <div
@@ -59,7 +67,8 @@ function FeatureFlagItem({ meta, enabled, onToggle, disabled }: FeatureFlagItemP
         'group flex items-center justify-between rounded-lg border p-4 transition-all duration-200',
         enabled
           ? 'border-primary/30 bg-primary/5 hover:border-primary/50'
-          : 'border-border/50 bg-muted/30 hover:border-border'
+          : 'border-border/50 bg-muted/30 hover:border-border',
+        isExternalService && 'border-dashed'
       )}
     >
       <div className="flex items-center gap-4">
@@ -81,6 +90,11 @@ function FeatureFlagItem({ meta, enabled, onToggle, disabled }: FeatureFlagItemP
             )}>
               {t(meta.labelKey)}
             </span>
+            {isExternalService && (
+              <Badge variant="outline" className="text-[10px] px-1.5 py-0 border-amber-500/50 text-amber-600">
+                External
+              </Badge>
+            )}
             {enabled && (
               <Badge variant="secondary" className="text-[10px] px-1.5 py-0 bg-primary/20 text-primary border-0">
                 {t('featureFlags.enabled')}
@@ -90,6 +104,11 @@ function FeatureFlagItem({ meta, enabled, onToggle, disabled }: FeatureFlagItemP
           <p className="text-sm text-muted-foreground">
             {t(meta.descriptionKey)}
           </p>
+          {isExternalService && (
+            <p className="text-xs text-amber-600/80 mt-1">
+              {t('featureFlags.externalServiceNote')}
+            </p>
+          )}
         </div>
       </div>
       <Switch

--- a/src/hooks/useFeatureFlags.ts
+++ b/src/hooks/useFeatureFlags.ts
@@ -7,6 +7,10 @@ import { useTranslation } from 'react-i18next';
 /**
  * Feature flag definitions for Eryxon MES
  * Each flag controls visibility of a major module or feature group
+ *
+ * Note: Some features require external services (marked below).
+ * These are optional components that must be separately deployed.
+ * See docs/SELF_HOSTING_GUIDE.md for deployment instructions.
  */
 export interface FeatureFlags {
   // Core modules (always enabled - listed for reference)
@@ -24,10 +28,14 @@ export interface FeatureFlags {
   issues: boolean;          // Issues tracking
   capacity: boolean;        // Capacity planning
   assignments: boolean;     // Assignments management
+
+  // External service features (require separate deployment)
+  advancedCAD: boolean;     // PMI/MBD extraction - requires eryxon3d service (services/eryxon3d)
 }
 
 /**
- * Default feature flags - all features enabled by default
+ * Default feature flags - core features enabled, external services disabled by default
+ * External service features (advancedCAD) require separate deployment and are opt-in
  */
 export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   analytics: true,
@@ -38,6 +46,8 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   issues: true,
   capacity: true,
   assignments: true,
+  // External service features - disabled by default (require separate deployment)
+  advancedCAD: false,
 };
 
 /**
@@ -107,6 +117,14 @@ export const FEATURE_FLAG_METADATA: FeatureFlagMeta[] = [
     descriptionKey: 'featureFlags.assignments.description',
     icon: 'UserCheck',
     category: 'operations',
+  },
+  // External service features
+  {
+    key: 'advancedCAD',
+    labelKey: 'featureFlags.advancedCAD.label',
+    descriptionKey: 'featureFlags.advancedCAD.description',
+    icon: 'Box',
+    category: 'admin',
   },
 ];
 
@@ -201,6 +219,7 @@ export function useFeatureFlags() {
       issues: false,
       capacity: false,
       assignments: false,
+      advancedCAD: false,
     };
     updateFlags.mutate(allDisabled);
   };

--- a/src/i18n/locales/de/admin.json
+++ b/src/i18n/locales/de/admin.json
@@ -401,6 +401,11 @@
     "assignments": {
       "label": "Zuweisungen",
       "description": "Arbeitszuweisungen und Bedienerplanung"
-    }
+    },
+    "advancedCAD": {
+      "label": "Erweiterte CAD (PMI/MBD)",
+      "description": "Serverseitige CAD-Verarbeitung mit PMI/MBD-Extraktion. Erfordert externen eryxon3d-Service."
+    },
+    "externalServiceNote": "Diese Funktion erfordert einen externen Dienst. Siehe Self-Hosting-Anleitung für Bereitstellungsanweisungen."
   }
 }

--- a/src/i18n/locales/en/admin.json
+++ b/src/i18n/locales/en/admin.json
@@ -488,6 +488,11 @@
     "assignments": {
       "label": "Assignments",
       "description": "Work assignments and operator scheduling"
-    }
+    },
+    "advancedCAD": {
+      "label": "Advanced CAD (PMI/MBD)",
+      "description": "Server-side CAD processing with PMI/MBD extraction. Requires external eryxon3d service."
+    },
+    "externalServiceNote": "This feature requires an external service. See the Self-Hosting Guide for deployment instructions."
   }
 }

--- a/src/i18n/locales/nl/admin.json
+++ b/src/i18n/locales/nl/admin.json
@@ -647,6 +647,11 @@
     "assignments": {
       "label": "Toewijzingen",
       "description": "Werktoewijzingen en operator planning"
-    }
+    },
+    "advancedCAD": {
+      "label": "Geavanceerde CAD (PMI/MBD)",
+      "description": "Server-side CAD-verwerking met PMI/MBD-extractie. Vereist externe eryxon3d-service."
+    },
+    "externalServiceNote": "Deze functie vereist een externe service. Zie de Self-Hosting Guide voor implementatie-instructies."
   }
 }


### PR DESCRIPTION
- Add advancedCAD feature flag for PMI/MBD extraction (requires eryxon3d service)
- External service features are disabled by default and marked with "External" badge
- Update README with clear BSL 1.1 licensing explanation and external components table
- Add translations for new feature flag in EN, NL, DE
- Feature flags now distinguish between core features and external services