### PR TITLE
fix(auth): restore Cloudflare Turnstile captcha for sign-in/sign-up

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,14 @@ VITE_SUPABASE_PROJECT_ID="your-project-id"
 # VITE_DEFAULT_LANGUAGE="en"
 
 # =============================================================================
+# CAPTCHA CONFIGURATION (Required for auth)
+# =============================================================================
+# Cloudflare Turnstile site key - get from Cloudflare dashboard
+# https://dash.cloudflare.com/?to=/:account/turnstile
+
+VITE_TURNSTILE_SITE_KEY="your-turnstile-site-key"
+
+# =============================================================================
 # CAD PROCESSING SERVICE (Optional)
 # =============================================================================
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
+    "@marsidev/react-turnstile": "^1.1.3",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/src/i18n/locales/de/auth.json
+++ b/src/i18n/locales/de/auth.json
@@ -24,6 +24,8 @@
     "haveAccount": "Haben Sie bereits ein Konto? Melden Sie sich an",
     "fillAllFields": "Bitte füllen Sie alle Felder aus",
     "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten",
+    "captchaRequired": "Bitte vervollständigen Sie die Captcha-Verifizierung",
+    "captchaError": "Captcha-Verifizierung fehlgeschlagen. Bitte versuchen Sie es erneut.",
     "agreeToTerms": "Ich stimme dem",
     "privacyPolicy": "Datenschutzrichtlinie",
     "and": "und den",

--- a/src/i18n/locales/en/auth.json
+++ b/src/i18n/locales/en/auth.json
@@ -24,6 +24,8 @@
     "haveAccount": "Already have an account? Sign in",
     "fillAllFields": "Please fill in all fields",
     "unexpectedError": "An unexpected error occurred",
+    "captchaRequired": "Please complete the captcha verification",
+    "captchaError": "Captcha verification failed. Please try again.",
     "agreeToTerms": "I agree to the",
     "privacyPolicy": "Privacy Policy",
     "and": "and",

--- a/src/i18n/locales/nl/auth.json
+++ b/src/i18n/locales/nl/auth.json
@@ -24,6 +24,8 @@
     "haveAccount": "Heeft u al een account? Meld u aan",
     "fillAllFields": "Vul alle velden in",
     "unexpectedError": "Er is een onverwachte fout opgetreden",
+    "captchaRequired": "Voltooi alstublieft de captcha-verificatie",
+    "captchaError": "Captcha-verificatie mislukt. Probeer het opnieuw.",
     "agreeToTerms": "Ik ga akkoord met het",
     "privacyPolicy": "Privacybeleid",
     "and": "en",


### PR DESCRIPTION
Supabase has captcha protection enabled server-side, but the frontend was not sending captcha tokens, causing authentication failures.

- Add @marsidev/react-turnstile package for Cloudflare Turnstile integration
- Update AuthContext to accept and pass captcha tokens to Supabase auth
- Add Turnstile widget to Auth.tsx with automatic reset on errors
- Add VITE_TURNSTILE_SITE_KEY environment variable
- Add captcha error translations for EN, NL, DE locales