### PR TITLE
Fix 404 error on page refresh and direct load

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,6 +8,10 @@
     {
       "source": "/api/mcp/:path*",
       "destination": "/api/mcp/:path*"
+    },
+    {
+      "source": "/((?!api/).*)",
+      "destination": "/index.html"
     }
   ],
   "headers": [


### PR DESCRIPTION
Add catch-all rewrite rule in vercel.json to serve index.html for all non-API routes. This fixes the 404 error when directly loading or refreshing any client-side route.