### PR TITLE
Document STEP AP242 PMI semantic data

### DIFF
--- a/services/eryxon3d/Dockerfile
+++ b/services/eryxon3d/Dockerfile
@@ -3,14 +3,20 @@
 # Uses conda to install pythonocc-core with OpenCASCADE dependencies
 #
 # Build: docker build -t pmi-extractor .
+# Build with specific version: docker build --build-arg PYTHONOCC_VERSION=7.6.2 -t pmi-extractor .
 # Run:   docker run -p 8000:8000 pmi-extractor
 
 FROM continuumio/miniconda3:latest
 
 WORKDIR /app
 
+# pythonocc-core version - can be overridden at build time
+# Known issue: Some versions don't expose Handle_TDocStd_Document needed for PMI
+# See docs/STEP-AP242-PMI.md for version compatibility
+ARG PYTHONOCC_VERSION=7.7.2
+
 # Install pythonocc-core via conda (includes OpenCASCADE)
-RUN conda install -c conda-forge python=3.11 pythonocc-core=7.7.2 -y && \
+RUN conda install -c conda-forge python=3.11 pythonocc-core=${PYTHONOCC_VERSION} -y && \
     conda clean -afy
 
 # Install Python dependencies
@@ -22,6 +28,7 @@ COPY main.py .
 COPY extractor.py .
 COPY supabase_client.py .
 COPY test_pmi_extraction.py .
+COPY test_handle.py .
 
 # Create non-root user for security
 RUN useradd -m -u 1000 appuser && \

--- a/services/eryxon3d/docs/STEP-AP242-PMI.md
+++ b/services/eryxon3d/docs/STEP-AP242-PMI.md
@@ -1,0 +1,186 @@
+# STEP AP242 PMI Extraction
+
+## Overview
+
+This document explains how STEP AP242 PMI (Product Manufacturing Information) extraction works in Eryxon3D and how to troubleshoot common issues.
+
+## What is STEP AP242 PMI?
+
+STEP AP242 files can contain **semantic PMI** — structured data representing:
+
+- **Dimensions** — linear, angular, radius, diameter with nominal value and tolerances
+- **Geometric Tolerances** — flatness, parallelism, position, etc. with datum references
+- **Datums** — reference features labeled A, B, C, etc.
+- **Annotation positions** — 3D coordinates for where to display the annotation
+- **Leader lines** — lines connecting annotation to geometry
+- **Associated geometry** — which faces/edges the annotation applies to
+
+## Architecture
+
+### Backend: pythonocc-core + OpenCASCADE
+
+PMI extraction uses **pythonocc-core**, Python bindings for OpenCASCADE Technology (OCCT). PMI is accessed via XDE (Extended Data Exchange) modules.
+
+**Key OCCT classes:**
+```
+STEPCAFControl_Reader         — reads STEP with PMI when GDT mode enabled
+XCAFDoc_DocumentTool          — access to document tools
+XCAFDoc_ShapeTool             — navigate geometry/assembly structure
+XCAFDoc_DimTolTool            — iterate over dimensions and tolerances
+XCAFDoc_Dimension             — individual dimension object
+XCAFDoc_GeomTolerance         — geometric tolerance object
+XCAFDoc_Datum                 — datum feature
+XCAFDimTolObjects_*           — dimension/tolerance properties
+```
+
+### Critical Requirement: GDT Mode
+
+The STEP reader **must** have `SetGDTMode(True)` enabled, otherwise PMI is discarded during import:
+
+```python
+reader = STEPCAFControl_Reader()
+reader.SetGDTMode(True)  # CRITICAL — enables PMI import
+reader.SetNameMode(True)
+reader.SetColorMode(True)
+```
+
+## Known Issue: Handle_TDocStd_Document
+
+### The Problem
+
+Certain pythonocc-core versions don't expose `Handle_TDocStd_Document`, which is required to create a valid XCAF document. Without this handle, XCAF document initialization crashes or PMI gets silently disabled.
+
+**Symptoms:**
+- All NIST test files crash with "Worker crashed (process pool broken)"
+- PMI extraction returns empty results
+- Log shows: `XCAF handle document init failed`
+
+### Version Compatibility
+
+| pythonocc-core | Handle Exposed | PMI Works |
+|----------------|----------------|-----------|
+| 7.4.x          | ❓ Unknown     | Test required |
+| 7.5.x          | ❓ Unknown     | Test required |
+| 7.6.x          | ❓ Unknown     | Test required |
+| 7.7.0          | ❓ Unknown     | Test required |
+| 7.7.1          | ❓ Unknown     | Test required |
+| 7.7.2          | ❌ No          | ❌ Crashes |
+
+### How to Test a Version
+
+Run this Docker command to check if a version exposes the handle:
+
+```bash
+# Check Handle_TDocStd_Document availability
+docker run --rm continuumio/miniconda3:latest /bin/sh -lc "
+  conda install -c conda-forge pythonocc-core=VERSION_HERE -y 2>&1 | tail -5 && \
+  python -c \"
+from OCC.Core import TDocStd
+attrs = [n for n in dir(TDocStd) if 'Handle' in n or 'Document' in n]
+print('Available TDocStd exports:')
+for a in attrs: print(f'  {a}')
+has_handle = 'Handle_TDocStd_Document' in attrs
+print(f'\\nHandle_TDocStd_Document available: {has_handle}')
+\""
+```
+
+### Solution: Find a Working Version
+
+1. **Search available versions:**
+```bash
+docker run --rm continuumio/miniconda3:latest /bin/sh -lc \
+  "conda search -c conda-forge pythonocc-core | tail -n 40"
+```
+
+2. **Test each version using the test script:**
+```bash
+cd services/eryxon3d
+PYTHONOCC_VERSION=7.6.2 ./run_tests.sh --nist
+```
+
+3. **Update Dockerfile with working version:**
+```dockerfile
+ARG PYTHONOCC_VERSION=7.6.2
+RUN conda install -c conda-forge python=3.11 pythonocc-core=${PYTHONOCC_VERSION} -y
+```
+
+## NIST Test Files
+
+The `/NIST-PMI-STEP-Files/` directory contains official NIST MBE PMI validation files:
+
+| Folder | Files | Description | Expected PMI |
+|--------|-------|-------------|--------------|
+| `AP203 geometry only/` | 11 | Geometry-only exports | None |
+| `AP203 with PMI/` | 5 | AP203 with graphical PMI | Graphical only |
+| Root (AP242 files) | 17 | AP242 with semantic PMI | Full PMI |
+
+### File Naming Convention
+
+- `nist_ctc_##` — Combination Test Cases
+- `nist_ftc_##` — Functional Tolerance Cases
+- `nist_stc_##` — Semantic Tolerance Cases
+- `_ap242-e#` suffix — AP242 edition (e1, e2, e3)
+- `_rd`, `_rc`, `_rb` suffix — Revision codes
+
+### Running NIST Batch Test
+
+```bash
+# Build and run all NIST tests
+./run_tests.sh --nist --report=/app/NIST-PMI-STEP-Files/nist_report.json
+
+# With specific pythonocc version
+PYTHONOCC_VERSION=7.6.2 ./run_tests.sh --nist
+```
+
+## Output Format
+
+PMI extraction returns JSON with:
+
+```json
+{
+  "version": "1.0",
+  "dimensions": [
+    {
+      "id": "dim_1",
+      "type": "linear|angular|radius|diameter|ordinate",
+      "value": 50.0,
+      "unit": "mm",
+      "tolerance": {"upper": 0.1, "lower": -0.1, "type": "bilateral"},
+      "text": "50.00 ±0.10 mm",
+      "position": {"x": 0, "y": 0, "z": 0},
+      "leader_points": []
+    }
+  ],
+  "geometric_tolerances": [
+    {
+      "id": "tol_1",
+      "type": "flatness|position|...",
+      "value": 0.05,
+      "unit": "mm",
+      "symbol": "⏥",
+      "modifier": "Ⓜ",
+      "datum_refs": ["A", "B"],
+      "text": "⏥ 0.050 Ⓜ | A | B",
+      "position": {"x": 0, "y": 0, "z": 0}
+    }
+  ],
+  "datums": [
+    {
+      "id": "datum_1",
+      "label": "A",
+      "position": {"x": 0, "y": 0, "z": 0}
+    }
+  ],
+  "surface_finishes": [],
+  "notes": [],
+  "graphical_pmi": []
+}
+```
+
+## References
+
+- [OCCT XDE User Guide](https://dev.opencascade.org/doc/overview/html/occt_user_guides__xde.html)
+- [OCCT STEP Translator](https://dev.opencascade.org/doc/overview/html/occt_user_guides__step.html)
+- [pythonocc-core](https://github.com/tpaviot/pythonocc-core)
+- [NIST PMI Validation](https://www.nist.gov/el/systems-integration-division-73400/mbe-pmi-validation-and-conformance-testing)
+- [MBx-IF CAX STEP Files](https://www.mbx-if.org/cax/cax_step.php)

--- a/services/eryxon3d/test_handle.py
+++ b/services/eryxon3d/test_handle.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""
+Test Handle_TDocStd_Document availability in pythonocc-core.
+
+This script checks if the current pythonocc-core version exposes
+Handle_TDocStd_Document, which is required for XCAF document creation
+and PMI extraction.
+
+Usage:
+    python test_handle.py
+    python test_handle.py --verbose
+"""
+
+import argparse
+import sys
+
+
+def check_handle_availability(verbose: bool = False) -> bool:
+    """Check if Handle_TDocStd_Document is available."""
+    try:
+        from OCC.Core import TDocStd
+
+        # Get all exports from TDocStd module
+        exports = dir(TDocStd)
+
+        if verbose:
+            print("TDocStd module exports:")
+            for name in sorted(exports):
+                if not name.startswith("_"):
+                    print(f"  {name}")
+            print()
+
+        # Check for Handle_TDocStd_Document
+        has_handle = "Handle_TDocStd_Document" in exports
+
+        # Also check alternative patterns
+        handle_patterns = [
+            "Handle_TDocStd_Document",
+            "TDocStd_Document",
+        ]
+
+        found = []
+        for pattern in handle_patterns:
+            if pattern in exports:
+                found.append(pattern)
+
+        print(f"pythonocc TDocStd exports found: {', '.join(found) or 'None relevant'}")
+        print(f"Handle_TDocStd_Document available: {has_handle}")
+
+        return has_handle
+
+    except ImportError as e:
+        print(f"ERROR: pythonocc-core not installed: {e}")
+        return False
+    except Exception as e:
+        print(f"ERROR: {e}")
+        return False
+
+
+def test_xcaf_document_creation(verbose: bool = False) -> bool:
+    """Test if XCAF document creation works."""
+    try:
+        from OCC.Core.TCollection import TCollection_ExtendedString
+        from OCC.Core.XCAFApp import XCAFApp_Application
+
+        fmt = TCollection_ExtendedString("MDTV-XCAF")
+        app = XCAFApp_Application.GetApplication()
+
+        # Method 1: NewDocument returning handle directly
+        try:
+            result = app.NewDocument(fmt)
+            if result is not None:
+                if hasattr(result, "GetObject"):
+                    doc = result.GetObject()
+                    if doc is not None and hasattr(doc, "Main"):
+                        main = doc.Main()
+                        if not (hasattr(main, "IsNull") and main.IsNull()):
+                            print("XCAF document creation: SUCCESS (NewDocument returns handle)")
+                            return True
+                elif hasattr(result, "Main"):
+                    main = result.Main()
+                    if not (hasattr(main, "IsNull") and main.IsNull()):
+                        print("XCAF document creation: SUCCESS (NewDocument returns document)")
+                        return True
+        except Exception as e:
+            if verbose:
+                print(f"  Method 1 (NewDocument) failed: {e}")
+
+        # Method 2: Using Handle_TDocStd_Document
+        try:
+            from OCC.Core.TDocStd import Handle_TDocStd_Document
+
+            h_doc = Handle_TDocStd_Document()
+            app.NewDocument(fmt, h_doc)
+            if not h_doc.IsNull():
+                doc = h_doc.GetObject()
+                if doc is not None and hasattr(doc, "Main"):
+                    main = doc.Main()
+                    if not (hasattr(main, "IsNull") and main.IsNull()):
+                        print("XCAF document creation: SUCCESS (Handle_TDocStd_Document)")
+                        return True
+        except ImportError:
+            if verbose:
+                print("  Method 2: Handle_TDocStd_Document not available")
+        except Exception as e:
+            if verbose:
+                print(f"  Method 2 (Handle) failed: {e}")
+
+        # Method 3: TDocStd_Document directly
+        try:
+            from OCC.Core.TDocStd import TDocStd_Document
+
+            doc = TDocStd_Document(fmt)
+            # Try to register with app
+            try:
+                app.NewDocument(fmt, doc)
+            except Exception:
+                pass  # May fail but document might still be usable
+
+            if hasattr(doc, "Main"):
+                main = doc.Main()
+                if not (hasattr(main, "IsNull") and main.IsNull()):
+                    print("XCAF document creation: SUCCESS (TDocStd_Document direct)")
+                    return True
+        except Exception as e:
+            if verbose:
+                print(f"  Method 3 (TDocStd_Document) failed: {e}")
+
+        print("XCAF document creation: FAILED (all methods)")
+        return False
+
+    except ImportError as e:
+        print(f"ERROR: Required OCC modules not available: {e}")
+        return False
+    except Exception as e:
+        print(f"ERROR: {e}")
+        return False
+
+
+def test_pmi_tools(verbose: bool = False) -> bool:
+    """Test if PMI tools are accessible."""
+    try:
+        from OCC.Core.TCollection import TCollection_ExtendedString
+        from OCC.Core.XCAFApp import XCAFApp_Application
+        from OCC.Core.XCAFDoc import XCAFDoc_DocumentTool
+        from OCC.Core.TDF import TDF_LabelSequence
+
+        # First create a document
+        fmt = TCollection_ExtendedString("MDTV-XCAF")
+        app = XCAFApp_Application.GetApplication()
+
+        doc = None
+
+        # Try each method
+        try:
+            from OCC.Core.TDocStd import Handle_TDocStd_Document
+            h_doc = Handle_TDocStd_Document()
+            app.NewDocument(fmt, h_doc)
+            if not h_doc.IsNull():
+                doc = h_doc.GetObject()
+        except Exception:
+            pass
+
+        if doc is None:
+            try:
+                result = app.NewDocument(fmt)
+                if result is not None:
+                    if hasattr(result, "GetObject"):
+                        doc = result.GetObject()
+                    elif hasattr(result, "Main"):
+                        doc = result
+            except Exception:
+                pass
+
+        if doc is None:
+            print("PMI tools test: SKIPPED (no valid document)")
+            return False
+
+        main_label = doc.Main()
+
+        # Test DimTolTool
+        try:
+            dim_tol_tool = XCAFDoc_DocumentTool.DimTolTool(main_label)
+            if dim_tol_tool is not None:
+                # Try to get labels
+                dim_labels = TDF_LabelSequence()
+                dim_tol_tool.GetDimensionLabels(dim_labels)
+
+                tol_labels = TDF_LabelSequence()
+                dim_tol_tool.GetGeomToleranceLabels(tol_labels)
+
+                datum_labels = TDF_LabelSequence()
+                dim_tol_tool.GetDatumLabels(datum_labels)
+
+                print("PMI tools test: SUCCESS")
+                print(f"  DimTolTool: available")
+                print(f"  GetDimensionLabels: works")
+                print(f"  GetGeomToleranceLabels: works")
+                print(f"  GetDatumLabels: works")
+                return True
+        except Exception as e:
+            if verbose:
+                print(f"  DimTolTool test failed: {e}")
+
+        print("PMI tools test: FAILED")
+        return False
+
+    except Exception as e:
+        print(f"PMI tools test: ERROR - {e}")
+        return False
+
+
+def get_pythonocc_version() -> str:
+    """Get installed pythonocc-core version."""
+    try:
+        import OCC
+        return getattr(OCC, "__version__", "unknown")
+    except Exception:
+        return "not installed"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Test Handle_TDocStd_Document availability"
+    )
+    parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
+    args = parser.parse_args()
+
+    print("=" * 60)
+    print("pythonocc-core Handle_TDocStd_Document Test")
+    print("=" * 60)
+
+    version = get_pythonocc_version()
+    print(f"\npythonocc-core version: {version}")
+    print()
+
+    # Run tests
+    handle_ok = check_handle_availability(args.verbose)
+    print()
+
+    doc_ok = test_xcaf_document_creation(args.verbose)
+    print()
+
+    pmi_ok = test_pmi_tools(args.verbose)
+    print()
+
+    # Summary
+    print("=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    print(f"Handle_TDocStd_Document: {'AVAILABLE' if handle_ok else 'NOT AVAILABLE'}")
+    print(f"XCAF document creation:  {'WORKS' if doc_ok else 'FAILS'}")
+    print(f"PMI tools accessible:    {'YES' if pmi_ok else 'NO'}")
+    print()
+
+    if doc_ok and pmi_ok:
+        print("PMI extraction should work with this version.")
+        sys.exit(0)
+    else:
+        print("PMI extraction will NOT work with this version.")
+        print("Try a different pythonocc-core version.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Add docs/STEP-AP242-PMI.md with version compatibility info
- Add test_handle.py to diagnose Handle_TDocStd_Document availability
- Refactor extractor.py to isolate XCAF failures and fall back gracefully
- Update run_tests.sh with --check-handle option and version support
- Update Dockerfile to accept PYTHONOCC_VERSION build argument

The root cause of worker crashes is pythonocc-core 7.7.2 not exposing Handle_TDocStd_Document. This refactor prevents crashes by catching XCAF errors and falling back to geometry-only extraction.

To find a working version, run:
  PYTHONOCC_VERSION=7.6.2 ./run_tests.sh --check-handle