### PR TITLE
Review merged PR for incomplete UI changes

### DIFF
--- a/src/hooks/useFeatureFlags.ts
+++ b/src/hooks/useFeatureFlags.ts
@@ -135,7 +135,7 @@ export function useFeatureFlags() {
       if (error) throw error;
 
       // Merge with defaults to ensure all flags exist
-      const storedFlags = (data as any)?.feature_flags as Partial<FeatureFlags> | null;
+      const storedFlags = data?.feature_flags as Partial<FeatureFlags> | null;
       return {
         ...DEFAULT_FEATURE_FLAGS,
         ...(storedFlags || {}),
@@ -158,7 +158,7 @@ export function useFeatureFlags() {
 
       const { error } = await supabase
         .from('tenants')
-        .update({ feature_flags: mergedFlags } as any)
+        .update({ feature_flags: mergedFlags })
         .eq('id', tenant.id);
 
       if (error) throw error;

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -3027,6 +3027,7 @@ export type Database = {
           demo_mode_enabled: boolean | null
           factory_closing_time: string | null
           factory_opening_time: string | null
+          feature_flags: Json | null
           grace_period_ends_at: string | null
           id: string
           last_parts_reset_date: string | null
@@ -3077,6 +3078,7 @@ export type Database = {
           demo_mode_enabled?: boolean | null
           factory_closing_time?: string | null
           factory_opening_time?: string | null
+          feature_flags?: Json | null
           grace_period_ends_at?: string | null
           id?: string
           last_parts_reset_date?: string | null
@@ -3127,6 +3129,7 @@ export type Database = {
           demo_mode_enabled?: boolean | null
           factory_closing_time?: string | null
           factory_opening_time?: string | null
+          feature_flags?: Json | null
           grace_period_ends_at?: string | null
           id?: string
           last_parts_reset_date?: string | null

--- a/supabase/migrations/20251229102512_add_feature_flags_column.sql
+++ b/supabase/migrations/20251229102512_add_feature_flags_column.sql
@@ -1,0 +1,9 @@
+-- Add feature_flags column to tenants table
+-- This column stores per-tenant feature flag settings as JSONB
+-- Default is empty object, which will fall back to all features enabled in the application code
+
+ALTER TABLE public.tenants
+ADD COLUMN IF NOT EXISTS feature_flags JSONB DEFAULT '{}';
+
+-- Add a comment to document the column
+COMMENT ON COLUMN public.tenants.feature_flags IS 'JSONB object storing feature flag settings. Keys: analytics, monitoring, shipping, operatorViews, integrations, issues, capacity, assignments. All default to true if not specified.';


### PR DESCRIPTION
PR #280 added the feature flags UI but was missing the database migration. This adds:
- Migration to add feature_flags JSONB column to tenants table
- Updated Supabase types to include feature_flags field
- Removed 'as any' casts from useFeatureFlags hook

Without this column, feature flag changes were not persisting.