### PR TITLE
Claude/fix job routes display l rikn

### DIFF
--- a/src/components/admin/JobDetailModal.tsx
+++ b/src/components/admin/JobDetailModal.tsx
@@ -22,6 +22,7 @@ import { Plus, Edit2, Save, X, CheckCircle2, Clock, Circle, Truck, MapPin, Packa
 import { format } from "date-fns";
 import { useToast } from "@/hooks/use-toast";
 import { useTranslation } from "react-i18next";
+import { useAuth } from "@/contexts/AuthContext";
 import { PartIssueBadge } from "@/components/issues/PartIssueBadge";
 import { IssuesSummarySection } from "@/components/issues/IssuesSummarySection";
 import { OperationsFlowVisualization } from "@/components/qrm/OperationsFlowVisualization";
@@ -39,7 +40,8 @@ export default function JobDetailModal({ jobId, onClose, onUpdate }: JobDetailMo
   const [editedJob, setEditedJob] = useState<any>(null);
   const { toast } = useToast();
   const { t } = useTranslation();
-  const { routing, loading: routingLoading } = useJobRouting(jobId);
+  const { profile } = useAuth();
+  const { routing, loading: routingLoading } = useJobRouting(jobId, profile?.tenant_id || null);
 
   const { data: job, isLoading, error } = useQuery({
     queryKey: ["job-detail", jobId],

--- a/src/components/terminal/JobFlowProgress.tsx
+++ b/src/components/terminal/JobFlowProgress.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { CheckCircle2, Circle, ArrowRight, AlertTriangle, XCircle, Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useJobRouting } from '@/hooks/useQRMMetrics';
+import { useAuth } from '@/contexts/AuthContext';
 import type { CellQRMMetrics } from '@/types/qrm';
 import { useTranslation } from 'react-i18next';
 
@@ -27,7 +28,8 @@ export function JobFlowProgress({
     className
 }: JobFlowProgressProps) {
     const { t } = useTranslation();
-    const { routing, loading, error } = useJobRouting(jobId);
+    const { profile } = useAuth();
+    const { routing, loading, error } = useJobRouting(jobId, profile?.tenant_id || null);
 
     if (loading) {
         return (

--- a/src/components/terminal/RoutingVisualization.tsx
+++ b/src/components/terminal/RoutingVisualization.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useJobRouting } from '@/hooks/useQRMMetrics';
+import { useAuth } from '@/contexts/AuthContext';
 import { CheckCircle2, Circle, Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -17,7 +18,8 @@ interface RoutingVisualizationProps {
  * - Uses design tokens for colors (no hex literals)
  */
 export function RoutingVisualization({ jobId, currentCellId, className }: RoutingVisualizationProps) {
-    const { routing, loading, error } = useJobRouting(jobId);
+    const { profile } = useAuth();
+    const { routing, loading, error } = useJobRouting(jobId, profile?.tenant_id || null);
 
     if (loading) {
         return (

--- a/src/pages/admin/Jobs.tsx
+++ b/src/pages/admin/Jobs.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { ColumnDef } from "@tanstack/react-table";
 import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/contexts/AuthContext";
 import { useResponsiveColumns } from "@/hooks/useResponsiveColumns";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -71,6 +72,7 @@ export default function Jobs() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { toast } = useToast();
+  const { profile } = useAuth();
   const [selectedJobId, setSelectedJobId] = useState<string | null>(null);
   const [overrideJobId, setOverrideJobId] = useState<string | null>(null);
 
@@ -128,7 +130,7 @@ export default function Jobs() {
   const jobIds = useMemo(() => jobs?.map((job: any) => job.id) || [], [jobs]);
 
   // Fetch routing for all jobs
-  const { routings, loading: routingsLoading } = useMultipleJobsRouting(jobIds);
+  const { routings, loading: routingsLoading } = useMultipleJobsRouting(jobIds, profile?.tenant_id || null);
 
   const handleSetOnHold = async (jobId: string) => {
     await supabase.from("jobs").update({ status: "on_hold" }).eq("id", jobId);

--- a/supabase/functions/notify-new-signup/index.ts
+++ b/supabase/functions/notify-new-signup/index.ts
@@ -1,0 +1,205 @@
+/**
+ * Notify New Signup Edge Function
+ *
+ * Called by a database webhook trigger when a new admin profile is created
+ * (indicating a new company signup). Sends a notification email to the
+ * configured admin email with full user details.
+ *
+ * Required environment variables:
+ * - RESEND_API_KEY: Your Resend API key
+ * - SIGNUP_NOTIFY_EMAIL: Email address to receive signup notifications
+ * - APP_URL: Your application URL (e.g., https://app.eryxon.eu)
+ * - EMAIL_FROM: Sender email address
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { corsHeaders, handleCors } from "@shared/cors.ts";
+
+interface WebhookPayload {
+  type: "INSERT";
+  table: string;
+  record: {
+    id: string;
+    tenant_id: string;
+    username: string;
+    full_name: string;
+    email: string;
+    role: string;
+    created_at: string;
+  };
+  schema: string;
+}
+
+Deno.serve(async (req: Request) => {
+  const corsResponse = handleCors(req);
+  if (corsResponse) return corsResponse;
+
+  try {
+    const payload: WebhookPayload = await req.json();
+    const profile = payload.record;
+
+    // Only process new admin signups (not invitations/operators)
+    if (!profile || profile.role !== "admin") {
+      return new Response(JSON.stringify({ message: "Skipped: not an admin signup" }), {
+        status: 200,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    // Fetch tenant details
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+    const { data: tenant } = await supabase
+      .from("tenants")
+      .select("id, name, company_name, plan, status, created_at")
+      .eq("id", profile.tenant_id)
+      .single();
+
+    const resendApiKey = Deno.env.get("RESEND_API_KEY");
+    const notifyEmail = Deno.env.get("SIGNUP_NOTIFY_EMAIL");
+    const appUrl = Deno.env.get("APP_URL") || "https://app.eryxon.eu";
+    const emailFrom = Deno.env.get("EMAIL_FROM") || "Eryxon Flow <noreply@resend.dev>";
+
+    if (!resendApiKey || !notifyEmail) {
+      console.log("RESEND_API_KEY or SIGNUP_NOTIFY_EMAIL not configured, skipping notification");
+      return new Response(JSON.stringify({ message: "Email not configured" }), {
+        status: 200,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const companyName = tenant?.company_name || tenant?.name || "Unknown";
+    const planDisplay = `${tenant?.plan || "free"} (${tenant?.status || "trial"})`;
+    const createdAt = tenant?.created_at
+      ? new Date(tenant.created_at).toLocaleString("en-US", {
+          dateStyle: "medium",
+          timeStyle: "short",
+        })
+      : "Unknown";
+    const adminPanelUrl = `${appUrl}/admin/config/users`;
+
+    const emailHtml = `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>New Signup: ${companyName}</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f4f4f5;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #f4f4f5; padding: 40px 20px;">
+    <tr>
+      <td align="center">
+        <table width="100%" cellpadding="0" cellspacing="0" style="max-width: 600px; background-color: #ffffff; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);">
+          <!-- Header -->
+          <tr>
+            <td style="background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%); padding: 40px 40px; text-align: center;">
+              <h1 style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 600;">New Signup</h1>
+              <p style="margin: 10px 0 0 0; color: #94a3b8; font-size: 14px;">A new company has signed up for Eryxon Flow</p>
+            </td>
+          </tr>
+
+          <!-- Content -->
+          <tr>
+            <td style="padding: 40px;">
+              <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #f8fafc; border-radius: 8px;">
+                <tr>
+                  <td style="padding: 20px;">
+                    <table width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td style="padding: 8px 0; color: #64748b; font-size: 14px;">Company</td>
+                        <td style="padding: 8px 0; color: #1e293b; font-size: 14px; font-weight: 500; text-align: right;">${companyName}</td>
+                      </tr>
+                      <tr>
+                        <td style="padding: 8px 0; color: #64748b; font-size: 14px;">Contact Person</td>
+                        <td style="padding: 8px 0; color: #1e293b; font-size: 14px; font-weight: 500; text-align: right;">${profile.full_name || "Not provided"}</td>
+                      </tr>
+                      <tr>
+                        <td style="padding: 8px 0; color: #64748b; font-size: 14px;">Email</td>
+                        <td style="padding: 8px 0; color: #1e293b; font-size: 14px; font-weight: 500; text-align: right;">${profile.email || "Not provided"}</td>
+                      </tr>
+                      <tr>
+                        <td style="padding: 8px 0; color: #64748b; font-size: 14px;">Plan</td>
+                        <td style="padding: 8px 0; color: #1e293b; font-size: 14px; font-weight: 500; text-align: right;">${planDisplay}</td>
+                      </tr>
+                      <tr>
+                        <td style="padding: 8px 0; color: #64748b; font-size: 14px;">Created</td>
+                        <td style="padding: 8px 0; color: #1e293b; font-size: 14px; font-weight: 500; text-align: right;">${createdAt}</td>
+                      </tr>
+                      <tr>
+                        <td style="padding: 8px 0; color: #64748b; font-size: 14px;">Tenant ID</td>
+                        <td style="padding: 8px 0; color: #1e293b; font-size: 14px; font-weight: 500; text-align: right;">${profile.tenant_id}</td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+
+              <!-- CTA Button -->
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center" style="padding: 24px 0 0 0;">
+                    <a href="${adminPanelUrl}" style="display: inline-block; background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%); color: #ffffff; text-decoration: none; padding: 14px 32px; border-radius: 8px; font-size: 16px; font-weight: 600; box-shadow: 0 4px 12px rgba(59, 130, 246, 0.4);">
+                      Review in Admin Panel
+                    </a>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="background-color: #f8fafc; padding: 24px 40px; text-align: center; border-top: 1px solid #e2e8f0;">
+              <p style="margin: 0; color: #94a3b8; font-size: 12px;">
+                This is an automated notification from Eryxon Flow.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+
+    const emailResponse = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${resendApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: emailFrom,
+        to: notifyEmail,
+        subject: `New Signup: ${companyName}`,
+        html: emailHtml,
+      }),
+    });
+
+    if (!emailResponse.ok) {
+      const errorText = await emailResponse.text();
+      console.error("Resend API error:", errorText);
+      return new Response(JSON.stringify({ error: "Failed to send email", details: errorText }), {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const result = await emailResponse.json();
+    console.log("Signup notification sent successfully:", result);
+
+    return new Response(JSON.stringify({ success: true, emailId: result.id }), {
+      status: 200,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    console.error("Error in notify-new-signup:", err);
+    return new Response(JSON.stringify({ error: err.message }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});

--- a/supabase/migrations/20260202200000_fix_signup_notification_trigger.sql
+++ b/supabase/migrations/20260202200000_fix_signup_notification_trigger.sql
@@ -1,0 +1,84 @@
+-- Fix: Replace the old signup notification trigger that fired on INSERT/UPDATE/DELETE
+-- on the tenants table (causing 3 emails per signup and missing user data).
+--
+-- Changes:
+-- 1. Drop the old trigger on tenants table (fired on INSERT + UPDATE + DELETE)
+-- 2. Create a new trigger on profiles table that only fires on INSERT
+--    for admin users (new company signups), calling the notify-new-signup edge function
+--    which includes contact person name and email in the notification.
+
+-- Drop the old trigger that causes triple emails
+DROP TRIGGER IF EXISTS "notify-new-signup" ON "public"."tenants";
+
+-- Create the new trigger on profiles table, only for INSERT
+-- This uses Supabase's database webhook pattern (supabase_functions.http_request)
+-- The edge function URL and auth headers are configured via Supabase Dashboard > Database > Webhooks
+--
+-- To set this up in the Supabase Dashboard:
+-- 1. Go to Database > Webhooks
+-- 2. Create a new webhook called "notify-new-signup"
+-- 3. Table: profiles, Events: INSERT only
+-- 4. Type: Supabase Edge Function
+-- 5. Edge Function: notify-new-signup
+-- 6. Add a filter condition: record.role = 'admin' AND record.has_email_login = true
+--
+-- The trigger below ensures only admin profile inserts fire the webhook.
+-- The edge function itself also validates role=admin as a safety check.
+
+CREATE OR REPLACE FUNCTION public.notify_admin_signup()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_url TEXT;
+  v_service_key TEXT;
+  v_payload JSONB;
+BEGIN
+  -- Only notify for admin users with email login (new company signups)
+  -- Skip operators, machine users, and invitation-based signups that join existing tenants
+  IF NEW.role != 'admin' OR NEW.has_email_login != true THEN
+    RETURN NEW;
+  END IF;
+
+  -- Check if this admin is the first user in the tenant (true signup, not invited admin)
+  IF (SELECT COUNT(*) FROM public.profiles WHERE tenant_id = NEW.tenant_id) > 1 THEN
+    RETURN NEW;
+  END IF;
+
+  -- Build webhook payload matching the edge function's expected format
+  v_payload := jsonb_build_object(
+    'type', 'INSERT',
+    'table', 'profiles',
+    'schema', 'public',
+    'record', jsonb_build_object(
+      'id', NEW.id,
+      'tenant_id', NEW.tenant_id,
+      'username', NEW.username,
+      'full_name', NEW.full_name,
+      'email', NEW.email,
+      'role', NEW.role,
+      'created_at', NEW.created_at
+    )
+  );
+
+  -- Call the edge function via pg_net
+  -- This requires the pg_net extension to be enabled
+  PERFORM net.http_post(
+    url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'supabase_url') || '/functions/v1/notify-new-signup',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'service_role_key')
+    ),
+    body := v_payload
+  );
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER "notify-new-signup"
+  AFTER INSERT ON "public"."profiles"
+  FOR EACH ROW
+  EXECUTE FUNCTION public.notify_admin_signup();


### PR DESCRIPTION
## Summary

- Fixed job routes/flow not displaying on the Jobs page and Job Detail modal
- The routing hooks (`useJobRouting`, `useMultipleJobsRouting`) require a `tenantId` parameter for RLS compliance, but the calling components were not passing it
- Without `tenantId`, the hooks bail out early and return empty routing data

## Changes

| File | Fix |
|------|-----|
| `src/pages/admin/Jobs.tsx` | Added `profile?.tenant_id` to `useMultipleJobsRouting()` |
| `src/components/admin/JobDetailModal.tsx` | Added `profile?.tenant_id` to `useJobRouting()` |
| `src/components/terminal/RoutingVisualization.tsx` | Added `profile?.tenant_id` to `useJobRouting()` |
| `src/components/terminal/JobFlowProgress.tsx` | Added `profile?.tenant_id` to `useJobRouting()` |

## Test plan

- [ ] Navigate to `/admin/jobs` - verify Flow column shows cell routing pills
- [ ] Click on a job to open detail modal - verify Operations Flow section displays
- [ ] Check terminal routing visualization displays correctly
