### PR TITLE
fix(auth): restore Turnstile on Vercel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,7 @@ VITE_SUPABASE_PROJECT_ID="your-project-id"
 # =============================================================================
 # Cloudflare Turnstile site key - get from Cloudflare dashboard
 # https://dash.cloudflare.com/?to=/:account/turnstile
-# If not set, auth will work without captcha protection
+# If set, public auth forms require Turnstile verification
 
 # VITE_TURNSTILE_SITE_KEY="your-turnstile-site-key"
 

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
             content="Eryxon Flow - Manufacturing Execution System"
         />
         <meta name="theme-color" content="#6366f1" />
-        <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.supabase.co; connect-src 'self' https://*.supabase.co wss://*.supabase.co; font-src 'self' data:; frame-src 'none'; object-src 'none'; base-uri 'self';" />
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.supabase.co https://challenges.cloudflare.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://challenges.cloudflare.com; font-src 'self' data:; frame-src 'self' https://challenges.cloudflare.com; object-src 'none'; base-uri 'self';" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <link rel="apple-touch-icon" href="/favicon.svg" />
     </head>

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -201,6 +201,7 @@ VITE_SUPABASE_PROJECT_ID="${VITE_SUPABASE_PROJECT_ID}"
 
 # Cloudflare Turnstile (Optional)
 VITE_TURNSTILE_SITE_KEY="${VITE_TURNSTILE_SITE_KEY}"
+
 ENVEOF
 
   ok "Created .env file at ${ENV_FILE}"

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -102,7 +102,7 @@ describe('AuthContext', () => {
     mockFrom.mockReturnValue({
       select: vi.fn().mockReturnValue({
         eq: vi.fn().mockReturnValue({
-          single: vi.fn().mockResolvedValue({
+          maybeSingle: vi.fn().mockResolvedValue({
             data: mockProfile,
             error: null,
           }),
@@ -145,6 +145,34 @@ describe('AuthContext', () => {
     it('sets up auth state listener on mount', () => {
       renderHook(() => useAuth(), { wrapper });
       expect(mockOnAuthStateChange).toHaveBeenCalled();
+    });
+
+    it('handles users without a profile row without throwing a 406-style lookup error', async () => {
+      mockGetSession.mockResolvedValue({
+        data: { session: mockSession },
+        error: null,
+      });
+
+      mockFrom.mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: null,
+              error: null,
+            }),
+          }),
+        }),
+      });
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.user?.id).toBe(mockUser.id);
+      expect(result.current.profile).toBeNull();
+      expect(result.current.tenant).toBeNull();
     });
   });
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -98,19 +98,23 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         .from("profiles")
         .select("id, tenant_id, username, full_name, email, role, active, is_machine, is_root_admin")
         .eq("id", userId)
-        .single();
+        .maybeSingle();
 
       if (error) throw error;
-      setProfile(data as Profile);
 
-      if (data) {
-        await fetchTenant();
-        prefetchCommonData(queryClient, data.tenant_id, {
-          fetchCells: () => Promise.resolve(supabase.from('cells').select('*').eq('tenant_id', data.tenant_id).eq('active', true).then(r => r.data)),
-          fetchMaterials: () => Promise.resolve(supabase.from('materials').select('*').eq('tenant_id', data.tenant_id).then(r => r.data)),
-          fetchScrapReasons: () => Promise.resolve(supabase.from('scrap_reasons').select('*').eq('tenant_id', data.tenant_id).then(r => r.data)),
-        });
+      if (!data) {
+        setProfile(null);
+        setTenant(null);
+        return;
       }
+
+      setProfile(data as Profile);
+      await fetchTenant();
+      prefetchCommonData(queryClient, data.tenant_id, {
+        fetchCells: () => Promise.resolve(supabase.from('cells').select('*').eq('tenant_id', data.tenant_id).eq('active', true).then(r => r.data)),
+        fetchMaterials: () => Promise.resolve(supabase.from('materials').select('*').eq('tenant_id', data.tenant_id).then(r => r.data)),
+        fetchScrapReasons: () => Promise.resolve(supabase.from('scrap_reasons').select('*').eq('tenant_id', data.tenant_id).then(r => r.data)),
+      });
     } catch (error) {
       logger.error('AuthContext', 'Error fetching profile', error);
     } finally {

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, lazy, Suspense } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import type { TurnstileInstance } from "@marsidev/react-turnstile";
 import { useAuth } from "@/contexts/AuthContext";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -35,8 +36,7 @@ export default function Auth() {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [captchaToken, setCaptchaToken] = useState<string | null>(null);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const turnstileRef = useRef<any>(null);
+  const turnstileRef = useRef<TurnstileInstance | null>(null);
   const { signIn, signUp, profile } = useAuth();
   const navigate = useNavigate();
 
@@ -260,7 +260,7 @@ export default function Auth() {
                   >
                     {t("auth.agreeToTerms")}{" "}
                     <Link
-                      to="/privacy"
+                      to={ROUTES.COMMON.PRIVACY_POLICY}
                       className="text-primary hover:underline"
                       target="_blank"
                     >
@@ -268,7 +268,7 @@ export default function Auth() {
                     </Link>{" "}
                     {t("auth.and")}{" "}
                     <Link
-                      to="/terms"
+                      to={ROUTES.COMMON.TERMS_OF_SERVICE}
                       className="text-primary hover:underline"
                       target="_blank"
                     >
@@ -295,7 +295,6 @@ export default function Auth() {
               </Alert>
             )}
 
-            {/* Cloudflare Turnstile Captcha — only loaded when VITE_TURNSTILE_SITE_KEY is set */}
             {TURNSTILE_ENABLED && LazyTurnstile && (
               <Suspense fallback={<div className="flex justify-center py-2"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>}>
                 <div className="flex justify-center">

--- a/src/pages/auth/ForgotPassword.tsx
+++ b/src/pages/auth/ForgotPassword.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, lazy, Suspense } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import type { TurnstileInstance } from "@marsidev/react-turnstile";
 import { supabase } from "@/integrations/supabase/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -28,8 +29,7 @@ export default function ForgotPassword() {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
   const [captchaToken, setCaptchaToken] = useState<string | null>(null);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const turnstileRef = useRef<any>(null);
+  const turnstileRef = useRef<TurnstileInstance | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,35 @@
+{
+  "rewrites": [
+    {
+      "source": "/((?!.*\\.).*)",
+      "destination": "/index.html"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.supabase.co https://challenges.cloudflare.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://challenges.cloudflare.com; font-src 'self' data:; frame-src 'self' https://challenges.cloudflare.com; object-src 'none'; base-uri 'self';"
+        }
+      ]
+    }
+  ]
+}

--- a/website/src/content/docs/architecture/app-architecture.md
+++ b/website/src/content/docs/architecture/app-architecture.md
@@ -180,7 +180,7 @@ graph TD
 - JWT tokens with short expiration
 - Auto-refresh mechanism
 - Invitation acceptance and password validation hardening
-- Optional Turnstile protection on public auth flows
+- Optional Turnstile protection on public auth flows, with CSP and hosting config allowing the Cloudflare widget where enabled
 
 **2. Authorization:**
 - Role-based access control (RBAC)

--- a/website/src/content/docs/guides/deployment.md
+++ b/website/src/content/docs/guides/deployment.md
@@ -113,6 +113,7 @@ To enable:
 1. Create a Turnstile widget at [Cloudflare Dashboard](https://dash.cloudflare.com/?to=/:account/turnstile)
 2. Set `VITE_TURNSTILE_SITE_KEY` in your environment
 3. Configure the Turnstile secret key in Supabase Dashboard > Auth > Captcha
+4. On Vercel, keep the repo `vercel.json` so SPA rewrites and CSP headers continue to allow `https://challenges.cloudflare.com`
 
 ## Verification
 

--- a/website/src/content/docs/guides/self-hosting.md
+++ b/website/src/content/docs/guides/self-hosting.md
@@ -331,6 +331,7 @@ Add bot protection to auth forms:
    VITE_TURNSTILE_SITE_KEY="your-site-key"
    ```
 3. Configure secret key in Supabase **Authentication** → **Captcha Protection**
+4. On Vercel, keep the repo `vercel.json` so SPA rewrites and CSP headers continue to allow `https://challenges.cloudflare.com`
 
 ### Redis Caching (Upstash)
 


### PR DESCRIPTION
## Summary
- restore optional Cloudflare Turnstile on auth and password reset flows
- keep the safer auth profile lookup path and the corrected privacy/terms links
- add Vercel SPA rewrite and CSP headers so Turnstile can load from challenges.cloudflare.com
- document the Vercel requirement in deployment and self-hosting docs

## Validation
- npm run build
- npm run test:run
- npm run build (website)
- targeted auth-context test rerun

## Notes
- this fixes the deployed mismatch where Turnstile code existed but the shipped CSP blocked the widget and Vercel had no explicit SPA rewrite for auth routes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing user profiles during authentication flows.

* **New Features**
  * Added support for optional Cloudflare Turnstile CAPTCHA on public authentication forms.

* **Security**
  * Enhanced security headers and content policy configuration for deployments.

* **Documentation**
  * Updated deployment guides with Turnstile configuration and security header instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->