### PR TITLE
Fix Permissions-Policy header parsing error

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,6 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="X-Content-Type-Options" content="nosniff" />
-    <meta http-equiv="X-Frame-Options" content="DENY" />
-    <meta http-equiv="X-XSS-Protection" content="1; mode=block" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
     <title>eryxon-flow</title>
     <meta name="description" content="Lovable Generated Project" />

--- a/public/_headers
+++ b/public/_headers
@@ -4,7 +4,7 @@
   X-Content-Type-Options: nosniff
   X-XSS-Protection: 1; mode=block
   Referrer-Policy: strict-origin-when-cross-origin
-  Permissions-Policy: camera=(), microphone=(), geolocation=()
+  Permissions-Policy: accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()
 
 # Cache static assets
 /assets/*

--- a/src/config/cadBackend.ts
+++ b/src/config/cadBackend.ts
@@ -77,7 +77,7 @@ const defaultConfig: CADBackendConfig = {
 
   frontend: {
     enabled: true, // Frontend-only mode active
-    wasmUrl: 'https://cdn.jsdelivr.net/npm/occt-import-js@0.0.24/dist/occt-import-js.js',
+    wasmUrl: 'https://cdn.jsdelivr.net/npm/occt-import-js@0.0.23/dist/occt-import-js.js',
     maxFileSize: 50 * 1024 * 1024, // 50MB
   },
 


### PR DESCRIPTION
- Update occt-import-js version from 0.0.24 (non-existent) to 0.0.23
- Remove invalid http-equiv meta tags from index.html that cannot set HTTP headers (X-Frame-Options, X-Content-Type-Options, X-XSS-Protection)
- Update Permissions-Policy header to use recognized features only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Updated WASM processing library to an earlier version for frontend-mode operations

**Chores**
* Removed legacy security header directives from HTML configuration
* Enhanced browser permissions policy to support additional device features including accelerometer, gyroscope, and magnetometer capabilities

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->