### PR TITLE
Add live demo links throughout app and documentation

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,5 +1,7 @@
 # Deployment Guide
 
+> **Want to try it first?** Check out the [live demo at app.eryxon.eu](https://app.eryxon.eu) before deploying your own instance.
+
 ## Quick Start (Automated)
 
 The fastest way to deploy Eryxon MES:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Manufacturing Execution System (MES) for job shops and make-to-order manufacturers. Track jobs through production, give operators tablet-friendly work queues, and integrate with your ERP.
 
+**[Live Demo](https://app.eryxon.eu)** · [Documentation](https://eryxon.eu) · [GitHub](https://github.com/SheetMetalConnect/eryxon-flow)
+
 ## Who It's For
 
 **Job shops** running high-mix, low-volume production — sheet metal, machine shops, custom fabrication. If you're tracking thousands of unique parts through multiple operations, this is built for you.

--- a/src/i18n/locales/de/admin.json
+++ b/src/i18n/locales/de/admin.json
@@ -259,6 +259,7 @@
     "hostedDemo": {
       "name": "Gehostete Demo",
       "description": "Online ausprobieren mit begrenzter Nutzung",
+      "tryDemo": "Live-Demo testen",
       "note": "Nur für Evaluation und Bildungszwecke",
       "features": [
         "Begrenzte Aufträge und Teile",

--- a/src/i18n/locales/en/admin.json
+++ b/src/i18n/locales/en/admin.json
@@ -346,6 +346,7 @@
     "hostedDemo": {
       "name": "Hosted Demo",
       "description": "Try it online with limited usage",
+      "tryDemo": "Try Live Demo",
       "note": "For evaluation and educational purposes only",
       "features": [
         "Limited jobs and parts",

--- a/src/i18n/locales/nl/admin.json
+++ b/src/i18n/locales/nl/admin.json
@@ -495,6 +495,7 @@
     "hostedDemo": {
       "name": "Gehoste Demo",
       "description": "Probeer het online met beperkt gebruik",
+      "tryDemo": "Probeer Live Demo",
       "note": "Alleen voor evaluatie en educatieve doeleinden",
       "features": [
         "Beperkte opdrachten en onderdelen",

--- a/src/pages/common/About.tsx
+++ b/src/pages/common/About.tsx
@@ -33,6 +33,15 @@ export default function About() {
       <div className="space-y-2">
         <p className="text-sm text-muted-foreground">
           <a
+            href="https://app.eryxon.eu"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:underline"
+          >
+            Live Demo
+          </a>{" "}
+          ·{" "}
+          <a
             href={DOCS_GUIDES_URL}
             target="_blank"
             rel="noopener noreferrer"

--- a/src/pages/common/Pricing.tsx
+++ b/src/pages/common/Pricing.tsx
@@ -38,6 +38,16 @@ export default function Pricing() {
             <p className="text-xs text-muted-foreground italic">
               {t("pricing.hostedDemo.note")}
             </p>
+            <Button variant="outline" asChild className="w-full">
+              <a
+                href="https://app.eryxon.eu"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {t("pricing.hostedDemo.tryDemo")}
+                <ExternalLink className="h-4 w-4 ml-2" />
+              </a>
+            </Button>
           </CardContent>
         </Card>
 

--- a/website/src/components/override-components/Hero.astro
+++ b/website/src/components/override-components/Hero.astro
@@ -22,11 +22,13 @@ const is404 = Astro.locals.starlightRoute?.id === "404";
     class="hero relative z-10 flex flex-col items-center mx-auto px-4 sm:px-6 lg:px-8 pt-20 pb-35"
   >
     <a
-      href="#" 
+      href="https://app.eryxon.eu"
+      target="_blank"
+      rel="noopener noreferrer"
       class="mb-6 inline-flex items-center rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary ring-1 ring-inset ring-primary/20 hover:bg-primary/20 transition-colors"
     >
       <span class="mr-2 inline-block h-2 w-2 rounded-full bg-primary animate-pulse"></span>
-      Beta 0.1 Releasing January 15th 2025
+      Try the Live Demo →
     </a>
     {title && <h1 set:html={title} class="mb-8 text-center rounded-2xl" />}
     {tagline && <p set:html={tagline} class="text-xl text-center" />}

--- a/website/src/config/menu.en.json
+++ b/website/src/config/menu.en.json
@@ -7,6 +7,10 @@
     {
       "name": "Documentation",
       "url": "/introduction/"
+    },
+    {
+      "name": "Live Demo",
+      "url": "https://app.eryxon.eu"
     }
   ],
   "footer": {
@@ -30,6 +34,10 @@
     "help_links": {
       "title": "Resources",
       "links": [
+        {
+          "name": "Live Demo",
+          "url": "https://app.eryxon.eu"
+        },
         {
           "name": "Documentation",
           "url": "/introduction/"

--- a/website/src/config/menu.nl.json
+++ b/website/src/config/menu.nl.json
@@ -7,6 +7,10 @@
         {
             "name": "Documentatie",
             "url": "/nl/introduction/"
+        },
+        {
+            "name": "Live Demo",
+            "url": "https://app.eryxon.eu"
         }
     ],
     "footer": {
@@ -30,6 +34,10 @@
         "help_links": {
             "title": "Bronnen",
             "links": [
+                {
+                    "name": "Live Demo",
+                    "url": "https://app.eryxon.eu"
+                },
                 {
                     "name": "Documentatie",
                     "url": "/nl/introduction/"

--- a/website/src/content/docs/guides/quick-start.md
+++ b/website/src/content/docs/guides/quick-start.md
@@ -7,6 +7,8 @@ description: "Get up and running with Eryxon Flow in minutes."
 
 Get Eryxon Flow running in under 10 minutes.
 
+> **Just want to explore?** Try the [live demo at app.eryxon.eu](https://app.eryxon.eu) — no setup needed. Sign up and start exploring immediately.
+
 ---
 
 ## Prerequisites

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -7,10 +7,14 @@ hero:
     MES for <span class="text-primary">Job Shops</span>
   tagline: The shop floor app your operators will actually use. Real-time job tracking, tablet-friendly terminals, and ERP integration built for custom manufacturing.
   actions:
+    - text: Try Live Demo
+      link: https://app.eryxon.eu
+      icon: external
+      variant: primary
     - text: Get Started
       link: /guides/quick-start/
       icon: right-arrow
-      variant: primary
+      variant: minimal
     - text: View on GitHub
       link: https://github.com/SheetMetalConnect/eryxon-flow
       icon: external
@@ -86,7 +90,8 @@ import LinkButton from "~/components/LinkButton.astro";
 </Grid>
 
 <div class="flex flex-wrap justify-center gap-4 mt-12 pb-12">
-    <LinkButton href="/guides/quick-start/" variant="primary">Start Quick Guide</LinkButton>
+    <LinkButton href="https://app.eryxon.eu" variant="primary">Try Live Demo</LinkButton>
+    <LinkButton href="/guides/quick-start/" variant="minimal">Start Quick Guide</LinkButton>
     <LinkButton href="https://github.com/SheetMetalConnect/eryxon-flow" variant="minimal">Star on GitHub</LinkButton>
 </div>
 

--- a/website/src/content/docs/introduction.md
+++ b/website/src/content/docs/introduction.md
@@ -5,6 +5,8 @@ description: The simple, elegant and powerful manufacturing execution system tha
 
 **The simple, elegant and powerful manufacturing execution system that your people will love to use. Made for metals fabrication.**
 
+> **Try it now:** Explore the [live demo at app.eryxon.eu](https://app.eryxon.eu) — no installation required.
+
 ## What It Does
 
 Eryxon tracks jobs, parts, and tasks through production with a mobile and tablet-first interface. Data comes from your ERP via API.

--- a/website/src/content/sections/call-to-action.md
+++ b/website/src/content/sections/call-to-action.md
@@ -5,10 +5,10 @@ description: Digitize your shop floor and take control of production with Eryxon
 enable: true
 fill_button:
   enable: true
-  label: Get Started
-  link: /getting-started/introduction/quickstart
+  label: Try Live Demo
+  link: https://app.eryxon.eu
 outline_button:
   enable: true
-  label: GitHub
-  link: https://github.com/SheetMetalConnect/eryxon-flow
+  label: Get Started
+  link: /guides/quick-start/
 ---


### PR DESCRIPTION
## Summary
This PR adds prominent links to the live demo at `app.eryxon.eu` across the application and documentation to encourage users to try the system before deploying their own instance.

## Key Changes

**Documentation & Website:**
- Added live demo callout to DEPLOY.md and quick-start guide
- Added live demo link to README.md with other key resources
- Updated website hero section to link to live demo instead of generic "Beta" message
- Added "Live Demo" menu items to navigation (English and Dutch)
- Reordered homepage CTA buttons to prioritize "Try Live Demo" over "Get Started"
- Added intro callouts in documentation pages encouraging demo exploration

**Application UI:**
- Added "Try Live Demo" button to Pricing page's Hosted Demo card
- Added "Live Demo" link to About page footer links
- Added i18n translations for new "tryDemo" button label in English, German, and Dutch

**Implementation Details:**
- All external demo links use `target="_blank"` and `rel="noopener noreferrer"` for security
- Demo links are consistently styled with existing UI components (buttons, links)
- Translations added to all supported language files (en, de, nl)
- CTA button variants adjusted to make demo the primary action on homepage

## Rationale
This change lowers the barrier to entry by allowing potential users to explore the system's capabilities immediately without installation, while still maintaining clear paths to deployment documentation.