### PR TITLE
docs: Prepare documentation for v0.1 alpha public release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -446,6 +446,53 @@ function JobsPage() {
 
 ---
 
+## Deployment Architecture
+
+### Two Deployment Modes
+
+Eryxon Flow supports two deployment approaches:
+
+1. **Cloud Supabase + App Container (Recommended)**
+   - App runs on your infrastructure (Docker, VPS, Cloudflare Pages)
+   - Database and backend services run on Supabase Cloud
+   - Minimal disk space (~500MB for app)
+   - No database maintenance required
+
+2. **Fully Self-Hosted (Air-Gapped)**
+   - All services run on your infrastructure
+   - Requires `supabase-docker/` setup (10+ containers)
+   - Significant disk space required (20GB+ minimum, 50GB+ recommended)
+   - Full control over all components
+   - Only needed for air-gapped environments or strict data sovereignty
+
+### Database Schema Considerations
+
+When making database schema changes:
+
+- **Test both deployment modes** - Cloud Supabase and self-hosted use the same PostgreSQL, but verify migrations work in both
+- **Use Supabase migrations** - All schema changes go in `supabase/migrations/`
+- **Follow migration naming convention** - `YYYYMMDDHHMMSS_description.sql`
+- **Test migration rollback** - Ensure migrations can be safely applied and reverted
+- **Document breaking changes** - If a migration requires data transformation or manual steps, document it clearly
+
+### Environment Variables
+
+Different deployment modes require different environment variables:
+
+**App Container (both modes):**
+```env
+VITE_SUPABASE_URL=<supabase-url>
+VITE_SUPABASE_PUBLISHABLE_KEY=<anon-key>
+```
+
+**Self-Hosted Supabase:**
+- See `supabase-docker/.env.example` for full list
+- Includes PostgreSQL credentials, JWT secrets, SMTP config, etc.
+
+**Important:** Never commit `.env` files to git. Use `.env.example` as template.
+
+---
+
 ## Navigation & Menu Updates
 
 ### ALWAYS Update Navigation

--- a/src/config/cadBackend.ts
+++ b/src/config/cadBackend.ts
@@ -58,7 +58,7 @@ export interface CADBackendConfig {
  */
 const defaultConfig: CADBackendConfig = {
   // Default to frontend-only processing.
-  // Server-side PMI/MBD extraction is WIP and must be explicitly configured.
+  // Server-side PMI/MBD extraction is planned (not yet available).
   mode: 'frontend',
 
   custom: {

--- a/src/i18n/locales/de/admin.json
+++ b/src/i18n/locales/de/admin.json
@@ -462,7 +462,7 @@
     },
     "advancedCAD": {
       "label": "Erweiterte CAD (PMI/MBD)",
-      "description": "Serverseitige CAD-Verarbeitung mit PMI/MBD-Extraktion. Erfordert externen eryxon3d-Service."
+      "description": "Serverseitige CAD-Verarbeitung mit PMI/MBD-Extraktion. Geplante Funktion - erfordert externen Service."
     },
     "externalServiceNote": "Diese Funktion erfordert einen externen Dienst. Siehe Self-Hosting-Anleitung für Bereitstellungsanweisungen."
   }

--- a/src/i18n/locales/en/admin.json
+++ b/src/i18n/locales/en/admin.json
@@ -500,7 +500,7 @@
     },
     "advancedCAD": {
       "label": "Advanced CAD (PMI/MBD)",
-      "description": "Server-side CAD processing with PMI/MBD extraction. Requires external eryxon3d service."
+      "description": "Server-side CAD processing with PMI/MBD extraction. Planned feature - requires external service."
     },
     "externalServiceNote": "This feature requires an external service. See the Self-Hosting Guide for deployment instructions."
   }

--- a/src/i18n/locales/nl/admin.json
+++ b/src/i18n/locales/nl/admin.json
@@ -659,7 +659,7 @@
     },
     "advancedCAD": {
       "label": "Geavanceerde CAD (PMI/MBD)",
-      "description": "Server-side CAD-verwerking met PMI/MBD-extractie. Vereist externe eryxon3d-service."
+      "description": "Server-side CAD-verwerking met PMI/MBD-extractie. Geplande functie - vereist externe service."
     },
     "externalServiceNote": "Deze functie vereist een externe service. Zie de Self-Hosting Guide voor implementatie-instructies."
   }

--- a/website/src/content/docs/architecture/3d-engine.md
+++ b/website/src/content/docs/architecture/3d-engine.md
@@ -1,37 +1,40 @@
 ---
 title: "3D CAD Engine"
-description: "3D rendering architecture and PMI strategy"
+description: "Browser-based 3D rendering for STEP CAD files"
 ---
 
-:::caution[Work in Progress]
-Server-side PMI extraction is in **alpha** and not production-ready. The client-side 3D viewer works.
-:::
+Browser-based 3D CAD viewing for STEP files using Three.js and occt-import-js WASM parser.
 
-Flexible 3D CAD viewing architecture for metals manufacturing.
+## Architecture
 
-## Client-Side Rendering (Default)
-
-Recommended for production. Three.js + occt-import-js WASM parser.
+All 3D rendering happens client-side in the browser. No server-side CAD processing.
 
 - **Formats:** .step, .stp
+- **Parser:** occt-import-js (WASM-based STEP parser)
+- **Renderer:** Three.js WebGL
 - **Controls:** Zoom, orbit, pan, exploded view, wireframe
-- **PMI:** Not supported in client-side viewer
 - **Infrastructure:** None required - runs entirely in browser
 
 See [3D Viewer Guide](/guides/3d-viewer/) for usage.
 
-## Server-Side PMI Extraction (Alpha)
+## Technical Stack
 
-Experimental backend for extracting dimensions and tolerances from STEP AP242 files.
+| Component | Technology |
+|-----------|------------|
+| 3D Rendering | Three.js |
+| STEP Parsing | occt-import-js (WASM) |
+| Controls | OrbitControls |
+| Storage | Supabase Storage with RLS |
+| File Handling | Client-side blob fetch |
 
-- **Status:** Alpha - not production ready
-- **Approach:** Text parsing of STEP structures
-- **Usage:** Quality checks, operation planning automation
+## Limitations
 
-See [PMI Extraction](/features/pmi-extraction/) for details.
+- **File size:** Recommended < 10MB (max 50MB)
+- **Formats:** .step/.stp only
+- **PMI:** Manufacturing annotations not extracted (planned feature)
 
 ## Extensibility
 
-Bring your own engine:
-- **FreeCAD:** Server-side processing
-- **CAD Exchanger:** Multi-format + PMI (commercial license)
+Eryxon Flow uses browser-based rendering by design for simplicity and zero infrastructure requirements. For advanced use cases requiring PMI extraction or server-side processing, this is on the roadmap as a planned feature.
+
+See [Roadmap](/roadmap/) for planned features.

--- a/website/src/content/docs/features/batch-operations.md
+++ b/website/src/content/docs/features/batch-operations.md
@@ -4,7 +4,7 @@ description: "Group operations for laser nesting, tube batching, and finishing"
 ---
 
 :::caution[Work in Progress]
-This feature is under active development and **not production-ready**. Schema and APIs may change.
+This feature is under active development. Schema and APIs may change.
 :::
 
 Batch operations group multiple parts processed together - laser nesting, tube cutting, saw programs, finishing batches.

--- a/website/src/content/docs/features/flexible-metadata.md
+++ b/website/src/content/docs/features/flexible-metadata.md
@@ -4,7 +4,7 @@ description: "Custom fields for jobs, parts, operations, and resources"
 ---
 
 :::caution[Work in Progress]
-This feature is under active development and **not production-ready**. Schema and APIs may change.
+This feature is under active development. Schema and APIs may change.
 :::
 
 Store custom data on jobs, parts, operations, and resources via JSONB `metadata` fields. Includes templates for common manufacturing scenarios.

--- a/website/src/content/docs/features/pmi-extraction.md
+++ b/website/src/content/docs/features/pmi-extraction.md
@@ -1,81 +1,54 @@
 ---
 title: "PMI Extraction"
-description: "Extract manufacturing annotations from STEP CAD files"
+description: "Extract manufacturing annotations from STEP CAD files (Planned)"
 ---
 
-:::caution[Alpha Feature]
-Currently in **ALPHA** - not recommended for production. Use the default browser-based [3D Viewer](/guides/3d-viewer/) for now.
+:::note[Planned Feature]
+PMI extraction is currently **PLANNED** and not yet available. Use the browser-based [3D Viewer](/guides/3d-viewer/) for viewing STEP files.
 :::
 
-Extract Product Manufacturing Information (PMI) from STEP AP242 files with fallback support for AP203/AP214 legacy formats.
+Product Manufacturing Information (PMI) extraction will enable automatic reading of dimensions, tolerances, and annotations directly from STEP CAD files.
 
-**Extracted annotations:** Dimensions, GD&T tolerances, datums, surface finishes (Ra/Rz), weld symbols, notes
+## What is PMI?
 
-## Architecture
+PMI (Product Manufacturing Information) includes manufacturing annotations embedded in CAD files:
 
-Frontend (React + Three.js) → Backend (Python/FastAPI) → Text parser → 7 specialized extractors
+- **Dimensions:** Linear, angular, diameter, radius measurements
+- **GD&T Tolerances:** Geometric dimensioning and tolerancing symbols
+- **Datums:** Reference labels (A, B, C) for measurements
+- **Surface Finishes:** Ra/Rz roughness values
+- **Weld Symbols:** Fillet, groove, spot weld annotations
+- **Notes:** Manufacturing instructions
 
-Backend modes: `custom` (Eryxon3D Docker), `byob` (Bring Your Own), `frontend` (browser-only fallback)
+## Planned Capabilities
 
-## Extractors
+When implemented, PMI extraction will:
 
-| Extractor | Output |
-|-----------|--------|
-| Dimension | Linear, angular, diameter, radius |
-| Tolerance | GD&T symbols with datum refs |
-| Datum | Reference labels (A, B, C) |
-| SurfaceFinish | Ra, Rz values |
-| WeldSymbol | Fillet, groove, spot welds |
-| AP203/AP214 | Graphical PMI for legacy files |
+- Read semantic PMI data from STEP AP242 files
+- Support legacy graphical PMI from AP203/AP214 files
+- Display annotations overlaid on the 3D model
+- Enable automatic quality checks from CAD tolerances
+- Assist with operation planning by extracting critical dimensions
 
-## GD&T Symbols (ASME Y14.5 / ISO 1101)
-
-| Type | Symbol | Type | Symbol |
-|------|--------|------|--------|
-| Flatness | ⏥ | Perpendicularity | ⊥ |
-| Circularity | ○ | Position | ⌖ |
-| Cylindricity | ⌭ | Concentricity | ◎ |
-| Profile (Surface) | ⌓ | Runout | ↗ |
-
-**Modifiers:** Ⓜ (MMC), Ⓛ (LMC)
-
-## Configuration
-
-```bash
-VITE_CAD_SERVICE_URL=http://localhost:8888
-VITE_CAD_SERVICE_API_KEY=your-api-key
-VITE_CAD_BACKEND_MODE=custom  # custom | byob | frontend
-```
-
-## Visualization
-
-PMI overlay via CSS2DRenderer with leader lines. Color-coded by type:
-- **Cyan:** Dimensions | **Purple:** GD&T | **Green:** Datums
-- **Orange:** Surface | **Red:** Welds | **Slate:** Notes
-
-## File Format Support
+## File Format Support (Planned)
 
 | Format | PMI Support |
 |--------|-------------|
-| STEP AP242 | ✅ Full semantic PMI |
-| STEP AP214/AP203 | ⚠️ Graphical only |
-| IGES | ❌ None |
+| STEP AP242 | Full semantic PMI |
+| STEP AP214/AP203 | Graphical annotations only |
+| IGES | No PMI support |
 
-## API
+## Use Cases
 
-```http
-POST /process
-X-API-Key: your-api-key
+- **Quality Control:** Compare actual measurements against CAD tolerances
+- **Operation Planning:** Auto-populate inspection requirements
+- **Manufacturing Prep:** Extract critical dimensions for setup sheets
+- **Documentation:** Generate inspection reports from CAD data
 
-{ "file_url": "...", "include_pmi": true }
-```
+## Current Status
 
-Returns geometry meshes + PMI data (dimensions, tolerances, datums, surface finishes).
+This feature is on the roadmap. See [Roadmap](/roadmap/) for development priorities.
 
-## Limitations
-
-- PMI positions default to origin if no annotation placement data
-- AP203/AP214 files contain graphical (presentation) PMI only
-- Composite tolerances may not render all modifier symbols
+For now, use the [3D Viewer](/guides/3d-viewer/) to view STEP geometry without PMI annotations.
 
 See also: [3D Viewer Guide](/guides/3d-viewer/), [3D Engine Architecture](/architecture/3d-engine/)

--- a/website/src/content/docs/features/shipping-management.md
+++ b/website/src/content/docs/features/shipping-management.md
@@ -4,7 +4,7 @@ description: "Internal logistics for completed jobs"
 ---
 
 :::caution[Work in Progress]
-This feature is under active development and **not production-ready**. Schema and APIs may change.
+This feature is under active development. Schema and APIs may change.
 :::
 
 Shipping module for production logistics - group completed jobs by destination, assign to vehicles, track delivery. Not an ERP shipping system.

--- a/website/src/content/docs/guides/self-hosting.md
+++ b/website/src/content/docs/guides/self-hosting.md
@@ -3,33 +3,46 @@ title: "Self-Hosting Guide"
 description: "Deploy Eryxon Flow on your own infrastructure"
 ---
 
-Self-host Eryxon Flow on your own infrastructure. Free and unlimited.
+Self-host Eryxon Flow on your own infrastructure.
 
 See also: [Edge Functions Setup](/api/edge_functions_setup/), [MCP Integration](/api/mcp_integration/)
 
 > [!IMPORTANT]
-> **License & Usage:** Eryxon Flow is licensed under **BSL 1.1**. This means you are free to self-host, modify, and use it for your own business operations. However, you are **not** permitted to commercially resell the software or provide it as a competing SaaS offering. The license converts to Apache 2.0 after 4 years.
+> **License & Usage:** Eryxon Flow is licensed under **BSL 1.1**. You can self-host, modify, and use it for your own business operations. You cannot commercially resell the software or provide it as a competing SaaS offering. The license converts to Apache 2.0 after 4 years.
 
 ---
 
 ## Deployment Options
 
-| Option | Complexity | Best For |
-|--------|------------|----------|
-| **Supabase Cloud + Docker** | Easy | Most users, quick setup |
-| **Self-Hosted Supabase** | Advanced | Full control, air-gapped environments |
+| Option | Complexity | Disk Space | Best For |
+|--------|------------|------------|----------|
+| **Cloud Supabase + App Container** | Easy | ~500MB | **Recommended** - Most users |
+| **Fully Self-Hosted (All Services)** | Advanced | ~20GB+ | Air-gapped environments, full infrastructure control |
+
+**We recommend using Cloud Supabase** for the database and backend services. This guide focuses on that approach first.
 
 ---
 
-## Option 1: Supabase Cloud (Recommended)
+## Option 1: Cloud Supabase + App Container (Recommended)
 
-The fastest way to get started. Supabase offers a free tier that works for evaluation and small deployments.
+This approach deploys the Eryxon Flow app container on your infrastructure while using Supabase Cloud for the database and backend services.
+
+**Why this approach?**
+- Minimal disk space (~500MB vs 20GB+ for full self-hosting)
+- No database maintenance (Supabase handles backups, updates, scaling)
+- Free tier available (suitable for evaluation and small deployments)
+- Your app still runs on your infrastructure (Cloudflare Pages, Docker, VPS, etc.)
+
+**What runs where:**
+- **Your infrastructure:** Eryxon Flow app container (React frontend)
+- **Supabase Cloud:** PostgreSQL database, Auth, Storage, Realtime, Edge Functions
 
 ### Prerequisites
 
 - Node.js 18+ and npm (or Docker)
 - A Supabase account ([supabase.com](https://supabase.com))
 - Git
+- Optional: Docker for containerized deployment
 
 ### Step 1: Create Supabase Project
 
@@ -98,34 +111,47 @@ If missing, create them with:
 - **File size limit:** 50MB
 - **Allowed MIME types:** `image/*`, `application/pdf`, `model/step`
 
-### Step 6: Run the Application
+### Step 6: Deploy the App
 
-**Option A: Docker (Recommended)**
+**Recommended: Docker Container**
+
+The easiest deployment method is using the provided Docker container:
+
 ```bash
-
+# Configure environment
 cat > .env << EOF
 VITE_SUPABASE_URL=https://your-project-id.supabase.co
 VITE_SUPABASE_PUBLISHABLE_KEY=your-anon-key
 EOF
 
+# Start container
+docker compose up -d
 
-docker-compose up -d
+# Verify deployment
+docker compose ps
 ```
 
-**Option B: Development mode**
+**Access:** http://localhost (or your configured domain on port 80)
+
+**Alternative: Development Mode**
+
+For local development or testing:
+
 ```bash
 cp .env.example .env
-
+# Edit .env with your Supabase credentials
 
 npm install
 npm run dev
-
 ```
 
-**Option C: Production build**
+**Alternative: Static Build**
+
+For deployment to CDN/static hosting:
+
 ```bash
 npm run build
-
+# Output in dist/ directory
 ```
 
 ### Step 7: Create Your First User
@@ -138,17 +164,24 @@ npm run build
 
 ---
 
-## Option 2: Fully Self-Hosted (Air-Gapped)
+## Option 2: Fully Self-Hosted (All Services)
 
-For organizations requiring complete control over all infrastructure.
+**Only use this option if you need:**
+- Completely air-gapped deployment (no internet access)
+- Full control over all infrastructure components
+- Custom Supabase modifications
 
-### Prerequisites
+### Requirements
 
-- Docker and Docker Compose
-- 4GB+ RAM
-- 20GB+ disk space
-- Domain name (for production)
-- SSL certificates
+| Resource | Minimum | Recommended |
+|----------|---------|-------------|
+| RAM | 4GB | 8GB+ |
+| Disk Space | 20GB | 50GB+ |
+| CPU Cores | 2 | 4+ |
+
+**Important:** Supabase runs 10+ Docker containers (PostgreSQL, Auth, Storage, Realtime, Kong, Studio, etc.). This requires significant disk space and system resources.
+
+**For most users, we recommend Cloud Supabase instead.**
 
 ### Architecture
 
@@ -156,46 +189,64 @@ For organizations requiring complete control over all infrastructure.
 +----------------------------------------------------------+
 |                      Your Server                          |
 +----------------------------------------------------------+
+|  10+ Supabase Containers:                                |
 |  +---------+  +---------+  +----------+  +----------+    |
 |  | Postgres|  | GoTrue  |  |PostgREST |  | Realtime |    |
 |  |   DB    |  |  Auth   |  |   API    |  |   WS     |    |
 |  +---------+  +---------+  +----------+  +----------+    |
-|  +---------+  +---------+  +----------+                  |
-|  | Storage |  |  Kong   |  |  Studio  |                  |
-|  |   API   |  | Gateway |  | (Admin)  |                  |
-|  +---------+  +---------+  +----------+                  |
+|  +---------+  +---------+  +----------+  +----------+    |
+|  | Storage |  |  Kong   |  |  Studio  |  | imgproxy |    |
+|  |   API   |  | Gateway |  | (Admin)  |  |          |    |
+|  +---------+  +---------+  +----------+  +----------+    |
+|  + 6 more containers (Vector, Logflare, etc.)            |
 +----------------------------------------------------------+
 |  +------------------------------------------------------+|
-|  |              Eryxon Flow (Frontend)                  ||
+|  |              Eryxon Flow App Container               ||
 |  +------------------------------------------------------+|
 +----------------------------------------------------------+
 ```
 
-### Step 1: Clone Supabase Docker Setup
+### Step 1: Setup Supabase Docker
+
+The `supabase-docker/` directory contains the complete Supabase stack:
 
 ```bash
-git clone --depth 1 https://github.com/supabase/supabase
-cd supabase/docker
+cd supabase-docker
 cp .env.example .env
 ```
 
-### Step 2: Configure Environment
+### Step 2: Generate Secrets and Configure
 
-Edit `.env`:
+**Generate secure secrets:**
+
+```bash
+cd supabase-docker
+
+# Generate secrets using provided script
+bash utils/generate-keys.sh
+
+# OR manually edit .env with your own secrets
+nano .env
+```
+
+**Critical settings to change in `.env`:**
+
 ```env
+# MUST CHANGE - Database password
+POSTGRES_PASSWORD=your-super-secret-password
 
-POSTGRES_PASSWORD=your-secure-password
-JWT_SECRET=your-jwt-secret-min-32-chars
+# MUST CHANGE - JWT secret (32+ characters)
+JWT_SECRET=your-super-secret-jwt-token-with-at-least-32-characters
 
+# MUST CHANGE - Dashboard credentials
+DASHBOARD_USERNAME=your-admin-username
+DASHBOARD_PASSWORD=your-secure-dashboard-password
 
-ANON_KEY=your-anon-key
-SERVICE_ROLE_KEY=your-service-role-key
+# Update for your domain (or use localhost for local testing)
+SITE_URL=http://localhost:3000
+API_EXTERNAL_URL=http://localhost:8000
 
-
-SITE_URL=https://your-domain.com
-API_EXTERNAL_URL=https://your-domain.com
-
-
+# Email configuration (optional for testing, required for auth)
 SMTP_HOST=smtp.your-provider.com
 SMTP_PORT=587
 SMTP_USER=your-smtp-user
@@ -203,36 +254,74 @@ SMTP_PASS=your-smtp-password
 SMTP_SENDER_NAME=Eryxon Flow
 ```
 
+See `supabase-docker/README.md` for full configuration details.
+
 ### Step 3: Start Supabase Services
 
 ```bash
+# From supabase-docker directory
 docker compose up -d
-docker compose ps  # Verify all services running
+
+# Verify all containers are running (should see 10+ containers)
+docker compose ps
+
+# Check logs if any services fail
+docker compose logs
 ```
 
-### Step 4: Apply Schema and Deploy App
+**First startup takes 5-10 minutes** as Docker pulls all images.
+
+### Step 4: Apply Database Schema
+
+From the main Eryxon Flow directory:
 
 ```bash
-
-
-
 cd /path/to/eryxon-flow
+
+# Install Supabase CLI if not already installed
+npm install -g supabase
+
+# Apply migrations to local Supabase
+# (Use connection details from supabase-docker/.env)
+supabase db push --db-url "postgresql://postgres:your-password@localhost:5432/postgres"
+```
+
+### Step 5: Deploy Eryxon Flow App
+
+```bash
+# Configure app to connect to local Supabase
 cat > .env << EOF
-VITE_SUPABASE_URL=https://your-domain.com
-VITE_SUPABASE_PUBLISHABLE_KEY=your-anon-key
+VITE_SUPABASE_URL=http://localhost:8000
+VITE_SUPABASE_PUBLISHABLE_KEY=<ANON_KEY from supabase-docker/.env>
 EOF
 
-docker build -t eryxon-flow .
-docker run -p 3000:80 --env-file .env eryxon-flow
+# Build and run app container
+docker compose up -d
 ```
+
+**Access points:**
+- **App:** http://localhost (port 80)
+- **Supabase Studio:** http://localhost:8000 (admin dashboard)
+- **Database:** localhost:5432
 
 ### Production Checklist
 
-- [ ] SSL/TLS configured (Let's Encrypt)
-- [ ] PostgreSQL backups scheduled
-- [ ] Monitoring set up
-- [ ] Email delivery configured
-- [ ] Security review completed
+- [ ] **Disk space monitoring** - Supabase containers + PostgreSQL data grow over time (plan for 50GB+)
+- [ ] **PostgreSQL backups** - Schedule automated backups (critical!)
+- [ ] **SSL/TLS configured** - Use reverse proxy (Caddy/Nginx) with Let's Encrypt
+- [ ] **Secrets changed** - All default passwords and keys updated
+- [ ] **Email delivery** - SMTP configured for auth emails
+- [ ] **Resource monitoring** - Track RAM/CPU usage (10+ containers)
+- [ ] **Log rotation** - Configure Docker log limits to prevent disk fill
+- [ ] **Security review** - Firewall rules, exposed ports, network isolation
+
+**Disk Space Breakdown:**
+- Supabase Docker images: ~5GB
+- PostgreSQL data (grows with usage): 1-50GB+
+- Logs and temp files: 1-5GB
+- App container: ~500MB
+
+**Minimum recommended**: 50GB free disk space for small deployments.
 
 ---
 

--- a/website/src/content/docs/roadmap.md
+++ b/website/src/content/docs/roadmap.md
@@ -1,30 +1,30 @@
 ---
 title: "Roadmap"
-description: "Development roadmap and planned features"
+description: "Development roadmap and feature status"
 ---
 
-Current development priorities and planned features.
+Feature status for Eryxon Flow v0.1 alpha.
 
 ## Status Overview
 
 | Status | Meaning |
 |--------|---------|
-| ✅ **Stable** | Production-ready |
-| 🚧 **WIP** | Under development, not production-ready |
+| ✅ **Implemented** | Available and functional |
+| 🚧 **WIP** | Under active development |
 | 📋 **Planned** | On the roadmap, not started |
 
 ## Core Features
 
 | Feature | Status | Notes |
 |---------|--------|-------|
-| Job/Part/Operation tracking | ✅ Stable | Core workflow |
-| Operator terminal | ✅ Stable | Real-time work queue |
-| Time tracking | ✅ Stable | Start/pause/stop with history |
-| Issue reporting | ✅ Stable | With photo uploads |
-| 3D STEP viewer (browser) | ✅ Stable | Client-side rendering |
-| CSV import | ✅ Stable | Bulk data import |
-| Employee tracking | ✅ Stable | QRM capacity management |
-| Multi-tenancy | ✅ Stable | Full isolation with RLS |
+| Job/Part/Operation tracking | ✅ Implemented | Core workflow |
+| Operator terminal | ✅ Implemented | Real-time work queue |
+| Time tracking | ✅ Implemented | Start/pause/stop with history |
+| Issue reporting | ✅ Implemented | With photo uploads |
+| 3D STEP viewer (browser) | ✅ Implemented | Client-side rendering |
+| CSV import | ✅ Implemented | Bulk data import |
+| Employee tracking | ✅ Implemented | Capacity management |
+| Multi-tenancy | ✅ Implemented | Row-level security |
 
 ## Work in Progress
 
@@ -33,8 +33,6 @@ Current development priorities and planned features.
 | Batch/Nesting operations | 🚧 WIP | Schema may change |
 | Shipping management | 🚧 WIP | Internal logistics |
 | Flexible metadata | 🚧 WIP | Custom fields system |
-| PMI extraction | 🚧 WIP | Server-side CAD processing |
-| 3D Engine (server) | 🚧 WIP | External CAD processor |
 | MCP integration | 🚧 WIP | AI agent access |
 | MQTT publishing | 🚧 WIP | Industrial messaging |
 | Webhooks | 🚧 WIP | Event notifications |
@@ -46,6 +44,7 @@ Current development priorities and planned features.
 |---------|----------|-------|
 | Code refactor/overhaul | High | Clean up technical debt |
 | Fix existing features | High | Stabilize WIP features |
+| PMI extraction | Medium | Extract manufacturing annotations from STEP files |
 | MCP improvements | Medium | Better AI agent support |
 | Pre-built integrations | Medium | ERP connectors |
 | Mobile app | Low | Native iOS/Android |


### PR DESCRIPTION
Major documentation updates to reflect current architecture and remove references to removed eryxon3d-parser code:

Documentation Updates:
- Update 3D engine docs to clarify browser-only rendering (Three.js + occt-import-js)
- Move PMI extraction from WIP to Planned status in roadmap
- Remove "production-ready" and "stable" language throughout docs
- Update tone for v0.1 alpha release

Self-Hosting Guide:
- Recommend cloud Supabase as default deployment path
- Document disk space requirements for self-hosted (20GB+ minimum)
- Add clear app-only Docker deployment instructions
- Position fully self-hosted as for air-gapped environments only
- Document the two deployment modes (cloud vs fully self-hosted)

Code Cleanup:
- Update CAD backend config comments (WIP -> Planned)
- Remove eryxon3d-parser references from translations
- Update to generic "external service" terminology

CLAUDE.md Updates:
- Add deployment architecture section for AI agents
- Document two deployment modes and their implications
- Add database schema migration guidelines for both modes

Security:
- Verified no hardcoded secrets or credentials
- Confirmed .env files are properly gitignored
- Removed local .env file from supabase-docker/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified PMI Extraction is a planned feature, not yet available
  * Updated 3D rendering documentation to emphasize browser-based client-side processing
  * Restructured self-hosting deployment guide with improved options and setup instructions
  * Refined feature status messaging for batch operations, flexible metadata, and shipping management
  * Refreshed roadmap to reflect current feature status and development priorities

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->