### PR TITLE
Remove App Store from integrations navigation

### DIFF
--- a/src/components/AdminLayout.tsx
+++ b/src/components/AdminLayout.tsx
@@ -19,7 +19,6 @@ import {
   ChevronRight,
   ChevronDown,
   Menu,
-  Store,
   Clock,
   Layers,
   Database,
@@ -210,12 +209,6 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
 
   // Integrations - Developer tools, APIs, and external connections
   const integrationsNavItems = [
-    {
-      path: "/admin/integrations",
-      label: t("navigation.appStore"),
-      icon: Store,
-      exact: true,
-    },
     {
       path: "/admin/config/api-keys",
       label: t("navigation.apiKeys"),

--- a/src/hooks/useFeatureFlags.ts
+++ b/src/hooks/useFeatureFlags.ts
@@ -23,7 +23,7 @@ export interface FeatureFlags {
   analytics: boolean;       // Analytics section: QRM, OEE, Quality, Reliability, Jobs Analytics
   monitoring: boolean;      // Monitoring section: Activity, Expectations, Exceptions
   operatorViews: boolean;   // Operator views: Cell Overview, Terminal, My Activity, My Issues
-  integrations: boolean;    // Integrations: App Store, API Keys, Webhooks, MQTT, etc.
+  integrations: boolean;    // Integrations: API Keys, Webhooks, MQTT, Data Import/Export, etc.
   issues: boolean;          // Issues tracking
   capacity: boolean;        // Capacity planning
   assignments: boolean;     // Assignments management

--- a/src/i18n/locales/de/admin.json
+++ b/src/i18n/locales/de/admin.json
@@ -358,7 +358,7 @@
     },
     "integrations": {
       "label": "Integrationen",
-      "description": "App Store, API-Schlüssel, Webhooks, MQTT und Daten-Import/Export"
+      "description": "API-Schlüssel, Webhooks, MQTT und Daten-Import/Export"
     },
     "issues": {
       "label": "Probleme",

--- a/src/i18n/locales/de/navigation.json
+++ b/src/i18n/locales/de/navigation.json
@@ -42,7 +42,6 @@
     "capacity": "Kapazität",
     "cells": "Zellen",
     "calendar": "Kalender",
-    "appStore": "App Store",
     "mcpSetup": "MCP-Einrichtung",
     "mcpKeys": "MCP-Schlüssel",
     "mcpServer": "MCP-Server",

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -146,7 +146,6 @@
     "capacity": "Kapazität",
     "cells": "Zellen",
     "calendar": "Kalender",
-    "appStore": "App Store",
     "mcpKeys": "MCP-Schlüssel",
     "mcpServer": "MCP-Server",
     "mqttPublishers": "MQTT-Publisher",

--- a/src/i18n/locales/en/admin.json
+++ b/src/i18n/locales/en/admin.json
@@ -441,7 +441,7 @@
     },
     "integrations": {
       "label": "Integrations",
-      "description": "App Store, API Keys, Webhooks, MQTT, and Data Import/Export"
+      "description": "API Keys, Webhooks, MQTT, and Data Import/Export"
     },
     "issues": {
       "label": "Issues",

--- a/src/i18n/locales/en/navigation.json
+++ b/src/i18n/locales/en/navigation.json
@@ -44,7 +44,6 @@
     "capacity": "Capacity",
     "cells": "Cells",
     "calendar": "Calendar",
-    "appStore": "App Store",
     "mcpSetup": "MCP Setup",
     "mcpKeys": "MCP Keys",
     "mcpServer": "MCP Server",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -131,7 +131,6 @@
     "capacity": "Capacity",
     "cells": "Cells",
     "calendar": "Calendar",
-    "appStore": "App Store",
     "mcpKeys": "MCP Keys",
     "mcpServer": "MCP Server",
     "mqttPublishers": "MQTT Publishers",

--- a/src/i18n/locales/nl/admin.json
+++ b/src/i18n/locales/nl/admin.json
@@ -604,7 +604,7 @@
     },
     "integrations": {
       "label": "Integraties",
-      "description": "App Store, API Sleutels, Webhooks, MQTT en Data Import/Export"
+      "description": "API Sleutels, Webhooks, MQTT en Data Import/Export"
     },
     "issues": {
       "label": "Problemen",

--- a/src/i18n/locales/nl/navigation.json
+++ b/src/i18n/locales/nl/navigation.json
@@ -42,7 +42,6 @@
     "capacity": "Capaciteit",
     "cells": "Cellen",
     "calendar": "Kalender",
-    "appStore": "App Winkel",
     "mcpSetup": "MCP Setup",
     "mcpKeys": "MCP-sleutels",
     "mcpServer": "MCP-server",

--- a/src/i18n/locales/nl/translation.json
+++ b/src/i18n/locales/nl/translation.json
@@ -386,7 +386,6 @@
     "capacity": "Capaciteit",
     "cells": "Cellen",
     "calendar": "Kalender",
-    "appStore": "App Winkel",
     "mcpKeys": "MCP-sleutels",
     "mcpServer": "MCP-server",
     "mqttPublishers": "MQTT Publishers",


### PR DESCRIPTION
## Summary
This PR removes the App Store navigation item from the Integrations section of the admin panel. The App Store feature is being deprecated and replaced with more focused integration tools.

## Changes Made
- **AdminLayout.tsx**: Removed the App Store navigation item from the `integrationsNavItems` array and removed the unused `Store` icon import
- **useFeatureFlags.ts**: Updated the integrations feature flag comment to reflect the removal of App Store
- **Internationalization**: Removed "appStore" translation keys and updated integrations section descriptions across all supported languages:
  - English (en)
  - German (de)
  - Dutch (nl)

## Details
The integrations section now focuses on core integration tools: API Keys, Webhooks, MQTT, and Data Import/Export. The App Store navigation entry and its associated translations have been completely removed from the codebase.

All language files have been consistently updated to remove references to the App Store while maintaining the descriptions of remaining integration features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * App Store integration option has been removed from the admin dashboard navigation sidebar.
  * Feature descriptions updated to exclude App Store references.

* **Documentation & Localization**
  * Updated navigation labels and integration descriptions across English, German, and Dutch language locales.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->