### PR TITLE
Fix parent part selection handling in job creation form

### DIFF
--- a/src/pages/admin/JobCreate.tsx
+++ b/src/pages/admin/JobCreate.tsx
@@ -461,16 +461,16 @@ export default function JobCreate() {
                   <div>
                     <Label>{t("parts.parentPartOptional")}</Label>
                     <Select
-                      value={editingPart.parent_part_id}
+                      value={editingPart.parent_part_id || "__none__"}
                       onValueChange={(value) =>
-                        setEditingPart({ ...editingPart, parent_part_id: value })
+                        setEditingPart({ ...editingPart, parent_part_id: value === "__none__" ? undefined : value })
                       }
                     >
                       <SelectTrigger>
                         <SelectValue placeholder={t("parts.none")} />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="">{t("parts.none")}</SelectItem>
+                        <SelectItem value="__none__">{t("parts.none")}</SelectItem>
                         {parts.map((part) => (
                           <SelectItem key={part.id} value={part.id}>
                             {part.part_number}


### PR DESCRIPTION
## Summary
Fixed the parent part optional selection dropdown to properly handle the "none" state by using a sentinel value instead of an empty string.

## Changes
- Changed the "none" option value from an empty string (`""`) to a sentinel value (`"__none__"`)
- Updated the Select component's value binding to use `"__none__"` when `parent_part_id` is undefined
- Modified the `onValueChange` handler to convert the sentinel value back to `undefined` when storing in state

## Implementation Details
This change addresses a common issue with controlled Select components where an empty string value can be ambiguous or cause unexpected behavior. By using a explicit sentinel value (`"__none__"`), we ensure:
- Clear distinction between "no parent part selected" and other states
- Proper round-trip conversion between the UI state and the data model
- More predictable behavior when the parent_part_id is undefined/null

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parent part selector to correctly handle the "no parent" selection option in the part editing interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->