### PR TITLE
Make documentation URL configurable for self-hosters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,12 @@ VITE_SUPABASE_PROJECT_ID="your-project-id"
 VITE_TURNSTILE_SITE_KEY="your-turnstile-site-key"
 
 # =============================================================================
+# DOCUMENTATION URL (Optional - for self-hosters)
+# =============================================================================
+# Override the documentation URL if you host your own docs
+# VITE_DOCS_URL="https://eryxon.eu"
+
+# =============================================================================
 # CAD PROCESSING SERVICE (Optional)
 # =============================================================================
 

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -1067,9 +1067,9 @@ API access is governed by your subscription plan:
 ## Support
 
 For API support:
-- Documentation: https://docs.eryxon.com
-- Email: api-support@eryxon.com
-- Status Page: https://status.eryxon.com
+- Documentation: https://docs.eryxon.eu
+- Email: api-support@eryxon.eu
+- Status Page: https://status.eryxon.eu
 
 ---
 

--- a/src/components/AdminLayout.tsx
+++ b/src/components/AdminLayout.tsx
@@ -1,4 +1,5 @@
 import { useAuth } from "@/contexts/AuthContext";
+import { DOCS_GUIDES_URL } from "@/lib/config";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
@@ -284,7 +285,7 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
   // External links (open in new tab)
   const externalLinks = [
     {
-      href: "https://flow.eryxon.io/guides/",
+      href: DOCS_GUIDES_URL,
       label: t("navigation.docsAndHelp"),
       icon: BookOpen,
     },

--- a/src/components/operator/OperatorLayout.tsx
+++ b/src/components/operator/OperatorLayout.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { DOCS_GUIDES_URL } from '@/lib/config';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
@@ -186,7 +187,7 @@ export const OperatorLayout = ({ children, showBackToAdmin = false }: OperatorLa
                     asChild
                     className="gap-1.5 cursor-pointer focus:bg-white/5 text-xs"
                   >
-                    <a href="https://flow.eryxon.io/guides/" target="_blank" rel="noopener noreferrer">
+                    <a href={DOCS_GUIDES_URL} target="_blank" rel="noopener noreferrer">
                       <HelpCircle className="h-3.5 w-3.5" />
                       {t('common.helpAndDocs')}
                     </a>

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,13 @@
+/**
+ * Application Configuration
+ *
+ * External URLs and other configurable settings.
+ * Self-hosters can override these via environment variables.
+ */
+
+// Documentation site URL - self-hosters can point to their own docs
+export const DOCS_URL = import.meta.env.VITE_DOCS_URL || 'https://eryxon.eu';
+
+// Convenience exports for common doc paths
+export const DOCS_GUIDES_URL = `${DOCS_URL}/guides/`;
+export const DOCS_ERP_INTEGRATION_URL = `${DOCS_URL}/features/erp-integration/`;

--- a/src/pages/admin/DataImport.tsx
+++ b/src/pages/admin/DataImport.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef } from "react";
 import { Link } from "react-router-dom";
+import { DOCS_ERP_INTEGRATION_URL } from "@/lib/config";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
@@ -411,7 +412,7 @@ export default function DataImport() {
         <AlertTitle>Need Help?</AlertTitle>
         <AlertDescription className="flex flex-wrap items-center gap-3 mt-2">
           <span className="text-sm">Learn more about data sync options:</span>
-          <a href="https://flow.eryxon.io/features/erp-integration/" target="_blank" rel="noopener noreferrer">
+          <a href={DOCS_ERP_INTEGRATION_URL} target="_blank" rel="noopener noreferrer">
             <Button variant="outline" size="sm" className="h-7 gap-1.5">
               <HelpCircle className="h-3.5 w-3.5" />
               ERP Integration Guide

--- a/src/pages/common/About.tsx
+++ b/src/pages/common/About.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { Card, CardContent } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
+import { DOCS_GUIDES_URL } from "@/lib/config";
 
 export default function About() {
   return (
@@ -32,7 +33,7 @@ export default function About() {
       <div className="space-y-2">
         <p className="text-sm text-muted-foreground">
           <a
-            href="https://flow.eryxon.io/guides/"
+            href={DOCS_GUIDES_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="hover:underline"

--- a/src/pages/common/ApiDocs.tsx
+++ b/src/pages/common/ApiDocs.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { DOCS_GUIDES_URL } from "@/lib/config";
 import SwaggerUI from "swagger-ui-react";
 import "swagger-ui-react/swagger-ui.css";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -430,7 +431,7 @@ apiClient.post('/api-jobs', jobData)
                   CSV Import Wizard
                 </Button>
               </Link>
-              <a href="https://flow.eryxon.io/guides/" target="_blank" rel="noopener noreferrer">
+              <a href={DOCS_GUIDES_URL} target="_blank" rel="noopener noreferrer">
                 <Button variant="outline" size="sm" className="gap-2">
                   <HelpCircle className="h-4 w-4" />
                   Documentation

--- a/supabase/functions/send-invitation/index.ts
+++ b/supabase/functions/send-invitation/index.ts
@@ -6,8 +6,8 @@
  *
  * Required environment variables:
  * - RESEND_API_KEY: Your Resend API key
- * - APP_URL: Your application URL (e.g., https://app.eryxon.com)
- * - EMAIL_FROM: Sender email address (e.g., noreply@eryxon.com)
+ * - APP_URL: Your application URL (e.g., https://app.eryxon.eu)
+ * - EMAIL_FROM: Sender email address (e.g., noreply@eryxon.eu)
  */
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'


### PR DESCRIPTION
## Summary
This PR makes the documentation URL configurable via environment variables, allowing self-hosters to point to their own documentation instead of the default Eryxon docs. It also updates all hardcoded domain references from `.com` to `.eu`.

## Key Changes
- **New configuration module** (`src/lib/config.ts`): Created a centralized config file that exports documentation URLs with support for the `VITE_DOCS_URL` environment variable
- **Environment variable support**: Added `VITE_DOCS_URL` to `.env.example` with documentation for self-hosters
- **Centralized URL management**: Replaced all hardcoded documentation links with imports from the new config module:
  - `AdminLayout.tsx`: Updated guides link
  - `OperatorLayout.tsx`: Updated help & docs link
  - `DataImport.tsx`: Updated ERP integration guide link
  - `About.tsx`: Updated guides link
  - `ApiDocs.tsx`: Updated documentation link
- **Domain updates**: Changed all references from `eryxon.com` to `eryxon.eu` across:
  - API documentation
  - Email addresses
  - Status page URLs
  - Example environment variables in Supabase functions

## Implementation Details
- The config module provides convenience exports (`DOCS_GUIDES_URL`, `DOCS_ERP_INTEGRATION_URL`) that construct full URLs from the base `DOCS_URL`
- Defaults to `https://eryxon.eu` if `VITE_DOCS_URL` is not set
- Self-hosters can override by setting `VITE_DOCS_URL` in their environment
- All changes are backward compatible with existing deployments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Centralized documentation URL configuration for improved maintainability and flexibility across the application.
  * Updated all references to documentation guides and integration resources to use the new centralized configuration system.

* **Documentation**
  * Updated support contact information with current domain and contact endpoints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->