### PR TITLE
Fix GDPR account/tenant deletion to actually delete data

### DIFF
--- a/src/i18n/locales/de/admin.json
+++ b/src/i18n/locales/de/admin.json
@@ -60,6 +60,60 @@
       "successCleared": "Demodaten erfolgreich gelöscht",
       "errorCreate": "Erstellen der Demodaten fehlgeschlagen",
       "errorClear": "Löschen der Demodaten fehlgeschlagen"
+    },
+    "gdpr": {
+      "title": "Datenlöschung (DSGVO)",
+      "description": "Löschen Sie dauerhaft Ihr Konto oder alle Organisationsdaten",
+      "deleteAccount": {
+        "title": "Mein Konto löschen",
+        "description": "Löschen Sie dauerhaft Ihr Benutzerkonto und alle zugehörigen persönlichen Daten.",
+        "warning": "Warnung",
+        "warningMessage": "Diese Aktion kann nicht rückgängig gemacht werden. Ihr Konto, Zeiterfassungen, Zuweisungen und Probleme werden dauerhaft gelöscht.",
+        "button": "Mein Konto löschen",
+        "confirmTitle": "Ihr Konto löschen?",
+        "confirmMessage": "Dies löscht dauerhaft Ihr Konto und alle zugehörigen Daten:",
+        "confirmItems": {
+          "profile": "Ihr Benutzerprofil",
+          "timeEntries": "Alle von Ihnen erstellten Zeiterfassungen",
+          "assignments": "Alle Zuweisungen an Sie",
+          "issues": "Alle von Ihnen erstellten Probleme"
+        },
+        "confirmWarning": "Diese Aktion kann nicht rückgängig gemacht werden",
+        "confirmDescription": "Sie werden sofort abgemeldet und können Ihr Konto nicht wiederherstellen.",
+        "confirmButton": "Mein Konto löschen",
+        "deleting": "Wird gelöscht...",
+        "confirmationRequired": "Bitte geben Sie DELETE zur Bestätigung ein",
+        "success": "Ihr Konto und alle zugehörigen Daten wurden dauerhaft gelöscht"
+      },
+      "deleteTenant": {
+        "title": "Gesamte Organisation löschen",
+        "description": "Löschen Sie dauerhaft Ihre Organisation und ALLE Daten für alle Benutzer.",
+        "warningTitle": "Kritische Warnung",
+        "warningMessage": "Dies löscht ALLE Aufträge, Teile, Arbeitsgänge, Benutzer und Daten für Ihre gesamte Organisation. Diese Aktion betrifft ALLE Benutzer in Ihrer Organisation und kann NICHT rückgängig gemacht werden.",
+        "button": "Gesamte Organisation löschen",
+        "confirmTitle": "Gesamte Organisation löschen?",
+        "confirmMessage": "Dies löscht dauerhaft Ihre Organisation und ALLE Daten:",
+        "confirmItems": {
+          "users": "Alle Benutzerkonten und Profile",
+          "jobs": "Alle Aufträge, Teile und Arbeitsgänge",
+          "timeEntries": "Alle Zeiterfassungen und Zuweisungen",
+          "issues": "Alle Probleme und Produktionsdaten",
+          "config": "Alle Zellen, Materialien und Ressourcen",
+          "api": "Alle API-Schlüssel und Webhooks",
+          "all": "Alles andere in Ihrer Organisation"
+        },
+        "confirmWarningTitle": "KRITISCH: Dies betrifft ALLE Benutzer",
+        "confirmWarningMessage": "Dies löscht Daten für ALLE Benutzer in Ihrer Organisation. Alle verlieren den Zugang. Diese Aktion ist DAUERHAFT und kann NICHT rückgängig gemacht werden.",
+        "confirmButton": "Organisation löschen",
+        "deleting": "Wird gelöscht...",
+        "confirmationRequired": "Bitte geben Sie DELETE zur Bestätigung ein",
+        "success": "Ihre Organisation und alle Daten wurden dauerhaft gelöscht"
+      },
+      "typeToConfirm": "Geben Sie \"{{text}}\" zur Bestätigung ein",
+      "exportFirst": "Bevor Sie löschen, können Sie Ihre Daten exportieren über die",
+      "dataExportLink": "Datenexport-Funktion",
+      "privacyPolicyLink": "Datenschutzrichtlinie",
+      "seePolicy": "Bei Fragen zur Datenlöschung siehe unsere"
     }
   },
   "users": {

--- a/src/i18n/locales/en/admin.json
+++ b/src/i18n/locales/en/admin.json
@@ -119,7 +119,9 @@
         "confirmWarning": "This action cannot be undone",
         "confirmDescription": "You will be immediately signed out and will not be able to recover your account.",
         "confirmButton": "Delete My Account",
-        "deleting": "Deleting..."
+        "deleting": "Deleting...",
+        "confirmationRequired": "Please type DELETE to confirm",
+        "success": "Your account and all associated data have been permanently deleted"
       },
       "deleteTenant": {
         "title": "Delete Entire Organization",
@@ -141,8 +143,11 @@
         "confirmWarningTitle": "CRITICAL: This affects ALL users",
         "confirmWarningMessage": "This will delete data for ALL users in your organization. Everyone will lose access. This action is PERMANENT and CANNOT be undone.",
         "confirmButton": "Delete Organization",
-        "deleting": "Deleting..."
+        "deleting": "Deleting...",
+        "confirmationRequired": "Please type DELETE to confirm",
+        "success": "Your organization and all data have been permanently deleted"
       },
+      "typeToConfirm": "Type \"{{text}}\" to confirm",
       "exportFirst": "Before deleting, you can export your data using the",
       "dataExportLink": "Data Export feature",
       "privacyPolicyLink": "Privacy Policy",

--- a/src/i18n/locales/nl/admin.json
+++ b/src/i18n/locales/nl/admin.json
@@ -269,7 +269,9 @@
         "confirmWarning": "Deze actie kan niet ongedaan worden gemaakt",
         "confirmDescription": "U wordt onmiddellijk afgemeld en kunt uw account niet meer herstellen.",
         "confirmButton": "Mijn account verwijderen",
-        "deleting": "Verwijderen..."
+        "deleting": "Verwijderen...",
+        "confirmationRequired": "Typ DELETE om te bevestigen",
+        "success": "Uw account en alle bijbehorende gegevens zijn permanent verwijderd"
       },
       "deleteTenant": {
         "title": "Hele organisatie verwijderen",
@@ -291,8 +293,11 @@
         "confirmWarningTitle": "KRITIEK: Dit heeft invloed op ALLE gebruikers",
         "confirmWarningMessage": "Dit verwijdert gegevens voor ALLE gebruikers in uw organisatie. Iedereen verliest toegang. Deze actie is PERMANENT en kan NIET ongedaan worden gemaakt.",
         "confirmButton": "Organisatie verwijderen",
-        "deleting": "Verwijderen..."
+        "deleting": "Verwijderen...",
+        "confirmationRequired": "Typ DELETE om te bevestigen",
+        "success": "Uw organisatie en alle gegevens zijn permanent verwijderd"
       },
+      "typeToConfirm": "Typ \"{{text}}\" om te bevestigen",
       "exportFirst": "Voordat u verwijdert, kunt u uw gegevens exporteren via de",
       "dataExportLink": "Gegevensexport functie",
       "privacyPolicyLink": "Privacybeleid",


### PR DESCRIPTION
Previously, the delete account/tenant handlers only signed the user out without actually deleting any data. This was a critical gap between what was claimed in the legal documents and what was implemented.

Changes:
- Call delete_user_account() RPC function for account deletion
- Call delete_tenant_data() RPC function for tenant deletion
- Add confirmation input (type "DELETE" to confirm) for both actions
- Disable delete button until confirmation text matches
- Reset confirmation text when dialog closes
- Add proper error handling with translated messages
- Add success messages with translations

UX improvements:
- Users must type "DELETE" to confirm destructive actions
- Button is disabled until confirmation is entered correctly
- Clear feedback on success/failure with toast notifications
- Proper loading states during deletion

Translations added for all three languages (EN, NL, DE):
- settings.gdpr.typeToConfirm
- settings.gdpr.deleteAccount.confirmationRequired
- settings.gdpr.deleteAccount.success
- settings.gdpr.deleteTenant.confirmationRequired
- settings.gdpr.deleteTenant.success

Also added missing German gdpr section with full translations.