### PR TITLE
fix(db): add RLS policy for tenants table UPDATE

### DIFF
--- a/supabase/migrations/20260119000000_fix_tenants_update_policy.sql
+++ b/supabase/migrations/20260119000000_fix_tenants_update_policy.sql
@@ -1,0 +1,21 @@
+-- Migration: Add UPDATE policy for tenants table
+-- This allows admin users to update their own tenant's configuration
+-- Previously only service_role could update tenants, which prevented
+-- the onboarding modal completion from being persisted.
+
+-- Add UPDATE policy for admins to update their tenant
+CREATE POLICY "Admins can update their tenant"
+ON "public"."tenants"
+FOR UPDATE
+USING (
+  ("id" = "public"."get_user_tenant_id"())
+  AND "public"."has_role"("auth"."uid"(), 'admin'::"public"."app_role")
+)
+WITH CHECK (
+  ("id" = "public"."get_user_tenant_id"())
+  AND "public"."has_role"("auth"."uid"(), 'admin'::"public"."app_role")
+);
+
+-- Add comment explaining the policy
+COMMENT ON POLICY "Admins can update their tenant" ON "public"."tenants"
+IS 'Allows admin users to update their own tenant configuration, including onboarding status';


### PR DESCRIPTION
The onboarding modal completion status was not being persisted because the tenants table RLS policies only allowed SELECT (view) access for authenticated users. Admin users could not update their tenant's onboarding_completed_at field.

This migration adds an UPDATE policy that allows admin users to update their own tenant's configuration, fixing the onboarding modal persistence issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled admin users to update their own tenant configuration, including onboarding status, with proper authorization controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->