### PR TITLE
fix(viewer): fix STEP parser loading failures

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
             content="Eryxon Flow - Manufacturing Execution System"
         />
         <meta name="theme-color" content="#6366f1" />
-        <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.supabase.co https://challenges.cloudflare.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://challenges.cloudflare.com https://cdn.jsdelivr.net; font-src 'self' data:; frame-src 'self' https://challenges.cloudflare.com; object-src 'none'; base-uri 'self';" />
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.supabase.co https://challenges.cloudflare.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://challenges.cloudflare.com https://cdn.jsdelivr.net; font-src 'self' data:; frame-src 'self' https://challenges.cloudflare.com; object-src 'none'; base-uri 'self';" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <link rel="apple-touch-icon" href="/favicon.svg" />
     </head>

--- a/src/components/STEPViewer.tsx
+++ b/src/components/STEPViewer.tsx
@@ -75,6 +75,7 @@ export function STEPViewer({
   const [stepLoading, setStepLoading] = useState(false);
   const [loadingError, setLoadingError] = useState<string | null>(null);
   const [librariesLoaded, setLibrariesLoaded] = useState(false);
+  const [loadRetryCount, setLoadRetryCount] = useState(0);
   const [wireframeMode, setWireframeMode] = useState(false);
   const [explodedView, setExplodedView] = useState(false);
   const [explosionFactor, setExplosionFactor] = useState(1);
@@ -156,32 +157,44 @@ export function STEPViewer({
     }
 
     const loadOcct = async () => {
-      if (!window.occtimportjs) {
-        const script = document.createElement('script');
-        script.src = occtScriptUrl;
-
-        script.onload = () => {
-          setTimeout(() => {
-            if (window.occtimportjs) {
-              setLibrariesLoaded(true);
-            } else {
-              setLoadingError('Failed to initialize STEP parser');
-            }
-          }, 500);
-        };
-
-        script.onerror = () => {
-          setLoadingError('Failed to load STEP parser library');
-        };
-
-        document.head.appendChild(script);
-      } else {
+      if (window.occtimportjs) {
         setLibrariesLoaded(true);
+        return;
       }
+
+      // Remove any previously failed script tag so retry works
+      const existing = document.querySelector(`script[src="${occtScriptUrl}"]`);
+      if (existing) existing.remove();
+
+      const script = document.createElement('script');
+      script.src = occtScriptUrl;
+
+      script.onload = () => {
+        // Poll for the global to appear instead of a fixed timeout —
+        // WASM init time varies by device/network speed
+        let attempts = 0;
+        const maxAttempts = 40; // 40 × 150ms = 6s max wait
+        const poll = setInterval(() => {
+          attempts++;
+          if (window.occtimportjs) {
+            clearInterval(poll);
+            setLibrariesLoaded(true);
+          } else if (attempts >= maxAttempts) {
+            clearInterval(poll);
+            setLoadingError('Failed to initialize STEP parser');
+          }
+        }, 150);
+      };
+
+      script.onerror = () => {
+        setLoadingError('Failed to load STEP parser library');
+      };
+
+      document.head.appendChild(script);
     };
 
     loadOcct();
-  }, [occtScriptUrl, serverGeometry, preferServerGeometry]);
+  }, [occtScriptUrl, serverGeometry, preferServerGeometry, loadRetryCount]);
 
   useEffect(() => {
     if (!librariesLoaded || !containerRef.current) return;
@@ -1799,7 +1812,7 @@ export function STEPViewer({
                 onClick={() => {
                   setLoadingError(null);
                   setLibrariesLoaded(false);
-                  setTimeout(() => setLibrariesLoaded(true), 100);
+                  setLoadRetryCount(c => c + 1);
                 }}
                 className="text-xs"
               >

--- a/vercel.json
+++ b/vercel.json
@@ -27,7 +27,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.supabase.co https://challenges.cloudflare.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://challenges.cloudflare.com https://cdn.jsdelivr.net; font-src 'self' data:; frame-src 'self' https://challenges.cloudflare.com; object-src 'none'; base-uri 'self';"
+          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.supabase.co https://challenges.cloudflare.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://challenges.cloudflare.com https://cdn.jsdelivr.net; font-src 'self' data:; frame-src 'self' https://challenges.cloudflare.com; object-src 'none'; base-uri 'self';"
         }
       ]
     }


### PR DESCRIPTION
Three issues caused "Failed to load STEP parser library" errors:

1. CSP missing `worker-src blob:` — occt-import-js (Emscripten) creates
   Web Workers from blob URLs which were blocked without this directive

2. Fragile 500ms setTimeout to detect WASM init — replaced with polling
   (up to 6s) so it works reliably on slow devices/connections

3. Retry button was broken — toggling librariesLoaded didn't re-trigger
   the script loading useEffect. Added loadRetryCount to deps and
   cleanup of failed script tags on retry.

https://claude.ai/code/session_01KHtUQ7srb8x3wevwZqXgfs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved STEP parser loading reliability with enhanced retry mechanism and better failure recovery
  * Optimized parser detection to reduce load-related failures

* **Chores**
  * Updated Content-Security-Policy configuration to improve worker resource handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->