### PR TITLE
Add wrangler.toml for website static asset deployment

### DIFF
--- a/website/wrangler.toml
+++ b/website/wrangler.toml
@@ -1,0 +1,12 @@
+# Cloudflare Pages/Workers configuration for the docs site
+# This overrides the root wrangler.toml when deploying from /website/
+
+name = "eryxon-flow-website"
+compatibility_date = "2026-01-10"
+
+# For Pages-style deployment
+pages_build_output_dir = "./dist"
+
+# For Workers static assets (new recommended approach)
+[assets]
+directory = "./dist"


### PR DESCRIPTION
Configures proper Pages/Workers static asset deployment for the docs site. Uses both pages_build_output_dir and [assets].directory for compatibility with Cloudflare's new Workers-based deployment.