### PR TITLE
Refactor file viewer modals to single-container pattern

### DIFF
--- a/src/components/admin/OperationDetailModal.tsx
+++ b/src/components/admin/OperationDetailModal.tsx
@@ -4,7 +4,6 @@ import { QueryKeys } from "@/lib/queryClient";
 import {
   Dialog,
   DialogContent,
-  DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
@@ -595,11 +594,12 @@ export default function OperationDetailModal({
       </Dialog>
 
       <Dialog open={fileViewerOpen} onOpenChange={handleFileDialogClose}>
-        <DialogContent className="glass-card w-full h-[100dvh] sm:h-[90vh] sm:max-w-6xl flex flex-col p-0 rounded-none sm:rounded-lg inset-0 sm:inset-auto sm:left-[50%] sm:top-[50%] sm:translate-x-[-50%] sm:translate-y-[-50%]">
-          <DialogHeader className="px-4 sm:px-6 py-3 sm:py-4 border-b shrink-0">
-            <DialogTitle className="text-sm sm:text-base pr-8 truncate">{currentFileTitle}</DialogTitle>
-          </DialogHeader>
-          <div className="flex-1 overflow-hidden min-h-0 rounded-lg border border-white/10 m-2 sm:m-4">
+        <DialogContent className="w-full h-[100dvh] sm:h-[90vh] sm:max-w-6xl flex flex-col p-0 gap-0 border-0 bg-transparent shadow-2xl rounded-none sm:rounded-xl overflow-hidden inset-0 sm:inset-auto sm:left-[50%] sm:top-[50%] sm:translate-x-[-50%] sm:translate-y-[-50%]">
+          <div className="relative flex-1 min-h-0 bg-background sm:rounded-xl overflow-hidden">
+            <div className="absolute top-2 left-3 z-10 max-w-[60%]">
+              <span className="text-[11px] text-muted-foreground/70 font-medium truncate block">{currentFileTitle}</span>
+            </div>
+            <DialogTitle className="sr-only">{currentFileTitle}</DialogTitle>
             {currentFileType === "step" && currentFileUrl && <STEPViewer url={currentFileUrl} />}
             {currentFileType === "pdf" && currentFileUrl && <PDFViewer url={currentFileUrl} />}
           </div>

--- a/src/components/admin/PartDetailModal.tsx
+++ b/src/components/admin/PartDetailModal.tsx
@@ -1173,11 +1173,12 @@ export default function PartDetailModal({ partId, onClose, onUpdate }: PartDetai
       </DialogContent>
 
       <Dialog open={fileViewerOpen} onOpenChange={handleFileDialogClose}>
-        <DialogContent className="w-full h-[100dvh] sm:h-[90vh] sm:max-w-6xl flex flex-col p-0 rounded-none sm:rounded-lg inset-0 sm:inset-auto sm:left-[50%] sm:top-[50%] sm:translate-x-[-50%] sm:translate-y-[-50%]">
-          <DialogHeader className="px-4 sm:px-6 py-3 sm:py-4 border-b shrink-0">
-            <DialogTitle className="text-sm sm:text-base pr-8 truncate">{currentFileTitle}</DialogTitle>
-          </DialogHeader>
-          <div className="flex-1 overflow-hidden min-h-0">
+        <DialogContent className="w-full h-[100dvh] sm:h-[90vh] sm:max-w-6xl flex flex-col p-0 gap-0 border-0 bg-transparent shadow-2xl rounded-none sm:rounded-xl overflow-hidden inset-0 sm:inset-auto sm:left-[50%] sm:top-[50%] sm:translate-x-[-50%] sm:translate-y-[-50%]">
+          <div className="relative flex-1 min-h-0 bg-background sm:rounded-xl overflow-hidden">
+            <div className="absolute top-2 left-3 z-10 max-w-[60%]">
+              <span className="text-[11px] text-muted-foreground/70 font-medium truncate block">{currentFileTitle}</span>
+            </div>
+            <DialogTitle className="sr-only">{currentFileTitle}</DialogTitle>
             {currentFileUrl && currentFileType === "step" && (
               <STEPViewer url={currentFileUrl} title={currentFileTitle} />
             )}

--- a/src/components/operator/OperationDetailModal.tsx
+++ b/src/components/operator/OperationDetailModal.tsx
@@ -16,7 +16,6 @@ import {
 import {
   Dialog,
   DialogContent,
-  DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
@@ -621,11 +620,12 @@ export default function OperationDetailModal({
       </AlertDialog>
 
       <Dialog open={fileViewerOpen} onOpenChange={handleFileDialogClose}>
-        <DialogContent className="max-w-6xl h-[90vh] flex flex-col p-0">
-          <DialogHeader className="px-6 py-4 border-b">
-            <DialogTitle>{currentFileTitle}</DialogTitle>
-          </DialogHeader>
-          <div className="flex-1 overflow-hidden">
+        <DialogContent className="w-full h-[100dvh] sm:h-[90vh] sm:max-w-6xl flex flex-col p-0 gap-0 border-0 bg-transparent shadow-2xl rounded-none sm:rounded-xl overflow-hidden inset-0 sm:inset-auto sm:left-[50%] sm:top-[50%] sm:translate-x-[-50%] sm:translate-y-[-50%]">
+          <div className="relative flex-1 min-h-0 bg-background sm:rounded-xl overflow-hidden">
+            <div className="absolute top-2 left-3 z-10 max-w-[60%]">
+              <span className="text-[11px] text-muted-foreground/70 font-medium truncate block">{currentFileTitle}</span>
+            </div>
+            <DialogTitle className="sr-only">{currentFileTitle}</DialogTitle>
             {currentFileUrl && currentFileType === "step" && (
               <STEPViewer url={currentFileUrl} title={currentFileTitle} />
             )}

--- a/src/components/terminal/DetailPanel.tsx
+++ b/src/components/terminal/DetailPanel.tsx
@@ -432,37 +432,26 @@ export function DetailPanel({ job, onStart, onPause, onComplete, stepUrl, pdfUrl
 
             {fullscreenViewer && createPortal(
                 <div
-                    className="fixed inset-0 z-[100] bg-background/95 backdrop-blur-md flex flex-col"
+                    className="fixed inset-0 z-[100] bg-black/90 backdrop-blur-md flex flex-col"
                     onClick={() => setFullscreenViewer(null)}
                 >
                     <div
-                        className="flex items-center justify-between p-3 border-b border-border bg-card/80 backdrop-blur-sm"
+                        className="relative flex-1 min-h-0"
                         onClick={(e) => e.stopPropagation()}
                     >
-                        <div className="flex items-center gap-2">
-                            {fullscreenViewer === '3d' ? (
-                                <Box className="w-4 h-4 text-primary" />
-                            ) : (
-                                <FileText className="w-4 h-4 text-primary" />
-                            )}
-                            <span className="font-medium text-foreground">{job.jobCode}</span>
-                            <span className="text-muted-foreground text-sm">- {fullscreenViewer === '3d' ? '3D Model' : 'Drawing'}</span>
+                        <div className="absolute top-3 left-4 z-10 flex items-center gap-2">
+                            <span className="text-xs text-muted-foreground/70 font-medium">{job.jobCode}</span>
+                            <span className="text-[10px] text-muted-foreground/50">{fullscreenViewer === '3d' ? '3D' : 'PDF'}</span>
                         </div>
                         <Button
                             variant="ghost"
                             size="sm"
                             onClick={() => setFullscreenViewer(null)}
-                            className="h-8 w-8 p-0 hover:bg-accent"
+                            className="absolute top-2 right-3 z-10 h-8 w-8 p-0 hover:bg-accent/50 text-muted-foreground"
                         >
                             <X className="w-4 h-4" />
                         </Button>
-                    </div>
-
-                    <div
-                        className="flex-1 p-4 min-h-0"
-                        onClick={(e) => e.stopPropagation()}
-                    >
-                        <div className="h-full rounded-lg overflow-hidden border border-border bg-background shadow-xl">
+                        <div className="h-full bg-background overflow-hidden">
                             {fullscreenViewer === '3d' && stepUrl && (
                                 <STEPViewer
                                     url={stepUrl}
@@ -476,10 +465,6 @@ export function DetailPanel({ job, onStart, onPause, onComplete, stepUrl, pdfUrl
                                 <PDFViewer url={pdfUrl} title={job.jobCode} />
                             )}
                         </div>
-                    </div>
-
-                    <div className="text-center pb-3 text-muted-foreground text-xs">
-                        Tap outside or press X to close
                     </div>
                 </div>,
                 document.body

--- a/src/pages/admin/Jobs.tsx
+++ b/src/pages/admin/Jobs.tsx
@@ -36,7 +36,6 @@ import { PDFViewer } from "@/components/PDFViewerLazy";
 import {
   Dialog,
   DialogContent,
-  DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
 import {
@@ -546,11 +545,12 @@ export default function Jobs() {
       )}
 
       <Dialog open={fileViewerOpen} onOpenChange={handleFileDialogClose}>
-        <DialogContent className="glass-card w-full h-[100dvh] sm:h-[90vh] sm:max-w-6xl flex flex-col p-0 rounded-none sm:rounded-lg inset-0 sm:inset-auto sm:left-[50%] sm:top-[50%] sm:translate-x-[-50%] sm:translate-y-[-50%]">
-          <DialogHeader className="px-4 sm:px-6 py-3 sm:py-4 border-b shrink-0">
-            <DialogTitle className="text-sm sm:text-base pr-8 truncate">{currentFileTitle}</DialogTitle>
-          </DialogHeader>
-          <div className="flex-1 overflow-hidden min-h-0 rounded-lg border border-white/10 m-2 sm:m-4">
+        <DialogContent className="w-full h-[100dvh] sm:h-[90vh] sm:max-w-6xl flex flex-col p-0 gap-0 border-0 bg-transparent shadow-2xl rounded-none sm:rounded-xl overflow-hidden inset-0 sm:inset-auto sm:left-[50%] sm:top-[50%] sm:translate-x-[-50%] sm:translate-y-[-50%]">
+          <div className="relative flex-1 min-h-0 bg-background sm:rounded-xl overflow-hidden">
+            <div className="absolute top-2 left-3 z-10 max-w-[60%]">
+              <span className="text-[11px] text-muted-foreground/70 font-medium truncate block">{currentFileTitle}</span>
+            </div>
+            <DialogTitle className="sr-only">{currentFileTitle}</DialogTitle>
             {currentFileType === "step" && currentFileUrl && (
               <STEPViewer url={currentFileUrl} />
             )}

--- a/src/pages/admin/Parts.tsx
+++ b/src/pages/admin/Parts.tsx
@@ -29,7 +29,6 @@ import { PDFViewer } from "@/components/PDFViewerLazy";
 import {
   Dialog,
   DialogContent,
-  DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
 import { toast } from "sonner";
@@ -480,15 +479,12 @@ export default function Parts() {
       )}
 
       <Dialog open={fileViewerOpen} onOpenChange={handleFileDialogClose}>
-        <DialogContent className="glass-card w-full h-[100dvh] sm:h-[90vh] sm:max-w-6xl flex flex-col p-0 rounded-none sm:rounded-lg inset-0 sm:inset-auto sm:left-[50%] sm:top-[50%] sm:translate-x-[-50%] sm:translate-y-[-50%]">
-          <DialogHeader className="px-4 sm:px-6 py-3 sm:py-4 border-b shrink-0">
-            <DialogTitle className="text-sm sm:text-base pr-8 flex items-center gap-2">
-              {currentFileType === "step" && <Box className="h-4 w-4 text-primary" />}
-              {currentFileType === "pdf" && <FileText className="h-4 w-4 text-destructive" />}
-              <span className="truncate">{currentFileTitle}</span>
-            </DialogTitle>
-          </DialogHeader>
-          <div className="flex-1 overflow-hidden min-h-0 rounded-lg border border-white/10 m-2 sm:m-4">
+        <DialogContent className="w-full h-[100dvh] sm:h-[90vh] sm:max-w-6xl flex flex-col p-0 gap-0 border-0 bg-transparent shadow-2xl rounded-none sm:rounded-xl overflow-hidden inset-0 sm:inset-auto sm:left-[50%] sm:top-[50%] sm:translate-x-[-50%] sm:translate-y-[-50%]">
+          <div className="relative flex-1 min-h-0 bg-background sm:rounded-xl overflow-hidden">
+            <div className="absolute top-2 left-3 z-10 max-w-[60%]">
+              <span className="text-[11px] text-muted-foreground/70 font-medium truncate block">{currentFileTitle}</span>
+            </div>
+            <DialogTitle className="sr-only">{currentFileTitle}</DialogTitle>
             {currentFileType === "step" && currentFileUrl && (
               <STEPViewer url={currentFileUrl} />
             )}

--- a/website/src/content/docs/engineering/design-system-reference.md
+++ b/website/src/content/docs/engineering/design-system-reference.md
@@ -1587,6 +1587,67 @@ All dialogs should use glass morphism for consistency.
 </Dialog>
 ```
 
+### File Viewer Modals (STEP / PDF)
+
+File viewer modals follow a **single-container** pattern — no nested borders, no header bars, no extra wrappers. The viewer fills the entire modal and the filename is shown as a subtle overlay label.
+
+**Why?** Nested containers (border inside border inside border) look unpolished. The viewer content should be the hero — maximize it.
+
+**Standard Dialog-based pattern** (used in Parts, Jobs, PartDetailModal, OperationDetailModal):
+
+```tsx
+<Dialog open={fileViewerOpen} onOpenChange={handleFileDialogClose}>
+  <DialogContent className="w-full h-[100dvh] sm:h-[90vh] sm:max-w-6xl flex flex-col p-0 gap-0 border-0 bg-transparent shadow-2xl rounded-none sm:rounded-xl overflow-hidden inset-0 sm:inset-auto sm:left-[50%] sm:top-[50%] sm:translate-x-[-50%] sm:translate-y-[-50%]">
+    <div className="relative flex-1 min-h-0 bg-background sm:rounded-xl overflow-hidden">
+      <div className="absolute top-2 left-3 z-10 max-w-[60%]">
+        <span className="text-[11px] text-muted-foreground/70 font-medium truncate block">
+          {currentFileTitle}
+        </span>
+      </div>
+      <DialogTitle className="sr-only">{currentFileTitle}</DialogTitle>
+      {currentFileType === "step" && currentFileUrl && (
+        <STEPViewer url={currentFileUrl} />
+      )}
+      {currentFileType === "pdf" && currentFileUrl && (
+        <PDFViewer url={currentFileUrl} />
+      )}
+    </div>
+  </DialogContent>
+</Dialog>
+```
+
+**Key rules:**
+- `p-0 gap-0 border-0 bg-transparent` — strip all default DialogContent chrome
+- Single inner container with `bg-background` and `sm:rounded-xl`
+- Filename as an absolute-positioned overlay (`text-[11px] text-muted-foreground/70`)
+- `DialogTitle` with `sr-only` for accessibility (screen readers still announce the title)
+- No `DialogHeader`, no `border-b` dividers, no `m-2` inner margins
+- Full height: `h-[100dvh]` mobile, `sm:h-[90vh]` desktop
+- `sm:max-w-6xl` for the max-width constraint
+
+**Standard Portal-based fullscreen pattern** (used in terminal DetailPanel):
+
+```tsx
+{fullscreenViewer && createPortal(
+  <div className="fixed inset-0 z-[100] bg-black/90 backdrop-blur-md flex flex-col">
+    <div className="relative flex-1 min-h-0">
+      <div className="absolute top-3 left-4 z-10">
+        <span className="text-xs text-muted-foreground/70 font-medium">{title}</span>
+      </div>
+      <Button variant="ghost" size="sm"
+        className="absolute top-2 right-3 z-10 h-8 w-8 p-0 hover:bg-accent/50 text-muted-foreground"
+        onClick={() => setFullscreenViewer(null)}>
+        <X className="w-4 h-4" />
+      </Button>
+      <div className="h-full bg-background overflow-hidden">
+        <STEPViewer url={stepUrl} ... />
+      </div>
+    </div>
+  </div>,
+  document.body
+)}
+```
+
 ### Status Badges with Manufacturing Colors
 
 Use consistent color coding for manufacturing statuses.


### PR DESCRIPTION
## Summary
Standardized file viewer modals (STEP/PDF) across the application to use a clean single-container pattern without nested borders, header bars, or extra wrappers. This improves visual polish and maximizes viewer content space.

## Key Changes
- **Updated design system documentation** with two file viewer modal patterns:
  - Dialog-based pattern for Parts, Jobs, PartDetailModal, and OperationDetailModal
  - Portal-based fullscreen pattern for terminal DetailPanel
  
- **Refactored file viewer modals** in 6 components to follow the new pattern:
  - `src/pages/admin/Parts.tsx`
  - `src/pages/admin/Jobs.tsx`
  - `src/components/admin/PartDetailModal.tsx`
  - `src/components/admin/OperationDetailModal.tsx`
  - `src/components/operator/OperationDetailModal.tsx`
  - `src/components/terminal/DetailPanel.tsx`

- **Removed nested container chrome:**
  - Eliminated `DialogHeader` components
  - Removed `border-b` dividers and `m-2`/`m-4` inner margins
  - Stripped `glass-card` class and replaced with `bg-transparent` on DialogContent
  - Removed redundant `rounded-lg border border-white/10` inner containers

- **Simplified filename display:**
  - Changed from icon + text in header to subtle overlay label (`text-[11px] text-muted-foreground/70`)
  - Positioned absolutely at top-left with `z-10`
  - Made `DialogTitle` screen-reader only (`sr-only`) for accessibility

- **Improved fullscreen viewer styling** in DetailPanel:
  - Changed background from `bg-background/95` to `bg-black/90` for better contrast
  - Repositioned close button and title as absolute overlays
  - Removed footer text ("Tap outside or press X to close")
  - Simplified layout structure

## Implementation Details
- All file viewer modals now use `p-0 gap-0 border-0 bg-transparent` on DialogContent to strip default chrome
- Single inner container with `bg-background` and `sm:rounded-xl` for rounded corners on desktop
- Full height: `h-[100dvh]` on mobile, `sm:h-[90vh]` on desktop
- Consistent max-width constraint: `sm:max-w-6xl`
- Filename overlay uses `max-w-[60%]` to prevent overflow on narrow screens

https://claude.ai/code/session_01MZPziRFCX24Aw8Eqmwnext