### PR TITLE
Refine MES operator flows and preserve Antigravity for admin/auth

### DIFF
--- a/src/components/admin/AdminPageHeader.test.tsx
+++ b/src/components/admin/AdminPageHeader.test.tsx
@@ -123,9 +123,8 @@ describe('AdminPageHeader', () => {
     render(<AdminPageHeader title="Test Title" />);
 
     const heading = screen.getByRole('heading', { level: 1 });
-    expect(heading).toHaveClass('text-xl');
-    expect(heading).toHaveClass('font-bold');
-    expect(heading).toHaveClass('bg-gradient-to-r');
+    expect(heading).toHaveClass('text-2xl');
+    expect(heading).toHaveClass('font-semibold');
   });
 
   it('applies correct CSS classes to description', () => {
@@ -153,5 +152,6 @@ describe('AdminPageHeader', () => {
 
     const button = screen.getByRole('button', { name: /action/i });
     expect(button).toHaveClass('cta-button');
+    expect(button).toHaveClass('min-h-11');
   });
 });

--- a/src/components/admin/AdminPageHeader.tsx
+++ b/src/components/admin/AdminPageHeader.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 import { LucideIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 interface AdminPageHeaderProps {
   title: string;
@@ -27,6 +28,7 @@ export function AdminPageHeader({
   action,
   children,
 }: AdminPageHeaderProps) {
+  const { t } = useTranslation();
   const isActionObject = action && typeof action === 'object' && 'onClick' in action;
   const ActionIcon = isActionObject ? action.icon : undefined;
 
@@ -35,7 +37,7 @@ export function AdminPageHeader({
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div className="space-y-1">
           <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-            Workspace
+            {t("common.workspace", "Workspace")}
           </div>
           <h1 className="bg-gradient-to-r from-foreground via-foreground to-foreground/70 bg-clip-text text-2xl font-semibold tracking-tight text-transparent">
             {title}

--- a/src/components/admin/AdminPageHeader.tsx
+++ b/src/components/admin/AdminPageHeader.tsx
@@ -27,35 +27,36 @@ export function AdminPageHeader({
   action,
   children,
 }: AdminPageHeaderProps) {
-  // Check if action is a React node or an object
   const isActionObject = action && typeof action === 'object' && 'onClick' in action;
   const ActionIcon = isActionObject ? action.icon : undefined;
 
   return (
-    <div className="space-y-3 sm:space-y-4">
-      <div>
-        {/* Header row - stacks on mobile, inline on larger screens */}
-        <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2 sm:gap-4 mb-1">
-          <h1 className="text-xl sm:text-2xl font-bold bg-gradient-to-r from-foreground via-foreground to-foreground/70 bg-clip-text text-transparent">
+    <div className="space-y-4">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-1">
+          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Workspace
+          </div>
+          <h1 className="bg-gradient-to-r from-foreground via-foreground to-foreground/70 bg-clip-text text-2xl font-semibold tracking-tight text-transparent">
             {title}
           </h1>
-          <div className="flex items-center gap-2 flex-wrap">
-            {children}
-            {action && isActionObject && (
-              <Button
-                onClick={action.onClick}
-                className="cta-button w-full sm:w-auto justify-center"
-              >
-                {ActionIcon && <ActionIcon className="mr-2 h-4 w-4" />}
-                {action.label}
-              </Button>
-            )}
-            {action && !isActionObject && (action as ReactNode)}
-          </div>
+          {description && (
+            <p className="max-w-3xl text-sm text-muted-foreground">{description}</p>
+          )}
         </div>
-        {description && (
-          <p className="text-muted-foreground text-xs sm:text-sm">{description}</p>
-        )}
+        <div className="flex flex-wrap items-center gap-2">
+          {children}
+          {action && isActionObject && (
+            <Button
+              onClick={action.onClick}
+              className="cta-button min-h-11 rounded-xl px-4"
+            >
+              {ActionIcon && <ActionIcon className="mr-2 h-4 w-4" />}
+              {action.label}
+            </Button>
+          )}
+          {action && !isActionObject && (action as ReactNode)}
+        </div>
       </div>
       <hr className="title-divider" />
     </div>

--- a/src/components/admin/OperationDetailModal.tsx
+++ b/src/components/admin/OperationDetailModal.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { StatusBadge } from "@/components/ui/status-badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Select,
@@ -250,11 +251,11 @@ export default function OperationDetailModal({
   };
 
   const getStatusBadge = (status: string) => {
-    const variants: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
-      not_started: "secondary",
-      in_progress: "default",
-      completed: "outline",
-      on_hold: "destructive",
+    const badgeStatus: Record<string, "pending" | "active" | "completed" | "on-hold"> = {
+      not_started: "pending",
+      in_progress: "active",
+      completed: "completed",
+      on_hold: "on-hold",
     };
     const labels: Record<string, string> = {
       not_started: t("operations.status.notStarted"),
@@ -262,7 +263,12 @@ export default function OperationDetailModal({
       completed: t("operations.status.completed"),
       on_hold: t("operations.status.onHold"),
     };
-    return <Badge variant={variants[status] || "default"}>{labels[status] || status}</Badge>;
+    return (
+      <StatusBadge
+        status={badgeStatus[status] || "pending"}
+        label={labels[status] || status}
+      />
+    );
   };
 
   const stepFiles =

--- a/src/components/admin/PageStatsRow.test.tsx
+++ b/src/components/admin/PageStatsRow.test.tsx
@@ -63,8 +63,7 @@ describe('PageStatsRow', () => {
 
     render(<PageStatsRow stats={stats} />);
 
-    const clickableStat = screen.getByText('Clickable').closest('.glass-card');
-    fireEvent.click(clickableStat!);
+    fireEvent.click(screen.getByRole('button', { name: /clickable/i }));
 
     expect(onClick).toHaveBeenCalledTimes(1);
   });
@@ -77,11 +76,8 @@ describe('PageStatsRow', () => {
 
     render(<PageStatsRow stats={stats} />);
 
-    const clickableStat = screen.getByText('Clickable').closest('.glass-card');
-    const nonClickableStat = screen.getByText('Non-clickable').closest('.glass-card');
-
-    expect(clickableStat).toHaveClass('cursor-pointer');
-    expect(nonClickableStat).not.toHaveClass('cursor-pointer');
+    expect(screen.getByRole('button', { name: /clickable/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /non-clickable/i })).not.toBeInTheDocument();
   });
 
   it('applies correct color classes for primary', () => {
@@ -140,10 +136,10 @@ describe('PageStatsRow', () => {
     expect(container.firstChild).toHaveClass('md:grid-cols-4');
   });
 
-  it('applies glass-card class to stat items', () => {
+  it('applies shared panel classes to stat items', () => {
     render(<PageStatsRow stats={mockStats} />);
 
-    const cards = document.querySelectorAll('.glass-card');
+    const cards = document.querySelectorAll('.rounded-2xl.border');
     expect(cards.length).toBe(mockStats.length);
   });
 

--- a/src/components/admin/PageStatsRow.tsx
+++ b/src/components/admin/PageStatsRow.tsx
@@ -55,8 +55,7 @@ const colorClasses = {
 export function PageStatsRow({ stats, className }: PageStatsRowProps) {
   return (
     <div className={cn(
-      "grid gap-2 sm:gap-3",
-      // Responsive grid: 2 cols on mobile, up to 4 on larger screens
+      "grid gap-3",
       "grid-cols-2 md:grid-cols-4",
       className
     )}>
@@ -64,26 +63,51 @@ export function PageStatsRow({ stats, className }: PageStatsRowProps) {
         const colors = colorClasses[stat.color || "muted"];
         const Icon = stat.icon;
 
-        return (
-          <div
-            key={index}
-            className={cn(
-              "glass-card p-2 sm:p-3 flex items-center gap-2 sm:gap-3 transition-all",
-              stat.onClick && "cursor-pointer hover:scale-[1.02] hover:shadow-lg active:scale-[0.98]"
-            )}
-            onClick={stat.onClick}
-          >
-            <div className={cn("p-1.5 sm:p-2 rounded-lg shrink-0", colors.bg)}>
-              <Icon className={cn("h-3.5 w-3.5 sm:h-4 sm:w-4", colors.text)} />
+        const content = (
+          <>
+            <div
+              className={cn(
+                "flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border",
+                colors.bg,
+              )}
+            >
+              <Icon className={cn("h-4 w-4", colors.text)} />
             </div>
             <div className="min-w-0 flex-1">
-              <div className={cn("text-base sm:text-lg font-bold leading-none", colors.value)}>
+              <div
+                className={cn(
+                  "text-xl font-semibold leading-none tracking-tight",
+                  colors.value,
+                )}
+              >
                 {stat.value}
               </div>
-              <div className="text-[10px] sm:text-xs text-muted-foreground truncate mt-0.5">
+              <div className="mt-1 truncate text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
                 {stat.label}
               </div>
             </div>
+          </>
+        );
+
+        if (stat.onClick) {
+          return (
+            <button
+              key={index}
+              type="button"
+              className="glass-card flex min-h-[96px] w-full items-center gap-3 rounded-2xl border border-border/80 p-4 text-left shadow-sm transition-colors hover:border-primary/30 hover:bg-muted/20"
+              onClick={stat.onClick}
+            >
+              {content}
+            </button>
+          );
+        }
+
+        return (
+          <div
+            key={index}
+            className="glass-card flex min-h-[96px] w-full items-center gap-3 rounded-2xl border border-border/80 p-4 text-left shadow-sm"
+          >
+            {content}
           </div>
         );
       })}

--- a/src/components/auth/AuthShell.test.tsx
+++ b/src/components/auth/AuthShell.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Factory } from "lucide-react";
+import { AuthCardHeader, AuthShell } from "./AuthShell";
+
+vi.mock("@/components/AnimatedBackground", () => ({
+  default: () => <div data-testid="animated-background" />,
+}));
+
+describe("AuthShell", () => {
+  it("renders the shared background, top-right content, and auth card wrapper", () => {
+    const { container } = render(
+      <AuthShell topRight={<button type="button">Language</button>}>
+        <div>Content</div>
+      </AuthShell>,
+    );
+
+    expect(screen.getByTestId("animated-background")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Language" })).toBeInTheDocument();
+    expect(screen.getByText("Content")).toBeInTheDocument();
+    expect(container.querySelector(".onboarding-card")).toBeInTheDocument();
+  });
+});
+
+describe("AuthCardHeader", () => {
+  it("renders the shared auth heading structure", () => {
+    const { container } = render(
+      <AuthCardHeader
+        icon={Factory}
+        eyebrow="Invited"
+        appName="Eryxon Flow"
+        badge="Preview"
+        title="Join your team"
+        description="Create your access and continue."
+      />,
+    );
+
+    expect(screen.getByText("Invited")).toBeInTheDocument();
+    expect(screen.getByText("Eryxon Flow")).toBeInTheDocument();
+    expect(screen.getByText("Preview")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: "Join your team" })).toBeInTheDocument();
+    expect(screen.getByText("Create your access and continue.")).toBeInTheDocument();
+    expect(container.querySelector("hr.title-divider")).toBeInTheDocument();
+  });
+});

--- a/src/components/auth/AuthShell.tsx
+++ b/src/components/auth/AuthShell.tsx
@@ -1,0 +1,80 @@
+import { ReactNode } from "react";
+import { LucideIcon } from "lucide-react";
+import AnimatedBackground from "@/components/AnimatedBackground";
+import { cn } from "@/lib/utils";
+
+interface AuthShellProps {
+  children: ReactNode;
+  topRight?: ReactNode;
+  containerClassName?: string;
+  cardClassName?: string;
+}
+
+interface AuthCardHeaderProps {
+  icon: LucideIcon;
+  title: string;
+  appName?: string;
+  badge?: string;
+  eyebrow?: string;
+  description?: ReactNode;
+  descriptionClassName?: string;
+  iconClassName?: string;
+}
+
+export function AuthShell({
+  children,
+  topRight,
+  containerClassName,
+  cardClassName,
+}: AuthShellProps) {
+  return (
+    <>
+      <AnimatedBackground />
+      <div className={cn("landing-container", containerClassName)}>
+        {topRight && <div className="absolute top-4 right-4 z-10">{topRight}</div>}
+        <div className={cn("onboarding-card", cardClassName)}>{children}</div>
+      </div>
+    </>
+  );
+}
+
+export function AuthCardHeader({
+  icon: Icon,
+  title,
+  appName,
+  badge,
+  eyebrow,
+  description,
+  descriptionClassName,
+  iconClassName,
+}: AuthCardHeaderProps) {
+  return (
+    <>
+      <div className="icon-container">
+        <Icon
+          className={cn("browser-icon text-primary", iconClassName)}
+          strokeWidth={1.5}
+        />
+      </div>
+
+      {eyebrow && <p className="welcome-text">{eyebrow}</p>}
+
+      {(appName || badge) && (
+        <div className="title-container">
+          {appName && <h1 className="main-title">{appName}</h1>}
+          {badge && <p className="preview-pill">{badge}</p>}
+        </div>
+      )}
+
+      <hr className="title-divider" />
+
+      <h2 className="hero-title">{title}</h2>
+
+      {description && (
+        <div className={cn("text-left", descriptionClassName ?? "informational-text")}>
+          {description}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/operator/CurrentlyTimingWidget.tsx
+++ b/src/components/operator/CurrentlyTimingWidget.tsx
@@ -2,14 +2,14 @@ import { useEffect, useState, useCallback } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useOperator } from "@/contexts/OperatorContext";
 import { supabase } from "@/integrations/supabase/client";
-import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Clock, Square, ChevronDown, ChevronUp } from "lucide-react";
+import { Clock3, Square, ChevronDown, ChevronUp, TimerReset } from "lucide-react";
 import { stopTimeTracking } from "@/lib/database";
 import { toast } from "sonner";
 import { formatDistanceToNow } from "date-fns";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
+import { OperatorPanel, OperatorStatusChip } from "./OperatorStation";
 
 interface ActiveEntry {
   id: string;
@@ -52,13 +52,13 @@ export default function CurrentlyTimingWidget() {
             job:jobs(job_number)
           )
         )
-      `
+      `,
       )
       .eq("operator_id", operatorId)
       .is("end_time", null);
 
     if (!error && data) {
-      setActiveEntries(data as any);
+      setActiveEntries(data as ActiveEntry[]);
     }
   }, [operatorId]);
 
@@ -69,12 +69,10 @@ export default function CurrentlyTimingWidget() {
       void loadActiveEntries();
     }, 0);
 
-    // Update every second for elapsed time
-    const interval = setInterval(() => {
+    const interval = window.setInterval(() => {
       setTick((prev) => prev + 1);
     }, 1000);
 
-    // Subscribe to time entries changes
     const channel = supabase
       .channel("my-time-entries")
       .on(
@@ -86,8 +84,8 @@ export default function CurrentlyTimingWidget() {
           filter: `operator_id=eq.${operatorId}`,
         },
         () => {
-          loadActiveEntries();
-        }
+          void loadActiveEntries();
+        },
       )
       .subscribe();
 
@@ -104,35 +102,48 @@ export default function CurrentlyTimingWidget() {
     try {
       await stopTimeTracking(operationId, operatorId);
       toast.success(t("operations.timeTrackingStopped"));
-      loadActiveEntries();
+      await loadActiveEntries();
     } catch (error: unknown) {
-      toast.error(error instanceof Error ? error.message : t("operations.failedToStopTimeTracking"));
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : t("operations.failedToStopTimeTracking"),
+      );
     }
   };
 
   if (activeEntries.length === 0) return null;
 
   return (
-    <Card className="bg-active-work/5 border-active-work/30 overflow-hidden">
-      {/* Header - always visible, clickable to toggle */}
+    <OperatorPanel className="overflow-hidden p-0">
       <button
-        onClick={() => setIsCollapsed(!isCollapsed)}
-        className="w-full flex items-center justify-between p-3 hover:bg-active-work/10 transition-colors"
+        onClick={() => setIsCollapsed((prev) => !prev)}
+        className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left hover:bg-muted/20"
       >
-        <div className="flex items-center gap-2">
-          <Clock className="h-4 w-4 text-active-work animate-pulse" />
-          <span className="font-semibold text-sm">{t("operations.currentlyTiming")}</span>
-          <span className="text-xs text-active-work bg-active-work/20 px-1.5 py-0.5 rounded-full">
-            {activeEntries.length}
-          </span>
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl border border-amber-500/30 bg-amber-500/10 text-amber-500">
+            <TimerReset className="h-5 w-5" />
+          </div>
+          <div className="min-w-0">
+            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              {t("operations.currentlyTiming")}
+            </div>
+            <div className="truncate text-sm font-semibold text-foreground">
+              {activeEntries.length === 1
+                ? activeEntries[0].operation.operation_name
+                : t("operations.currentlyTiming")}{" "}
+              {activeEntries.length > 1 ? `(${activeEntries.length})` : ""}
+            </div>
+          </div>
         </div>
+
         <div className="flex items-center gap-2">
-          {/* Show first entry summary when collapsed */}
-          {isCollapsed && activeEntries[0] && (
-            <span className="text-xs text-muted-foreground truncate max-w-[200px]">
-              {activeEntries[0].operation.operation_name}
-            </span>
-          )}
+          <OperatorStatusChip
+            icon={Clock3}
+            tone="warning"
+            label={`${activeEntries.length} ${t("common.active", "active")}`}
+            className="hidden sm:inline-flex"
+          />
           {isCollapsed ? (
             <ChevronDown className="h-4 w-4 text-muted-foreground" />
           ) : (
@@ -141,44 +152,52 @@ export default function CurrentlyTimingWidget() {
         </div>
       </button>
 
-      {/* Content - collapsible */}
       <div
         className={cn(
-          "transition-all duration-200 ease-in-out overflow-hidden",
-          isCollapsed ? "max-h-0 opacity-0" : "max-h-[500px] opacity-100"
+          "overflow-hidden transition-all duration-200",
+          isCollapsed ? "max-h-0 opacity-0" : "max-h-[420px] opacity-100",
         )}
       >
-        <div className="px-3 pb-3 space-y-2">
-          {activeEntries.map((entry) => (
-            <div
-              key={entry.id}
-              className="flex items-center justify-between p-3 bg-background rounded-lg border"
-            >
-              <div className="flex-1 min-w-0">
-                <div className="font-medium truncate text-sm">{entry.operation.operation_name}</div>
-                <div className="text-xs text-muted-foreground">
-                  {t("operations.job")} {entry.operation.part.job.job_number} • {entry.operation.part.part_number}
-                </div>
-                <div className="text-[10px] text-muted-foreground mt-1">
-                  {t("operations.started")} {formatDistanceToNow(new Date(entry.start_time), { addSuffix: true })}
-                </div>
-              </div>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleStop(entry.operation_id);
-                }}
-                className="gap-1.5 ml-3 h-8 text-xs"
+        <div className="border-t border-border px-4 py-3">
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {activeEntries.map((entry) => (
+              <div
+                key={entry.id}
+                className="rounded-2xl border border-border bg-muted/20 p-3"
               >
-                <Square className="h-3 w-3" />
-                {t("operations.stop")}
-              </Button>
-            </div>
-          ))}
+                <div className="space-y-1">
+                  <div className="text-sm font-semibold text-foreground">
+                    {entry.operation.operation_name}
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    {t("operations.job")} {entry.operation.part.job.job_number} •{" "}
+                    {entry.operation.part.part_number}
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    {t("operations.started")}{" "}
+                    {formatDistanceToNow(new Date(entry.start_time), {
+                      addSuffix: true,
+                    })}
+                  </div>
+                </div>
+
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    void handleStop(entry.operation_id);
+                  }}
+                  className="mt-3 min-h-11 w-full gap-2 rounded-xl"
+                >
+                  <Square className="h-4 w-4" />
+                  {t("operations.stop")}
+                </Button>
+              </div>
+            ))}
+          </div>
         </div>
       </div>
-    </Card>
+    </OperatorPanel>
   );
 }

--- a/src/components/operator/CurrentlyTimingWidget.tsx
+++ b/src/components/operator/CurrentlyTimingWidget.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useOperator } from "@/contexts/OperatorContext";
 import { supabase } from "@/integrations/supabase/client";
@@ -34,9 +34,24 @@ export default function CurrentlyTimingWidget() {
   const [activeEntries, setActiveEntries] = useState<ActiveEntry[]>([]);
   const [, setTick] = useState(0);
   const [isCollapsed, setIsCollapsed] = useState(false);
+  const operatorIdRef = useRef<string | null>(operatorId || null);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    operatorIdRef.current = operatorId || null;
+    queueMicrotask(() => {
+      setActiveEntries([]);
+    });
+  }, [operatorId]);
 
   const loadActiveEntries = useCallback(async () => {
-    if (!operatorId) return;
+    if (!operatorId) {
+      setActiveEntries([]);
+      return;
+    }
+
+    const requestId = ++requestIdRef.current;
+    const requestedOperatorId = operatorId;
 
     const { data, error } = await supabase
       .from("time_entries")
@@ -54,10 +69,15 @@ export default function CurrentlyTimingWidget() {
         )
       `,
       )
-      .eq("operator_id", operatorId)
+      .eq("operator_id", requestedOperatorId)
       .is("end_time", null);
 
-    if (!error && data) {
+    if (
+      !error &&
+      data &&
+      requestIdRef.current === requestId &&
+      operatorIdRef.current === requestedOperatorId
+    ) {
       setActiveEntries(data as ActiveEntry[]);
     }
   }, [operatorId]);
@@ -65,9 +85,9 @@ export default function CurrentlyTimingWidget() {
   useEffect(() => {
     if (!operatorId) return;
 
-    const loadTimeout = window.setTimeout(() => {
+    queueMicrotask(() => {
       void loadActiveEntries();
-    }, 0);
+    });
 
     const interval = window.setInterval(() => {
       setTick((prev) => prev + 1);
@@ -90,7 +110,6 @@ export default function CurrentlyTimingWidget() {
       .subscribe();
 
     return () => {
-      clearTimeout(loadTimeout);
       clearInterval(interval);
       supabase.removeChannel(channel);
     };
@@ -99,8 +118,11 @@ export default function CurrentlyTimingWidget() {
   const handleStop = async (operationId: string) => {
     if (!operatorId) return;
 
+    const requestedOperatorId = operatorId;
+
     try {
-      await stopTimeTracking(operationId, operatorId);
+      await stopTimeTracking(operationId, requestedOperatorId);
+      if (operatorIdRef.current !== requestedOperatorId) return;
       toast.success(t("operations.timeTrackingStopped"));
       await loadActiveEntries();
     } catch (error: unknown) {

--- a/src/components/operator/OperationCard.tsx
+++ b/src/components/operator/OperationCard.tsx
@@ -42,7 +42,9 @@ export default function OperationCard({
   );
 
   const dueDate = operation.part.job.due_date_override || operation.part.job.due_date;
-  const remainingTime = (operation.estimated_time || 0) - (operation.actual_time || 0);
+  const actualHours = (operation.actual_time || 0) / 60;
+  const estimatedHours = (operation.estimated_time || 0) / 60;
+  const remainingTime = estimatedHours - actualHours;
   const isOvertime = remainingTime < 0;
   const isAssignedToMe =
     operation.assigned_operator_id === profile?.id || assignedToMe;
@@ -140,8 +142,7 @@ export default function OperationCard({
             </div>
             <div className="mt-1 flex items-center gap-2 text-foreground">
               <Clock3 className="h-4 w-4 text-primary" />
-              {(operation.actual_time || 0).toFixed(1)}h /{" "}
-              {(operation.estimated_time || 0).toFixed(1)}h
+              {actualHours.toFixed(1)}h / {estimatedHours.toFixed(1)}h
             </div>
           </div>
 

--- a/src/components/operator/OperationCard.tsx
+++ b/src/components/operator/OperationCard.tsx
@@ -1,22 +1,28 @@
-import { OperationWithDetails } from "@/lib/database";
-import { Card } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Clock, User, Package, AlertTriangle, UserCheck } from "lucide-react";
-import { format } from "date-fns";
 import { useState } from "react";
+import { format } from "date-fns";
+import {
+  Clock3,
+  User,
+  Package,
+  AlertTriangle,
+  UserCheck,
+  ArrowRight,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
 import { useAuth } from "@/contexts/AuthContext";
 import { useOperationIssues } from "@/hooks/useOperationIssues";
 import OperationDetailModal from "./OperationDetailModal";
 import { useTranslation } from "react-i18next";
 import { ResourceCountBadge } from "@/components/ui/ResourceUsageDisplay";
 
+import { OperationWithDetails } from "@/lib/database";
+
 interface OperationCardProps {
   operation: OperationWithDetails;
   onUpdate: () => void;
   compact?: boolean;
-  /** Whether this operation's part is assigned to the active shop floor operator */
   assignedToMe?: boolean;
-  /** Name of the admin who made the assignment */
   assignedByName?: string;
 }
 
@@ -30,175 +36,140 @@ export default function OperationCard({
   const { t } = useTranslation();
   const [showDetail, setShowDetail] = useState(false);
   const { profile } = useAuth();
-  const { pendingCount, highestSeverity } = useOperationIssues(operation.id, profile?.tenant_id);
+  const { pendingCount, highestSeverity } = useOperationIssues(
+    operation.id,
+    profile?.tenant_id,
+  );
 
   const dueDate = operation.part.job.due_date_override || operation.part.job.due_date;
-  const remainingTime = operation.estimated_time - (operation.actual_time || 0);
+  const remainingTime = (operation.estimated_time || 0) - (operation.actual_time || 0);
   const isOvertime = remainingTime < 0;
-  // Check both profile-based assignment AND shop floor operator assignment
-  const isAssignedToMe = operation.assigned_operator_id === profile?.id || assignedToMe;
+  const isAssignedToMe =
+    operation.assigned_operator_id === profile?.id || assignedToMe;
 
-  const statusColors = {
-    not_started: "bg-status-pending",
-    in_progress: "bg-status-active",
-    completed: "bg-status-completed",
-    on_hold: "bg-status-on-hold",
+  const statusTone = {
+    not_started: "border-border bg-background/70 text-foreground",
+    in_progress:
+      "border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400",
+    completed:
+      "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+    on_hold:
+      "border-orange-500/30 bg-orange-500/10 text-orange-600 dark:text-orange-400",
   };
 
-  const severityColors = {
-    low: { border: 'border-severity-low', text: 'text-severity-low' },
-    medium: { border: 'border-severity-medium', text: 'text-severity-medium' },
-    high: { border: 'border-severity-high', text: 'text-severity-high' },
-    critical: { border: 'border-severity-critical', text: 'text-severity-critical' },
+  const severityTone = {
+    low: "border-border text-muted-foreground",
+    medium: "border-amber-500/30 text-amber-600 dark:text-amber-400",
+    high: "border-orange-500/30 text-orange-600 dark:text-orange-400",
+    critical: "border-destructive/30 text-destructive",
   };
 
-  if (compact) {
-    return (
-      <>
-        <Card
-          className={`p-3 cursor-pointer transition-all hover:shadow-md ${operation.active_time_entry ? "ring-2 ring-status-active" : ""
-            }`}
-          onClick={() => setShowDetail(true)}
-        >
-          {/* Status Bar */}
-          <div className={`h-1 -mx-3 -mt-3 mb-2 rounded-t ${statusColors[operation.status]}`} />
-
-          {/* Compact Header */}
-          <div className="flex items-center justify-between gap-2 mb-2">
-            <div className="flex-1 min-w-0">
-              <div className="font-medium text-sm truncate">{operation.operation_name}</div>
-              <div className="text-xs text-muted-foreground truncate">
-                {operation.part.job.job_number} / {operation.part.part_number}
-              </div>
-            </div>
-            <div className="flex gap-1 shrink-0">
-              {operation.part.parent_part_id && (
-                <Badge variant="outline" className="text-xs p-1">
-                  <Package className="h-3 w-3" />
-                </Badge>
-              )}
-              {pendingCount > 0 && (
-                <Badge variant="outline" className="text-xs p-1">
-                  <AlertTriangle className="h-3 w-3" />
-                </Badge>
-              )}
-              <ResourceCountBadge operationId={operation.id} />
-            </div>
-          </div>
-
-          {/* Compact Info */}
-          <div className="flex items-center justify-between text-xs">
-            <div className="flex items-center gap-1 text-muted-foreground">
-              <Clock className="h-3 w-3" />
-              <span>{operation.actual_time || 0}/{operation.estimated_time}m</span>
-            </div>
-            {operation.active_time_entry && (
-              <div className="flex items-center gap-1">
-                <div className="h-2 w-2 rounded-full bg-status-active animate-pulse" />
-                <span className="text-xs font-medium truncate max-w-20">
-                  {operation.active_time_entry.operator.full_name.split(' ')[0]}
-                </span>
-              </div>
-            )}
-          </div>
-        </Card>
-
-        <OperationDetailModal
-          operation={operation}
-          open={showDetail}
-          onOpenChange={setShowDetail}
-          onUpdate={onUpdate}
-        />
-      </>
-    );
-  }
+  const cardPadding = compact ? "p-3" : "p-4";
 
   return (
     <>
       <Card
-        className={`p-4 cursor-pointer transition-all hover:shadow-md ${operation.active_time_entry ? "ring-2 ring-status-active" : ""
-          }`}
+        className={`cursor-pointer rounded-2xl border-border/80 bg-card/95 ${cardPadding} shadow-sm transition-colors hover:border-primary/30 hover:bg-muted/20 ${
+          operation.active_time_entry ? "border-primary/40 bg-primary/5" : ""
+        }`}
         onClick={() => setShowDetail(true)}
       >
-        {/* Status Bar */}
-        <div className={`h-1 -mx-4 -mt-4 mb-3 rounded-t ${statusColors[operation.status]}`} />
-
-        {/* Header */}
-        <div className="flex items-start justify-between gap-2 mb-3">
-          <div className="flex-1 min-w-0">
-            <div className="font-semibold text-sm truncate">
-              {t("operations.job")} {operation.part.job.job_number}
-            </div>
-            <div className="text-xs text-muted-foreground">
-              {operation.part.part_number}
-            </div>
-          </div>
-          <div className="flex gap-1 shrink-0">
-            {operation.part.parent_part_id && (
-              <Badge variant="outline" className="text-xs">
-                <Package className="h-3 w-3 mr-1" />
-                {t("parts.assy")}
-              </Badge>
-            )}
-            {pendingCount > 0 && highestSeverity && (
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
               <Badge
                 variant="outline"
-                className={`text-xs ${severityColors[highestSeverity as keyof typeof severityColors]?.border} ${severityColors[highestSeverity as keyof typeof severityColors]?.text}`}
+                className={`rounded-full ${statusTone[operation.status]}`}
               >
-                <AlertTriangle className="h-3 w-3 mr-1" />
-                {pendingCount}
+                {operation.status.replace("_", " ")}
               </Badge>
-            )}
-            <ResourceCountBadge operationId={operation.id} />
+              {operation.part.parent_part_id ? (
+                <Badge variant="outline" className="rounded-full">
+                  <Package className="mr-1 h-3.5 w-3.5" />
+                  {t("parts.assy")}
+                </Badge>
+              ) : null}
+              {pendingCount > 0 && highestSeverity ? (
+                <Badge
+                  variant="outline"
+                  className={`rounded-full ${severityTone[highestSeverity as keyof typeof severityTone]}`}
+                >
+                  <AlertTriangle className="mr-1 h-3.5 w-3.5" />
+                  {pendingCount}
+                </Badge>
+              ) : null}
+              <ResourceCountBadge operationId={operation.id} />
+            </div>
+
+            <div>
+              <div className="font-mono text-sm font-semibold text-foreground">
+                {operation.part.job.job_number}
+              </div>
+              <div className="text-base font-semibold text-foreground">
+                {operation.operation_name}
+              </div>
+              <div className="text-sm text-muted-foreground">
+                {operation.part.part_number}
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-border bg-background/70 px-3 py-2 text-right">
+            <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+              {t("operations.due")}
+            </div>
+            <div className="text-sm font-semibold text-foreground">
+              {dueDate ? format(new Date(dueDate), "MMM d, yyyy") : "-"}
+            </div>
           </div>
         </div>
 
-        {/* Operation Name */}
-        <h4 className="font-medium mb-2">{operation.operation_name}</h4>
-
-        {/* Assignment Badge */}
-        {isAssignedToMe && (
-          <Badge variant="secondary" className="text-xs mb-2 flex items-center gap-1 w-fit bg-primary/10 text-primary border-primary/20">
-            <UserCheck className="h-3 w-3" />
+        {isAssignedToMe ? (
+          <Badge className="mt-3 rounded-full bg-primary/10 text-primary hover:bg-primary/10">
+            <UserCheck className="mr-1 h-3.5 w-3.5" />
             {assignedByName
               ? t("operations.assignedByAdmin", { name: assignedByName })
               : t("operations.assignedToYou")}
           </Badge>
-        )}
+        ) : null}
 
-        {/* Time Info */}
-        <div className="flex items-center gap-4 text-sm text-muted-foreground mb-2">
-          <div className="flex items-center gap-1">
-            <Clock className="h-3 w-3" />
-            <span>
-              {operation.actual_time || 0}/{operation.estimated_time}m
-            </span>
+        <div className="mt-4 grid gap-2 text-sm text-muted-foreground sm:grid-cols-2">
+          <div className="rounded-xl border border-border bg-background/70 px-3 py-2">
+            <div className="text-[11px] uppercase tracking-[0.18em]">
+              {t("operations.time", "Time")}
+            </div>
+            <div className="mt-1 flex items-center gap-2 text-foreground">
+              <Clock3 className="h-4 w-4 text-primary" />
+              {(operation.actual_time || 0).toFixed(1)}h /{" "}
+              {(operation.estimated_time || 0).toFixed(1)}h
+            </div>
           </div>
-          {remainingTime !== 0 && (
-            <span className={isOvertime ? "text-destructive font-medium" : ""}>
+
+          <div className="rounded-xl border border-border bg-background/70 px-3 py-2">
+            <div className="text-[11px] uppercase tracking-[0.18em]">
+              {t("operations.remaining", "Remaining")}
+            </div>
+            <div
+              className={`mt-1 flex items-center gap-2 ${
+                isOvertime ? "text-destructive" : "text-foreground"
+              }`}
+            >
+              <ArrowRight className="h-4 w-4" />
               {isOvertime ? "+" : ""}
-              {Math.abs(remainingTime)}m
-            </span>
-          )}
+              {Math.abs(remainingTime).toFixed(1)}h
+            </div>
+          </div>
         </div>
 
-        {/* Due Date */}
-        {dueDate && (
-          <div className="text-xs text-muted-foreground mb-2">
-            {t("operations.due")}: {format(new Date(dueDate), "MMM d, yyyy")}
-          </div>
-        )}
-
-        {/* Active Operator */}
-        {operation.active_time_entry && (
-          <div className="flex items-center gap-2 mt-3 pt-3 border-t">
-            <div className="h-2 w-2 rounded-full bg-status-active animate-pulse" />
-            <User className="h-3 w-3 text-muted-foreground" />
-            <span className="text-xs font-medium">
+        {operation.active_time_entry ? (
+          <div className="mt-4 flex items-center gap-2 rounded-xl border border-primary/20 bg-primary/5 px-3 py-2 text-sm">
+            <div className="h-2.5 w-2.5 rounded-full bg-primary" />
+            <User className="h-4 w-4 text-primary" />
+            <span className="font-medium text-foreground">
               {operation.active_time_entry.operator.full_name}
             </span>
           </div>
-        )}
+        ) : null}
       </Card>
 
       <OperationDetailModal

--- a/src/components/operator/OperatorLayout.tsx
+++ b/src/components/operator/OperatorLayout.tsx
@@ -1,17 +1,15 @@
-import { useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import { DOCS_GUIDES_URL } from '@/lib/config';
-import { Button } from '@/components/ui/button';
-import { ScrollArea } from '@/components/ui/scroll-area';
-import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { DOCS_GUIDES_URL } from "@/lib/config";
+import { Button } from "@/components/ui/button";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
+} from "@/components/ui/dropdown-menu";
 import {
   ListChecks,
   Clock,
@@ -24,27 +22,30 @@ import {
   Search,
   RefreshCw,
   UserCheck,
-} from 'lucide-react';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { useAuth } from '@/contexts/AuthContext';
-import { useOperator } from '@/contexts/OperatorContext';
-import CurrentlyTimingWidget from './CurrentlyTimingWidget';
-import { OperatorSwitcher, ActiveOperatorBadge } from './OperatorSwitcher';
-import { LanguageSwitcher } from '@/components/LanguageSwitcher';
-import { ThemeToggle } from '@/components/ui/theme-toggle';
-import { AppTour } from '@/components/onboarding';
-import AnimatedBackground from '@/components/AnimatedBackground';
-import { cn } from '@/lib/utils';
-import { GlobalSearch, SearchTriggerButton } from '@/components/GlobalSearch';
-import { TrialStatusBanner } from '@/components/admin/TrialStatusBanner';
-import { ROUTES } from '@/routes';
+} from "lucide-react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useAuth } from "@/contexts/AuthContext";
+import { useOperator } from "@/contexts/OperatorContext";
+import CurrentlyTimingWidget from "./CurrentlyTimingWidget";
+import { OperatorSwitcher } from "./OperatorSwitcher";
+import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import { ThemeToggle } from "@/components/ui/theme-toggle";
+import { AppTour } from "@/components/onboarding";
+import { cn } from "@/lib/utils";
+import { GlobalSearch, SearchTriggerButton } from "@/components/GlobalSearch";
+import { TrialStatusBanner } from "@/components/admin/TrialStatusBanner";
+import { ROUTES } from "@/routes";
+import { OperatorStatusChip } from "./OperatorStation";
 
 interface OperatorLayoutProps {
   children: React.ReactNode;
   showBackToAdmin?: boolean;
 }
 
-export const OperatorLayout = ({ children, showBackToAdmin = false }: OperatorLayoutProps) => {
+export const OperatorLayout = ({
+  children,
+  showBackToAdmin = false,
+}: OperatorLayoutProps) => {
   const { t } = useTranslation();
   const { profile, tenant, signOut } = useAuth();
   const { activeOperator } = useOperator();
@@ -53,206 +54,202 @@ export const OperatorLayout = ({ children, showBackToAdmin = false }: OperatorLa
   const [searchOpen, setSearchOpen] = useState(false);
 
   const navItems = [
-    { path: '/operator/work-queue', label: t('navigation.workQueue'), icon: ListChecks },
-    { path: '/operator/view', label: t('navigation.terminalView', 'Terminal View'), icon: Gauge },
-    { path: '/operator/my-activity', label: t('navigation.myActivity'), icon: Clock },
-    { path: '/operator/my-issues', label: t('navigation.myIssues'), icon: Flag },
+    {
+      path: "/operator/work-queue",
+      label: t("navigation.workQueue"),
+      icon: ListChecks,
+      hint: t("navigation.workQueue", "Work queue"),
+    },
+    {
+      path: "/operator/view",
+      label: t("navigation.terminalView", "Terminal View"),
+      icon: Gauge,
+      hint: t("navigation.terminalView", "Terminal"),
+    },
+    {
+      path: "/operator/my-activity",
+      label: t("navigation.myActivity"),
+      icon: Clock,
+      hint: t("navigation.myActivity", "Activity"),
+    },
+    {
+      path: "/operator/my-issues",
+      label: t("navigation.myIssues"),
+      icon: Flag,
+      hint: t("navigation.myIssues", "Issues"),
+    },
   ];
 
   const isActive = (path: string) => location.pathname === path;
 
   return (
     <>
-      <AnimatedBackground />
-      <div className="relative flex flex-col min-h-screen bg-background">
-        {/* Top Header - Glass Morphism - Compact */}
-        <header className="sticky top-0 z-50 w-full glass-card border-b border-border-subtle">
-          <div className="flex items-center justify-between h-12 px-3 sm:px-4">
-            {/* Left: Back to Admin or Tenant/Company Name */}
-            <div className="flex items-center gap-2 min-w-0">
-              {showBackToAdmin ? (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => navigate('/admin/dashboard')}
-                  className="gap-1.5 text-xs h-8"
-                >
-                  <Factory className="h-4 w-4" />
-                  <span className="hidden sm:inline">{t('navigation.backToAdmin', 'Back to Admin')}</span>
-                </Button>
-              ) : (
-                <>
-                  <Building2 className="h-5 w-5 text-primary shrink-0" />
-                  <span className="text-sm font-bold truncate max-w-[120px] sm:max-w-[200px]">
-                    {tenant?.company_name || tenant?.name || t('app.name')}
-                  </span>
-                </>
-              )}
-            </div>
-
-            {/* Center: Active Operator - Always visible and prominent */}
-            <div className="flex items-center gap-2">
-              {activeOperator ? (
-                <div className="flex items-center gap-2 px-2 sm:px-3 py-1 rounded-full bg-green-500/10 border border-green-500/30">
-                  <div className="w-2 h-2 rounded-full bg-green-500 animate-pulse shrink-0" />
-                  <UserCheck className="h-3.5 w-3.5 text-green-500 shrink-0 hidden sm:block" />
-                  <span className="text-xs font-bold text-green-500 truncate max-w-[80px] sm:max-w-[120px]">
-                    {activeOperator.full_name}
-                  </span>
-                  <span className="text-[10px] text-green-500/70 font-mono hidden sm:block">
-                    {activeOperator.employee_id}
-                  </span>
-                </div>
-              ) : (
-                <OperatorSwitcher variant="button" className="h-8" />
-              )}
-            </div>
-
-            {/* Right Side Actions */}
-            <div className="flex items-center gap-1.5">
-              {/* Search Button */}
-              <SearchTriggerButton onClick={() => setSearchOpen(true)} compact />
-
-              {/* Theme & Language Switchers */}
-              <ThemeToggle variant="dropdown" />
-              <LanguageSwitcher />
-
-              {/* User Menu */}
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" size="sm" className="h-8 w-8 rounded-full p-0">
-                    <Avatar className="h-7 w-7 border border-primary/20">
-                      <AvatarFallback className="bg-gradient-to-br from-primary to-primary/60 text-primary-foreground font-semibold text-xs">
-                        {profile?.full_name?.charAt(0).toUpperCase() || 'O'}
-                      </AvatarFallback>
-                    </Avatar>
+      <div className="relative flex min-h-screen flex-col bg-background text-foreground">
+        <header className="sticky top-0 z-50 border-b border-border bg-background/95 backdrop-blur-md">
+          <div className="mx-auto flex w-full max-w-screen-2xl flex-col gap-3 px-3 py-3 sm:px-4 lg:px-6">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="flex min-w-0 items-center gap-3">
+                {showBackToAdmin ? (
+                  <Button
+                    variant="outline"
+                    onClick={() => navigate("/admin/dashboard")}
+                    className="min-h-11 gap-2 rounded-xl border-border/80 bg-card px-3"
+                  >
+                    <Factory className="h-4 w-4" />
+                    <span>{t("navigation.backToAdmin", "Back to Admin")}</span>
                   </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent className="w-56 glass-card" align="end">
-                  {/* Tenant Info - Compact */}
-                  {tenant && (
-                    <>
-                      <div className="px-2 py-1.5 bg-primary/5 border-b border-border-subtle">
-                        <div className="flex items-center gap-1.5">
-                          <Building2 className="h-3.5 w-3.5 text-primary" />
-                          <span className="text-xs font-bold text-primary truncate">
-                            {tenant.company_name || tenant.name}
-                          </span>
-                        </div>
+                ) : (
+                  <div className="flex min-w-0 items-center gap-3">
+                    <div className="flex h-11 w-11 items-center justify-center rounded-2xl border border-border bg-muted/30">
+                      <Building2 className="h-5 w-5 text-primary" />
+                    </div>
+                    <div className="min-w-0">
+                      <div className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                        {t("navigation.terminalView", "Operator workspace")}
                       </div>
-                      <DropdownMenuSeparator className="bg-border-subtle" />
-                    </>
-                  )}
-
-                  {/* Active Operator Info */}
-                  {activeOperator && (
-                    <>
-                      <div className="px-2 py-1.5 bg-green-500/5 border-b border-green-500/20">
-                        <div className="flex items-center gap-1.5">
-                          <UserCheck className="h-3.5 w-3.5 text-green-500" />
-                          <div>
-                            <span className="text-xs font-bold text-green-500 block">
-                              {activeOperator.full_name}
-                            </span>
-                            <span className="text-[10px] text-green-500/70 font-mono">
-                              {activeOperator.employee_id}
-                            </span>
-                          </div>
-                        </div>
+                      <div className="truncate text-base font-semibold">
+                        {tenant?.company_name || tenant?.name || t("app.name")}
                       </div>
-                      <DropdownMenuSeparator className="bg-border-subtle" />
-                    </>
-                  )}
-
-                  {/* User Info - Compact */}
-                  <div className="px-2 py-1.5">
-                    <div className="text-xs font-semibold">{profile?.full_name}</div>
-                    <div className="text-[10px] text-muted-foreground">{profile?.email}</div>
-                    <div className="inline-block mt-1 px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase bg-gradient-to-r from-primary to-primary/60 text-primary-foreground">
-                      {t('app.operator')}
                     </div>
                   </div>
+                )}
+              </div>
 
-                  <DropdownMenuSeparator className="bg-border-subtle" />
+              <div className="flex flex-wrap items-center justify-end gap-2">
+                {activeOperator ? (
+                  <OperatorStatusChip
+                    icon={UserCheck}
+                    tone="success"
+                    label={`${activeOperator.full_name} • ${activeOperator.employee_id}`}
+                    className="max-w-full sm:max-w-[360px]"
+                  />
+                ) : (
+                  <OperatorSwitcher variant="button" className="min-h-11 rounded-xl" />
+                )}
 
-                  {/* Quick Switch Operator */}
-                  <DropdownMenuItem
-                    onClick={() => navigate(ROUTES.OPERATOR.LOGIN)}
-                    className="gap-1.5 cursor-pointer focus:bg-white/5 text-xs"
-                  >
-                    <RefreshCw className="h-3.5 w-3.5" />
-                    {t('operator.switchOperator')}
-                  </DropdownMenuItem>
+                <SearchTriggerButton onClick={() => setSearchOpen(true)} compact />
+                <ThemeToggle variant="dropdown" />
+                <LanguageSwitcher />
 
-                  <DropdownMenuItem
-                    asChild
-                    className="gap-1.5 cursor-pointer focus:bg-white/5 text-xs"
-                  >
-                    <a href={DOCS_GUIDES_URL} target="_blank" rel="noopener noreferrer">
-                      <HelpCircle className="h-3.5 w-3.5" />
-                      {t('common.helpAndDocs')}
-                    </a>
-                  </DropdownMenuItem>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-11 rounded-full border-border/80 bg-card px-1.5"
+                    >
+                      <Avatar className="h-8 w-8">
+                        <AvatarFallback className="bg-primary/10 text-primary">
+                          {profile?.full_name?.charAt(0).toUpperCase() || "O"}
+                        </AvatarFallback>
+                      </Avatar>
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent className="w-64 border-border/80 bg-popover" align="end">
+                    <div className="px-3 py-2">
+                      <div className="text-sm font-semibold">{profile?.full_name}</div>
+                      <div className="text-xs text-muted-foreground">{profile?.email}</div>
+                    </div>
+                    <DropdownMenuSeparator />
+                    {activeOperator ? (
+                      <>
+                        <div className="px-3 py-2 text-xs text-muted-foreground">
+                          {t("operator.switchOperator")}
+                          <div className="mt-1 font-medium text-foreground">
+                            {activeOperator.full_name} • {activeOperator.employee_id}
+                          </div>
+                        </div>
+                        <DropdownMenuSeparator />
+                      </>
+                    ) : null}
+                    <DropdownMenuItem
+                      onClick={() => navigate(ROUTES.OPERATOR.LOGIN)}
+                      className="min-h-11 gap-2"
+                    >
+                      <RefreshCw className="h-4 w-4" />
+                      {t("operator.switchOperator")}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem asChild className="min-h-11 gap-2">
+                      <a href={DOCS_GUIDES_URL} target="_blank" rel="noopener noreferrer">
+                        <HelpCircle className="h-4 w-4" />
+                        {t("common.helpAndDocs")}
+                      </a>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={signOut}
+                      className="min-h-11 gap-2 text-destructive focus:text-destructive"
+                    >
+                      <LogOut className="h-4 w-4" />
+                      {t("auth.signOut")}
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            </div>
 
-                  <DropdownMenuItem
-                    onClick={signOut}
-                    className="gap-1.5 cursor-pointer focus:bg-white/5 text-destructive focus:text-destructive text-xs"
-                  >
-                    <LogOut className="h-3.5 w-3.5" />
-                    {t('auth.signOut')}
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+            <div className="hidden gap-2 lg:grid lg:grid-cols-4">
+              {navItems.map((item) => (
+                <button
+                  key={item.path}
+                  onClick={() => navigate(item.path)}
+                  className={cn(
+                    "flex min-h-12 items-center justify-between rounded-2xl border px-4 text-left transition-colors",
+                    isActive(item.path)
+                      ? "border-primary/40 bg-primary/10 text-foreground"
+                      : "border-border/80 bg-card text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  <div className="flex items-center gap-3">
+                    <item.icon className="h-5 w-5" />
+                    <div>
+                      <div className="text-sm font-semibold">{item.label}</div>
+                      <div className="text-xs text-muted-foreground">{item.hint}</div>
+                    </div>
+                  </div>
+                  <Search className="h-4 w-4 opacity-0" />
+                </button>
+              ))}
             </div>
           </div>
         </header>
 
-        {/* Trial Status Banner */}
         <TrialStatusBanner />
 
-        {/* Currently Timing Widget - Sticky - Compact */}
-        <div className="sticky top-12 z-40 border-b border-border-subtle glass-card">
-          <div className="px-3 sm:px-4 py-2">
+        <div className="sticky top-[102px] z-40 border-b border-border bg-background/95 backdrop-blur-md lg:top-[154px]">
+          <div className="mx-auto w-full max-w-screen-2xl px-3 py-2 sm:px-4 lg:px-6">
             <CurrentlyTimingWidget />
           </div>
         </div>
 
-        {/* Main Content */}
-        <main className="flex-1 px-3 sm:px-4 py-3 sm:py-4 pb-20">
-          {children}
+        <main className="mx-auto flex w-full max-w-screen-2xl flex-1 px-3 py-4 pb-24 sm:px-4 lg:px-6">
+          <div className="w-full">{children}</div>
         </main>
 
-        {/* Bottom Navigation - Fixed for all screen sizes */}
-        <nav className="fixed bottom-0 left-0 right-0 z-50 border-t border-border-subtle glass-card">
-          <div className="grid grid-cols-4 h-14 max-w-lg mx-auto">
+        <nav className="fixed bottom-0 left-0 right-0 z-50 border-t border-border bg-background/98 backdrop-blur-md">
+          <div className="mx-auto grid h-16 max-w-screen-2xl grid-cols-4 px-2">
             {navItems.map((item) => (
               <button
                 key={item.path}
                 onClick={() => navigate(item.path)}
                 className={cn(
-                  "flex flex-col items-center justify-center gap-0.5 transition-base",
+                  "flex min-h-16 flex-col items-center justify-center gap-1 rounded-2xl transition-colors",
                   isActive(item.path)
                     ? "text-primary"
-                    : "text-muted-foreground hover:text-foreground"
+                    : "text-muted-foreground hover:text-foreground",
                 )}
               >
-                <item.icon className={cn("h-5 w-5", isActive(item.path) && "text-primary")} />
-                <span className={cn(
-                  "text-[10px] sm:text-xs",
-                  isActive(item.path) ? "font-semibold" : "font-medium"
-                )}>
-                  {item.label}
-                </span>
+                <item.icon className="h-5 w-5" />
+                <span className="text-[11px] font-semibold sm:text-xs">{item.label}</span>
               </button>
             ))}
           </div>
         </nav>
 
-        {/* Onboarding Tour - only show if not completed and tour_completed is explicitly false */}
-        {profile && (profile as any).tour_completed === false && <AppTour userRole="operator" />}
+        {profile && (profile as { tour_completed?: boolean }).tour_completed === false ? (
+          <AppTour userRole="operator" />
+        ) : null}
       </div>
 
-      {/* Global Search Modal */}
       <GlobalSearch open={searchOpen} onClose={() => setSearchOpen(false)} />
     </>
   );

--- a/src/components/operator/OperatorLayout.tsx
+++ b/src/components/operator/OperatorLayout.tsx
@@ -19,7 +19,6 @@ import {
   Building2,
   Gauge,
   Factory,
-  Search,
   RefreshCw,
   UserCheck,
 } from "lucide-react";
@@ -105,7 +104,7 @@ export const OperatorLayout = ({
                     </div>
                     <div className="min-w-0">
                       <div className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-                        {t("navigation.terminalView", "Operator workspace")}
+                        {t("navigation.terminalView", "Terminal View")}
                       </div>
                       <div className="truncate text-base font-semibold">
                         {tenant?.company_name || tenant?.name || t("app.name")}
@@ -206,7 +205,7 @@ export const OperatorLayout = ({
                       <div className="text-xs text-muted-foreground">{item.hint}</div>
                     </div>
                   </div>
-                  <Search className="h-4 w-4 opacity-0" />
+                  <span aria-hidden="true" className="h-4 w-4" />
                 </button>
               ))}
             </div>

--- a/src/components/operator/OperatorStation.tsx
+++ b/src/components/operator/OperatorStation.tsx
@@ -1,0 +1,187 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+type Tone = "neutral" | "active" | "success" | "warning" | "danger" | "info";
+
+const toneClasses: Record<Tone, string> = {
+  neutral: "border-border bg-card text-foreground",
+  active: "border-primary/30 bg-primary/5 text-primary",
+  success: "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+  warning: "border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400",
+  danger: "border-destructive/30 bg-destructive/10 text-destructive",
+  info: "border-sky-500/30 bg-sky-500/10 text-sky-600 dark:text-sky-400",
+};
+
+interface OperatorPageHeaderProps {
+  eyebrow?: string;
+  title: string;
+  description?: string;
+  meta?: ReactNode;
+  actions?: ReactNode;
+}
+
+export function OperatorPageHeader({
+  eyebrow,
+  title,
+  description,
+  meta,
+  actions,
+}: OperatorPageHeaderProps) {
+  return (
+    <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+      <div className="space-y-2">
+        {eyebrow ? (
+          <div className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+            {eyebrow}
+          </div>
+        ) : null}
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
+            {title}
+          </h1>
+          {description ? (
+            <p className="max-w-3xl text-sm text-muted-foreground sm:text-base">
+              {description}
+            </p>
+          ) : null}
+        </div>
+        {meta ? <div className="flex flex-wrap gap-2">{meta}</div> : null}
+      </div>
+      {actions ? (
+        <div className="flex flex-wrap items-center gap-2 lg:justify-end">
+          {actions}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+interface OperatorPanelProps extends HTMLAttributes<HTMLDivElement> {
+  padded?: boolean;
+}
+
+export function OperatorPanel({
+  className,
+  padded = true,
+  ...props
+}: OperatorPanelProps) {
+  return (
+    <Card
+      className={cn(
+        "border-border/80 bg-card/95 shadow-sm backdrop-blur-sm",
+        padded && "p-4 sm:p-5",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+interface OperatorStatCardProps {
+  label: string;
+  value: ReactNode;
+  icon?: LucideIcon;
+  tone?: Tone;
+  caption?: string;
+  className?: string;
+}
+
+export function OperatorStatCard({
+  label,
+  value,
+  icon: Icon,
+  tone = "neutral",
+  caption,
+  className,
+}: OperatorStatCardProps) {
+  return (
+    <OperatorPanel className={cn("p-4", className)}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-2">
+          <div className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            {label}
+          </div>
+          <div className="text-2xl font-semibold tracking-tight text-foreground">
+            {value}
+          </div>
+          {caption ? (
+            <div className="text-sm text-muted-foreground">{caption}</div>
+          ) : null}
+        </div>
+        {Icon ? (
+          <div
+            className={cn(
+              "flex h-11 w-11 items-center justify-center rounded-xl border",
+              toneClasses[tone],
+            )}
+          >
+            <Icon className="h-5 w-5" />
+          </div>
+        ) : null}
+      </div>
+    </OperatorPanel>
+  );
+}
+
+interface OperatorStatusChipProps {
+  icon?: LucideIcon;
+  label: string;
+  tone?: Tone;
+  className?: string;
+}
+
+export function OperatorStatusChip({
+  icon: Icon,
+  label,
+  tone = "neutral",
+  className,
+}: OperatorStatusChipProps) {
+  return (
+    <div
+      className={cn(
+        "inline-flex min-h-10 items-center gap-2 rounded-full border px-3 py-2 text-sm font-medium",
+        toneClasses[tone],
+        className,
+      )}
+    >
+      {Icon ? <Icon className="h-4 w-4 shrink-0" /> : null}
+      <span>{label}</span>
+    </div>
+  );
+}
+
+interface OperatorEmptyStateProps {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  action?: ReactNode;
+  className?: string;
+}
+
+export function OperatorEmptyState({
+  icon: Icon,
+  title,
+  description,
+  action,
+  className,
+}: OperatorEmptyStateProps) {
+  return (
+    <OperatorPanel
+      className={cn(
+        "flex min-h-[240px] flex-col items-center justify-center gap-4 text-center",
+        className,
+      )}
+    >
+      <div className="flex h-16 w-16 items-center justify-center rounded-2xl border border-border bg-muted/30">
+        <Icon className="h-8 w-8 text-muted-foreground" />
+      </div>
+      <div className="space-y-1">
+        <h3 className="text-lg font-semibold text-foreground">{title}</h3>
+        <p className="max-w-md text-sm text-muted-foreground">{description}</p>
+      </div>
+      {action ? <div className="pt-1">{action}</div> : null}
+    </OperatorPanel>
+  );
+}

--- a/src/components/terminal/DetailPanel.tsx
+++ b/src/components/terminal/DetailPanel.tsx
@@ -1,474 +1,702 @@
-import React, { useState, useMemo, useEffect } from 'react';
-import { TerminalJob } from '@/types/terminal';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Button } from '@/components/ui/button';
-import { Play, Pause, Square, FileText, Box, AlertTriangle, CheckCircle2, Clock, Circle, Maximize2, X, ChevronDown, ChevronRight, PackageCheck, Zap } from 'lucide-react';
-import { CncProgramQrCode } from './CncProgramQrCode';
-import { STEPViewer } from '@/components/STEPViewerLazy';
-import { PDFViewer } from '@/components/PDFViewerLazy';
-import { OperationResources } from './OperationResources';
-import { AssemblyDependencies } from './AssemblyDependencies';
-import type { PMIData, GeometryData } from '@/hooks/useCADProcessing';
-import { OperationWithDetails } from '@/lib/database';
-import { cn } from '@/lib/utils';
-import IssueForm from '@/components/operator/IssueForm';
-import ProductionQuantityModal from '@/components/operator/ProductionQuantityModal';
-import { JobFlowProgress } from './JobFlowProgress';
-import { useCellQRMMetrics } from '@/hooks/useQRMMetrics';
-import { useAuth } from '@/contexts/AuthContext';
-import { createPortal } from 'react-dom';
-import { supabase } from '@/integrations/supabase/client';
-import { IconDisplay } from '@/components/ui/icon-picker';
-import { useTranslation } from 'react-i18next';
-import { logger } from '@/lib/logger';
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { TerminalJob } from "@/types/terminal";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Play,
+  Pause,
+  Square,
+  FileText,
+  Box,
+  AlertTriangle,
+  CheckCircle2,
+  Clock3,
+  Circle,
+  Maximize2,
+  X,
+  ChevronDown,
+  ChevronRight,
+  PackageCheck,
+  Zap,
+  Layers3,
+  MapPinned,
+} from "lucide-react";
+import { CncProgramQrCode } from "./CncProgramQrCode";
+import { STEPViewer } from "@/components/STEPViewerLazy";
+import { PDFViewer } from "@/components/PDFViewerLazy";
+import { OperationResources } from "./OperationResources";
+import { AssemblyDependencies } from "./AssemblyDependencies";
+import type { PMIData, GeometryData } from "@/hooks/useCADProcessing";
+import { OperationWithDetails } from "@/lib/database";
+import { cn } from "@/lib/utils";
+import IssueForm from "@/components/operator/IssueForm";
+import ProductionQuantityModal from "@/components/operator/ProductionQuantityModal";
+import { JobFlowProgress } from "./JobFlowProgress";
+import { useCellQRMMetrics } from "@/hooks/useQRMMetrics";
+import { useAuth } from "@/contexts/AuthContext";
+import { supabase } from "@/integrations/supabase/client";
+import { IconDisplay } from "@/components/ui/icon-picker";
+import { useTranslation } from "react-i18next";
+import { logger } from "@/lib/logger";
 
 interface Substep {
-    id: string;
-    operation_id: string;
-    name: string;
-    icon_name?: string | null;
-    sequence: number;
-    status: string;
-    notes?: string;
+  id: string;
+  operation_id: string;
+  name: string;
+  icon_name?: string | null;
+  sequence: number;
+  status: string;
+  notes?: string;
 }
 
 interface DetailPanelProps {
-    job: TerminalJob;
-    onStart?: () => void;
-    onPause?: () => void;
-    onComplete?: () => void;
-    stepUrl?: string | null;
-    pdfUrl?: string | null;
-    pmiData?: PMIData | null;
-    serverGeometry?: GeometryData | null;
-    operations?: OperationWithDetails[];
-    onDataRefresh?: () => void;
+  job: TerminalJob;
+  onStart?: () => void;
+  onPause?: () => void;
+  onComplete?: () => void;
+  stepUrl?: string | null;
+  pdfUrl?: string | null;
+  pmiData?: PMIData | null;
+  serverGeometry?: GeometryData | null;
+  operations?: OperationWithDetails[];
+  onDataRefresh?: () => void;
 }
 
-export function DetailPanel({ job, onStart, onPause, onComplete, stepUrl, pdfUrl, pmiData, serverGeometry, operations = [], onDataRefresh }: DetailPanelProps) {
-    const { t } = useTranslation();
-    const [isIssueModalOpen, setIsIssueModalOpen] = useState(false);
-    const [isQuantityModalOpen, setIsQuantityModalOpen] = useState(false);
-    const [issuePrefilledData, setIssuePrefilledData] = useState<{ affectedQuantity?: number; isShortfall?: boolean } | null>(null);
-    const [fullscreenViewer, setFullscreenViewer] = useState<'3d' | 'pdf' | null>(null);
-    const [substepsByOperation, setSubstepsByOperation] = useState<Record<string, Substep[]>>({});
-    const [expandedOperations, setExpandedOperations] = useState<Set<string>>(new Set());
-    const { profile } = useAuth();
+type ViewerTab = "3d" | "pdf" | "ops";
 
-    useEffect(() => {
-        const fetchSubsteps = async () => {
-            if (!profile?.tenant_id || operations.length === 0) return;
+export function DetailPanel({
+  job,
+  onStart,
+  onPause,
+  onComplete,
+  stepUrl,
+  pdfUrl,
+  pmiData,
+  serverGeometry,
+  operations = [],
+  onDataRefresh,
+}: DetailPanelProps) {
+  const { t } = useTranslation();
+  const [isIssueModalOpen, setIsIssueModalOpen] = useState(false);
+  const [isQuantityModalOpen, setIsQuantityModalOpen] = useState(false);
+  const [issuePrefilledData, setIssuePrefilledData] = useState<{
+    affectedQuantity?: number;
+    isShortfall?: boolean;
+  } | null>(null);
+  const [fullscreenViewer, setFullscreenViewer] = useState<"3d" | "pdf" | null>(
+    null,
+  );
+  const [substepsByOperation, setSubstepsByOperation] = useState<
+    Record<string, Substep[]>
+  >({});
+  const [expandedOperations, setExpandedOperations] = useState<Set<string>>(
+    new Set(),
+  );
+  const { profile } = useAuth();
+  const defaultTab: ViewerTab = job.hasModel ? "3d" : job.hasPdf ? "pdf" : "ops";
 
-            const operationIds = operations.map(op => op.id);
-            const { data, error } = await supabase
-                .from("substeps")
-                .select("*")
-                .in("operation_id", operationIds)
-                .eq("tenant_id", profile.tenant_id)
-                .order("sequence", { ascending: true });
+  useEffect(() => {
+    const fetchSubsteps = async () => {
+      if (!profile?.tenant_id || operations.length === 0) return;
 
-            if (error) {
-                logger.error("DetailPanel", "Error fetching substeps", error);
-                return;
-            }
+      const operationIds = operations.map((operation) => operation.id);
+      const { data, error } = await supabase
+        .from("substeps")
+        .select("*")
+        .in("operation_id", operationIds)
+        .eq("tenant_id", profile.tenant_id)
+        .order("sequence", { ascending: true });
 
-            const grouped: Record<string, Substep[]> = {};
-            (data || []).forEach((substep) => {
-                if (!grouped[substep.operation_id]) {
-                    grouped[substep.operation_id] = [];
-                }
-                grouped[substep.operation_id].push(substep);
-            });
-            setSubstepsByOperation(grouped);
-        };
+      if (error) {
+        logger.error("DetailPanel", "Error fetching substeps", error);
+        return;
+      }
 
-        fetchSubsteps();
-    }, [operations, profile?.tenant_id]);
-
-    const toggleOperationExpand = (opId: string) => {
-        setExpandedOperations(prev => {
-            const next = new Set(prev);
-            if (next.has(opId)) {
-                next.delete(opId);
-            } else {
-                next.add(opId);
-            }
-            return next;
-        });
+      const grouped: Record<string, Substep[]> = {};
+      (data || []).forEach((substep) => {
+        if (!grouped[substep.operation_id]) {
+          grouped[substep.operation_id] = [];
+        }
+        grouped[substep.operation_id].push(substep);
+      });
+      setSubstepsByOperation(grouped);
     };
 
-    const nextOperation = useMemo(() => {
-        if (!job.currentSequence) return null;
-        // Find the next operation in sequence order
-        const sorted = [...operations].sort((a, b) => a.sequence - b.sequence);
-        const currentIndex = sorted.findIndex(op => op.id === job.operationId);
-        if (currentIndex === -1 || currentIndex === sorted.length - 1) return null;
-        return sorted[currentIndex + 1];
-    }, [operations, job.currentSequence, job.operationId]);
+    void fetchSubsteps();
+  }, [operations, profile?.tenant_id]);
 
-    const { metrics: nextCellMetrics } = useCellQRMMetrics(
-        nextOperation?.cell_id || null,
-        profile?.tenant_id || null
-    );
+  const toggleOperationExpand = (operationId: string) => {
+    setExpandedOperations((prev) => {
+      const next = new Set(prev);
+      if (next.has(operationId)) {
+        next.delete(operationId);
+      } else {
+        next.add(operationId);
+      }
+      return next;
+    });
+  };
 
-    const isBlockedByCapacity = useMemo(() => {
-        if (!nextOperation || !nextCellMetrics) return false;
-        // Check if capacity is enforced and if we're at or over the limit
-        if (!nextCellMetrics.enforce_limit) return false;
-        if (nextCellMetrics.wip_limit === null) return false;
-        return nextCellMetrics.current_wip >= nextCellMetrics.wip_limit;
-    }, [nextOperation, nextCellMetrics]);
+  const nextOperation = useMemo(() => {
+    if (!job.currentSequence) return null;
+    const sorted = [...operations].sort((a, b) => a.sequence - b.sequence);
+    const currentIndex = sorted.findIndex((operation) => operation.id === job.operationId);
+    if (currentIndex === -1 || currentIndex === sorted.length - 1) return null;
+    return sorted[currentIndex + 1];
+  }, [operations, job.currentSequence, job.operationId]);
+
+  const { metrics: nextCellMetrics } = useCellQRMMetrics(
+    nextOperation?.cell_id || null,
+    profile?.tenant_id || null,
+  );
+
+  const isBlockedByCapacity = useMemo(() => {
+    if (!nextOperation || !nextCellMetrics) return false;
+    if (!nextCellMetrics.enforce_limit || nextCellMetrics.wip_limit === null) {
+      return false;
+    }
+    return nextCellMetrics.current_wip >= nextCellMetrics.wip_limit;
+  }, [nextOperation, nextCellMetrics]);
+
+  const statusBadge = useMemo(() => {
+    if (job.isCurrentUserClocked) {
+      return {
+        label: t("terminal.inProcess"),
+        className: "border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400",
+      };
+    }
+
+    switch (job.status) {
+      case "in_progress":
+        return {
+          label: t("terminal.inProcess"),
+          className: "border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400",
+        };
+      case "in_buffer":
+        return {
+          label: t("terminal.inBuffer"),
+          className: "border-sky-500/30 bg-sky-500/10 text-sky-600 dark:text-sky-400",
+        };
+      case "on_hold":
+        return {
+          label: t("terminal.onHold", "On hold"),
+          className: "border-orange-500/30 bg-orange-500/10 text-orange-600 dark:text-orange-400",
+        };
+      default:
+        return {
+          label: t("terminal.expected"),
+          className: "border-border bg-muted text-foreground",
+        };
+    }
+  }, [job.isCurrentUserClocked, job.status, t]);
+
+  const showCompleteAction = job.status === "in_progress" || job.isCurrentUserClocked;
+  const completeDisabled =
+    Boolean(job.activeTimeEntryId) || isBlockedByCapacity;
+  const completeTitle = job.activeTimeEntryId
+    ? t(
+        "terminal.stopBeforeComplete",
+        "Pause active timing before completing the operation.",
+      )
+    : isBlockedByCapacity
+      ? t(
+          "terminal.capacityBlocked",
+          "Cannot complete because the next cell is at capacity.",
+        )
+      : t("terminal.completeOperation", "Complete operation");
+
+  const renderOperations = () => {
+    if (operations.length === 0) {
+      return (
+        <div className="rounded-2xl border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+          {t("terminal.noOperationsFound", "No routing steps found for this part.")}
+        </div>
+      );
+    }
 
     return (
-        <div className="flex flex-col h-full bg-card text-card-foreground">
+      <div className="space-y-2">
+        {operations.map((operation) => {
+          const operationSubsteps = substepsByOperation[operation.id] || [];
+          const hasSubsteps = operationSubsteps.length > 0;
+          const isExpanded = expandedOperations.has(operation.id);
+          const completedSubsteps = operationSubsteps.filter(
+            (substep) => substep.status === "completed",
+          ).length;
 
-            <div className="p-3 border-b border-border bg-card">
-                {job.isBulletCard && (
-                    <div className="mb-2 -mx-3 -mt-3 px-3 py-1.5 bg-destructive/10 border-b border-destructive/30 flex items-center gap-2">
-                        <Zap className="w-4 h-4 text-destructive animate-pulse" />
-                        <span className="text-xs font-bold text-destructive uppercase tracking-wider">{t('terminal.bulletCard')}</span>
-                    </div>
+          return (
+            <div
+              key={operation.id}
+              className={cn(
+                "rounded-2xl border border-border bg-background/80",
+                operation.id === job.operationId && "border-primary/40 bg-primary/5",
+              )}
+            >
+              <button
+                type="button"
+                onClick={() => hasSubsteps && toggleOperationExpand(operation.id)}
+                className={cn(
+                  "flex w-full items-center justify-between gap-3 px-4 py-3 text-left",
+                  !hasSubsteps && "cursor-default",
                 )}
-
-                <div className="flex justify-between items-start mb-1.5">
-                    <div className="min-w-0 flex-1">
-                        <h2 className="text-lg font-bold text-foreground truncate">{job.jobCode}</h2>
-                        <p className="text-muted-foreground text-xs truncate">{job.description}</p>
-                        {job.drawingNo && (
-                            <p className="text-muted-foreground text-[10px]">{t('parts.drawingNo')}: {job.drawingNo}</p>
-                        )}
-                    </div>
-                    <div className="text-right shrink-0 ml-2">
-                        <div className="text-base font-mono font-bold text-primary">{job.quantity} <span className="text-xs text-muted-foreground">pcs</span></div>
-                        <div className="text-[10px] text-muted-foreground">Due: {new Date(job.dueDate).toLocaleDateString()}</div>
-                    </div>
+              >
+                <div className="min-w-0 space-y-1">
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono text-xs text-muted-foreground">
+                      {operation.sequence}.
+                    </span>
+                    <span className="truncate text-sm font-semibold text-foreground">
+                      {operation.operation_name}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {operation.cell?.name || "?"}
+                    </span>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                    <span>{operation.estimated_time}h est.</span>
+                    {hasSubsteps ? (
+                      <span>
+                        {completedSubsteps}/{operationSubsteps.length}{" "}
+                        {t("terminal.substeps", "substeps")}
+                      </span>
+                    ) : null}
+                  </div>
                 </div>
-
-                <div className="my-2 p-2 bg-accent/10 border border-accent/20 rounded-md">
-                    <div className="text-[10px] text-muted-foreground uppercase tracking-wider font-bold">Ready to Start</div>
-                    <div className="text-sm font-semibold text-foreground flex items-center gap-1.5">
-                        <div className="w-1.5 h-1.5 rounded-full bg-primary animate-pulse" />
-                        {job.currentOp}
-                    </div>
-                </div>
-
-                <div className="flex gap-1.5">
-                    {!job.isCurrentUserClocked ? (
-                        <Button onClick={onStart} size="sm" className="flex-1 bg-emerald-600 hover:bg-emerald-700 text-white h-8 text-xs">
-                            <Play className="w-3.5 h-3.5 mr-1.5" /> Start
-                        </Button>
+                <div className="flex items-center gap-2">
+                  {operation.status === "completed" ? (
+                    <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+                  ) : null}
+                  {operation.status === "in_progress" ? (
+                    <Clock3 className="h-4 w-4 text-primary" />
+                  ) : null}
+                  {operation.status === "not_started" ? (
+                    <Circle className="h-4 w-4 text-muted-foreground/60" />
+                  ) : null}
+                  {operation.status === "on_hold" ? (
+                    <AlertTriangle className="h-4 w-4 text-amber-500" />
+                  ) : null}
+                  {hasSubsteps ? (
+                    isExpanded ? (
+                      <ChevronDown className="h-4 w-4 text-muted-foreground" />
                     ) : (
-                        <Button onClick={onPause} variant="outline" size="sm" className="flex-1 border-border text-foreground hover:bg-accent h-8 text-xs">
-                            <Pause className="w-3.5 h-3.5 mr-1.5" /> Pause
-                        </Button>
-                    )}
-                    <Button
-                        onClick={() => setIsQuantityModalOpen(true)}
-                        variant="outline"
-                        size="sm"
-                        className="border-primary text-primary hover:bg-primary/10 h-8 text-xs px-2"
-                        title={t('production.reportTitle', 'Record Production Quantities')}
-                    >
-                        <PackageCheck className="w-3.5 h-3.5" />
-                    </Button>
-                    {(job.status === 'in_progress' || job.isCurrentUserClocked) && !job.activeTimeEntryId && (
-                        <Button
-                            onClick={onComplete}
-                            variant="outline"
-                            size="sm"
-                            className="flex-1 border-border text-emerald-600 hover:bg-emerald-50 dark:hover:bg-emerald-950/30 h-8 text-xs"
-                            disabled={isBlockedByCapacity}
-                            title={isBlockedByCapacity ? "Cannot complete - next cell at capacity" : "Complete operation"}
-                        >
-                            <Square className="w-3.5 h-3.5 mr-1.5" /> Complete
-                        </Button>
-                    )}
-                    <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => {
-                            setIssuePrefilledData(null);
-                            setIsIssueModalOpen(true);
-                        }}
-                        title={t('issues.reportIssue', 'Report Issue')}
-                        className="border-amber-200 text-amber-600 hover:bg-amber-50 hover:text-amber-700 dark:border-amber-800 dark:text-amber-400 dark:hover:bg-amber-950/30 h-8 w-8 p-0"
-                    >
-                        <AlertTriangle className="w-3.5 h-3.5" />
-                    </Button>
+                      <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                    )
+                  ) : null}
                 </div>
-            </div>
+              </button>
 
-            {job.jobId && (
-                <div className="px-3 py-2 border-b border-border bg-muted/20">
-                    <JobFlowProgress
-                        jobId={job.jobId}
-                        currentCellId={job.cellId}
-                        nextCellName={nextOperation?.cell?.name}
-                        nextCellMetrics={nextCellMetrics}
-                    />
-                </div>
-            )}
-
-            {job.cncProgramName && (
-                <div className="px-3 py-2 border-b border-border flex items-center gap-3">
-                    <div className="bg-white p-1.5 rounded border border-border shrink-0">
-                        <CncProgramQrCode
-                            programName={job.cncProgramName}
-                            size={56}
-                        />
-                    </div>
-                    <div className="min-w-0">
-                        <div className="text-[10px] text-muted-foreground uppercase tracking-wider">{t('parts.cncProgramName')}</div>
-                        <p className="font-mono font-semibold text-sm text-foreground truncate">{job.cncProgramName}</p>
-                    </div>
-                </div>
-            )}
-
-            <div className="px-3 py-2 border-b border-border bg-muted/10 space-y-2">
-                <OperationResources operationId={job.operationId} />
-
-                <AssemblyDependencies partId={job.partId} />
-            </div>
-
-            <div className="flex-1 min-h-0">
-                <Tabs defaultValue={job.hasModel ? "3d" : job.hasPdf ? "pdf" : "ops"} className="h-full flex flex-col">
-                    <div className="px-2 pt-1.5">
-                        <TabsList className="w-full bg-muted text-muted-foreground h-8">
-                            {job.hasModel && (
-                                <TabsTrigger value="3d" className="flex-1 text-xs h-7 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm">
-                                    <Box className="w-3.5 h-3.5 mr-1" /> 3D
-                                </TabsTrigger>
-                            )}
-                            {job.hasPdf && (
-                                <TabsTrigger value="pdf" className="flex-1 text-xs h-7 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm">
-                                    <FileText className="w-3.5 h-3.5 mr-1" /> PDF
-                                </TabsTrigger>
-                            )}
-                            <TabsTrigger value="ops" className="flex-1 text-xs h-7 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm">
-                                Ops
-                            </TabsTrigger>
-                        </TabsList>
-                    </div>
-
-                    <div className="flex-1 p-2 min-h-0 overflow-hidden">
-                        {job.hasModel && (
-                            <TabsContent value="3d" className="h-full m-0 rounded-md overflow-hidden border border-border bg-background relative group">
-                                <STEPViewer
-                                    url={stepUrl || ""}
-                                    title={job.jobCode}
-                                    pmiData={pmiData}
-                                    serverGeometry={serverGeometry}
-                                    preferServerGeometry={true}
-                                />
-                                <Button
-                                    variant="secondary"
-                                    size="sm"
-                                    onClick={() => setFullscreenViewer('3d')}
-                                    className="absolute top-2 right-2 h-7 px-2 opacity-70 hover:opacity-100 bg-background/80 backdrop-blur-sm shadow-md z-10"
-                                >
-                                    <Maximize2 className="w-3.5 h-3.5 mr-1" /> Expand
-                                </Button>
-                            </TabsContent>
+              {hasSubsteps && isExpanded ? (
+                <div className="border-t border-border px-4 py-3">
+                  <div className="space-y-2">
+                    {operationSubsteps.map((substep) => (
+                      <div
+                        key={substep.id}
+                        className="flex items-center gap-2 text-sm text-muted-foreground"
+                      >
+                        {substep.status === "completed" ? (
+                          <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-500" />
+                        ) : substep.status === "in_progress" ? (
+                          <Clock3 className="h-4 w-4 shrink-0 text-primary" />
+                        ) : substep.status === "blocked" ? (
+                          <AlertTriangle className="h-4 w-4 shrink-0 text-destructive" />
+                        ) : (
+                          <Circle className="h-4 w-4 shrink-0 text-muted-foreground/60" />
                         )}
-
-                        {job.hasPdf && (
-                            <TabsContent value="pdf" className="h-full m-0 rounded-md overflow-hidden border border-border bg-background relative group">
-                                <PDFViewer url={pdfUrl || ""} title={job.jobCode} />
-                                <Button
-                                    variant="secondary"
-                                    size="sm"
-                                    onClick={() => setFullscreenViewer('pdf')}
-                                    className="absolute top-2 right-2 h-7 px-2 opacity-70 hover:opacity-100 bg-background/80 backdrop-blur-sm shadow-md z-10"
-                                >
-                                    <Maximize2 className="w-3.5 h-3.5 mr-1" /> Expand
-                                </Button>
-                            </TabsContent>
-                        )}
-
-                        <TabsContent value="ops" className="h-full m-0 overflow-auto">
-                            <div className="space-y-0.5">
-                                {operations.length === 0 && (
-                                    <div className="text-center text-muted-foreground py-4 text-xs">No operations found</div>
-                                )}
-                                {operations.map((op) => {
-                                    const opSubsteps = substepsByOperation[op.id] || [];
-                                    const hasSubsteps = opSubsteps.length > 0;
-                                    const isExpanded = expandedOperations.has(op.id);
-                                    const completedSubsteps = opSubsteps.filter(s => s.status === 'completed').length;
-
-                                    return (
-                                        <div key={op.id}>
-                                            <div
-                                                className={cn(
-                                                    "px-2 py-1 rounded border-l-2 flex items-center justify-between transition-colors",
-                                                    op.status === 'in_progress'
-                                                        ? "bg-primary/5 border-l-primary"
-                                                        : "bg-transparent border-l-transparent hover:bg-muted/30",
-                                                    op.status === 'completed' && "opacity-50",
-                                                    hasSubsteps && "cursor-pointer"
-                                                )}
-                                                onClick={() => hasSubsteps && toggleOperationExpand(op.id)}
-                                            >
-                                                <div className="flex items-center gap-1.5 min-w-0">
-                                                    {hasSubsteps && (
-                                                        <span className="text-muted-foreground">
-                                                            {isExpanded ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
-                                                        </span>
-                                                    )}
-                                                    <span className={cn(
-                                                        "text-[9px] font-mono w-4 shrink-0",
-                                                        op.status === 'completed' ? "text-emerald-500" :
-                                                            op.status === 'in_progress' ? "text-primary font-bold" :
-                                                                "text-muted-foreground"
-                                                    )}>
-                                                        {op.sequence}.
-                                                    </span>
-                                                    <span className={cn(
-                                                        "text-[11px] truncate",
-                                                        op.status === 'completed' ? "text-muted-foreground line-through" : "text-foreground"
-                                                    )}>
-                                                        {op.operation_name}
-                                                    </span>
-                                                    <span className="text-[9px] text-muted-foreground shrink-0">
-                                                        ({op.cell?.name?.slice(0, 8) || '?'})
-                                                    </span>
-                                                </div>
-                                                <div className="flex items-center gap-1 shrink-0">
-                                                    {hasSubsteps && (
-                                                        <span className="text-[8px] text-muted-foreground bg-muted px-1 rounded">
-                                                            {completedSubsteps}/{opSubsteps.length}
-                                                        </span>
-                                                    )}
-                                                    <span className="text-[9px] text-muted-foreground">{op.estimated_time}h</span>
-                                                    {op.status === 'completed' && <CheckCircle2 className="w-3 h-3 text-emerald-500" />}
-                                                    {op.status === 'in_progress' && <Clock className="w-3 h-3 text-primary" />}
-                                                    {op.status === 'not_started' && <Circle className="w-3 h-3 text-muted-foreground/50" />}
-                                                    {op.status === 'on_hold' && <AlertTriangle className="w-3 h-3 text-amber-500" />}
-                                                </div>
-                                            </div>
-                                            {hasSubsteps && isExpanded && (
-                                                <div className="ml-6 pl-2 border-l border-muted/50 space-y-0.5 py-1">
-                                                    {opSubsteps.map((substep) => (
-                                                        <div
-                                                            key={substep.id}
-                                                            className="flex items-center gap-1.5 text-[10px] py-0.5"
-                                                        >
-                                                            {substep.status === 'completed' ? (
-                                                                <CheckCircle2 className="w-3 h-3 text-emerald-500 shrink-0" />
-                                                            ) : substep.status === 'in_progress' ? (
-                                                                <Clock className="w-3 h-3 text-primary shrink-0" />
-                                                            ) : substep.status === 'blocked' ? (
-                                                                <AlertTriangle className="w-3 h-3 text-red-500 shrink-0" />
-                                                            ) : (
-                                                                <Circle className="w-3 h-3 text-muted-foreground/50 shrink-0" />
-                                                            )}
-                                                            {substep.icon_name && (
-                                                                <IconDisplay
-                                                                    iconName={substep.icon_name}
-                                                                    className="w-3 h-3 text-muted-foreground shrink-0"
-                                                                />
-                                                            )}
-                                                            <span className={cn(
-                                                                "truncate",
-                                                                substep.status === 'completed' && "text-muted-foreground line-through"
-                                                            )}>
-                                                                {substep.name}
-                                                            </span>
-                                                        </div>
-                                                    ))}
-                                                </div>
-                                            )}
-                                        </div>
-                                    );
-                                })}
-                            </div>
-                        </TabsContent>
-                    </div>
-                </Tabs>
-            </div>
-
-            {job.warnings && job.warnings.length > 0 && (
-                <div className="px-2 py-1.5 bg-amber-950/20 border-t border-amber-900/50">
-                    <div className="flex items-center gap-1.5 text-amber-600 dark:text-amber-400 text-xs font-medium">
-                        <AlertTriangle className="w-3.5 h-3.5" />
-                        {job.warnings.join(', ')}
-                    </div>
-                </div>
-            )}
-
-            <IssueForm
-                operationId={job.operationId}
-                open={isIssueModalOpen}
-                onOpenChange={(open) => {
-                    setIsIssueModalOpen(open);
-                    if (!open) setIssuePrefilledData(null);
-                }}
-                onSuccess={() => {
-                    setIsIssueModalOpen(false);
-                    setIssuePrefilledData(null);
-                }}
-                prefilledData={issuePrefilledData}
-            />
-
-            <ProductionQuantityModal
-                isOpen={isQuantityModalOpen}
-                onClose={() => setIsQuantityModalOpen(false)}
-                operationId={job.operationId}
-                operationName={job.currentOp}
-                partNumber={job.description}
-                plannedQuantity={job.quantity}
-                onSuccess={() => {
-                    setIsQuantityModalOpen(false);
-                    onDataRefresh?.();
-                }}
-                onFileIssue={(shortfallQuantity) => {
-                    setIssuePrefilledData({
-                        affectedQuantity: shortfallQuantity,
-                        isShortfall: true
-                    });
-                    setIsIssueModalOpen(true);
-                }}
-            />
-
-            {fullscreenViewer && createPortal(
-                <div
-                    className="fixed inset-0 z-[100] bg-black/90 backdrop-blur-md flex flex-col"
-                    onClick={() => setFullscreenViewer(null)}
-                >
-                    <div
-                        className="relative flex-1 min-h-0"
-                        onClick={(e) => e.stopPropagation()}
-                    >
-                        <div className="absolute top-3 left-4 z-10 flex items-center gap-2">
-                            <span className="text-xs text-muted-foreground/70 font-medium">{job.jobCode}</span>
-                            <span className="text-[10px] text-muted-foreground/50">{fullscreenViewer === '3d' ? '3D' : 'PDF'}</span>
-                        </div>
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => setFullscreenViewer(null)}
-                            className="absolute top-2 right-3 z-10 h-8 w-8 p-0 hover:bg-accent/50 text-muted-foreground"
+                        {substep.icon_name ? (
+                          <IconDisplay
+                            iconName={substep.icon_name}
+                            className="h-4 w-4 shrink-0 text-muted-foreground"
+                          />
+                        ) : null}
+                        <span
+                          className={cn(
+                            "truncate",
+                            substep.status === "completed" && "line-through",
+                          )}
                         >
-                            <X className="w-4 h-4" />
-                        </Button>
-                        <div className="h-full bg-background overflow-hidden">
-                            {fullscreenViewer === '3d' && stepUrl && (
-                                <STEPViewer
-                                    url={stepUrl}
-                                    title={job.jobCode}
-                                    pmiData={pmiData}
-                                    serverGeometry={serverGeometry}
-                                    preferServerGeometry={true}
-                                />
-                            )}
-                            {fullscreenViewer === 'pdf' && pdfUrl && (
-                                <PDFViewer url={pdfUrl} title={job.jobCode} />
-                            )}
-                        </div>
-                    </div>
-                </div>,
-                document.body
-            )}
-        </div>
+                          {substep.name}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
     );
+  };
+
+  return (
+    <div className="flex h-full min-h-[720px] flex-col bg-card text-card-foreground">
+      <div className="border-b border-border px-4 py-4 sm:px-5">
+        {job.isBulletCard ? (
+          <div className="mb-4 flex items-center gap-2 rounded-2xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm font-semibold text-destructive">
+            <Zap className="h-4 w-4" />
+            {t("terminal.bulletCard")}
+          </div>
+        ) : null}
+
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="font-mono text-xl font-semibold text-foreground">
+                {job.jobCode}
+              </h2>
+              <Badge variant="outline" className={cn("rounded-full", statusBadge.className)}>
+                {statusBadge.label}
+              </Badge>
+            </div>
+            <div className="text-base font-semibold text-foreground">{job.description}</div>
+            <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+              <span>{job.currentOp}</span>
+              <span>•</span>
+              <span>{job.material || "-"}</span>
+              <span>•</span>
+              <span>{job.quantity} pcs</span>
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-border bg-background/70 px-4 py-3 text-right">
+            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              {t("terminal.columns.dueDate")}
+            </div>
+            <div className="mt-1 text-base font-semibold text-foreground">
+              {new Date(job.dueDate).toLocaleDateString()}
+            </div>
+            <div className="text-sm text-muted-foreground">{job.hours}h remaining</div>
+          </div>
+        </div>
+
+        <div className="mt-4 grid gap-3 md:grid-cols-3">
+          <div className="rounded-2xl border border-border bg-background/70 px-4 py-3">
+            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              {t("terminal.currentPacket", "Current packet")}
+            </div>
+            <div className="mt-1 flex items-center gap-2 text-sm font-semibold text-foreground">
+              <Layers3 className="h-4 w-4 text-primary" />
+              {job.currentOp}
+            </div>
+            {job.drawingNo ? (
+              <div className="mt-1 text-xs text-muted-foreground">
+                {t("parts.drawingNo")}: {job.drawingNo}
+              </div>
+            ) : null}
+          </div>
+
+          <div className="rounded-2xl border border-border bg-background/70 px-4 py-3">
+            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              {t("terminal.columns.cell")}
+            </div>
+            <div className="mt-1 flex items-center gap-2 text-sm font-semibold text-foreground">
+              <MapPinned className="h-4 w-4 text-primary" />
+              {job.cellName || "-"}
+            </div>
+            {nextOperation?.cell?.name ? (
+              <div className="mt-1 text-xs text-muted-foreground">
+                {t("terminal.nextCell", "Next cell")}: {nextOperation.cell.name}
+              </div>
+            ) : null}
+          </div>
+
+          <div className="rounded-2xl border border-border bg-background/70 px-4 py-3">
+            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              {t("terminal.packet", "Packet contents")}
+            </div>
+            <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-foreground">
+              {job.hasModel ? <Badge variant="outline">3D</Badge> : null}
+              {job.hasPdf ? <Badge variant="outline">PDF</Badge> : null}
+              {job.cncProgramName ? <Badge variant="outline">CNC</Badge> : null}
+              {!job.hasModel && !job.hasPdf && !job.cncProgramName ? (
+                <span className="text-muted-foreground">
+                  {t("terminal.noFiles", "No attached files")}
+                </span>
+              ) : null}
+            </div>
+          </div>
+        </div>
+
+        {job.notes ? (
+          <div className="mt-4 rounded-2xl border border-border bg-muted/20 px-4 py-3 text-sm text-muted-foreground">
+            {job.notes}
+          </div>
+        ) : null}
+      </div>
+
+      {job.jobId ? (
+        <div className="border-b border-border px-4 py-4 sm:px-5">
+          <JobFlowProgress
+            jobId={job.jobId}
+            currentCellId={job.cellId}
+            nextCellName={nextOperation?.cell?.name}
+            nextCellMetrics={nextCellMetrics}
+          />
+        </div>
+      ) : null}
+
+      <div className="border-b border-border px-4 py-4 sm:px-5">
+        <div className="grid gap-3 lg:grid-cols-2">
+          <div className="rounded-2xl border border-border bg-background/70 px-4 py-3">
+            <OperationResources operationId={job.operationId} />
+          </div>
+          <div className="rounded-2xl border border-border bg-background/70 px-4 py-3">
+            <AssemblyDependencies partId={job.partId} />
+          </div>
+        </div>
+      </div>
+
+      {job.cncProgramName ? (
+        <div className="border-b border-border px-4 py-4 sm:px-5">
+          <div className="flex items-center gap-3 rounded-2xl border border-border bg-background/70 px-4 py-3">
+            <div className="rounded-xl border border-border bg-white p-2">
+              <CncProgramQrCode programName={job.cncProgramName} size={64} />
+            </div>
+            <div className="min-w-0">
+              <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                {t("parts.cncProgramName")}
+              </div>
+              <div className="font-mono text-base font-semibold text-foreground">
+                {job.cncProgramName}
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="flex-1 overflow-hidden">
+        <Tabs
+          key={`${job.id}-${defaultTab}`}
+          defaultValue={defaultTab}
+          className="flex h-full flex-col"
+        >
+          <div className="border-b border-border px-4 py-3 sm:px-5">
+            <TabsList className="grid h-auto w-full grid-cols-3 gap-2 rounded-2xl bg-muted/30 p-1">
+              <TabsTrigger
+                value="3d"
+                disabled={!job.hasModel}
+                className="min-h-12 rounded-xl data-[state=active]:bg-background"
+              >
+                <Box className="mr-2 h-4 w-4" />
+                3D
+              </TabsTrigger>
+              <TabsTrigger
+                value="pdf"
+                disabled={!job.hasPdf}
+                className="min-h-12 rounded-xl data-[state=active]:bg-background"
+              >
+                <FileText className="mr-2 h-4 w-4" />
+                PDF
+              </TabsTrigger>
+              <TabsTrigger
+                value="ops"
+                className="min-h-12 rounded-xl data-[state=active]:bg-background"
+              >
+                <Layers3 className="mr-2 h-4 w-4" />
+                {t("terminal.routing", "Routing")}
+              </TabsTrigger>
+            </TabsList>
+          </div>
+
+          <div className="flex-1 overflow-hidden p-4 sm:px-5 sm:pb-5">
+            {job.hasModel ? (
+              <TabsContent
+                value="3d"
+                className="relative h-full overflow-hidden rounded-2xl border border-border bg-background m-0"
+              >
+                <STEPViewer
+                  url={stepUrl || ""}
+                  title={job.jobCode}
+                  pmiData={pmiData}
+                  serverGeometry={serverGeometry}
+                  preferServerGeometry={true}
+                />
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => setFullscreenViewer("3d")}
+                  className="absolute right-3 top-3 h-10 rounded-xl bg-background/90 px-3"
+                >
+                  <Maximize2 className="mr-2 h-4 w-4" />
+                  {t("common.expand", "Expand")}
+                </Button>
+              </TabsContent>
+            ) : null}
+
+            {job.hasPdf ? (
+              <TabsContent
+                value="pdf"
+                className="relative h-full overflow-hidden rounded-2xl border border-border bg-background m-0"
+              >
+                <PDFViewer url={pdfUrl || ""} title={job.jobCode} />
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => setFullscreenViewer("pdf")}
+                  className="absolute right-3 top-3 h-10 rounded-xl bg-background/90 px-3"
+                >
+                  <Maximize2 className="mr-2 h-4 w-4" />
+                  {t("common.expand", "Expand")}
+                </Button>
+              </TabsContent>
+            ) : null}
+
+            <TabsContent value="ops" className="h-full overflow-auto m-0">
+              {renderOperations()}
+            </TabsContent>
+          </div>
+        </Tabs>
+      </div>
+
+      {job.warnings?.length ? (
+        <div className="border-t border-border bg-amber-500/10 px-4 py-3 text-sm text-amber-600 dark:text-amber-400 sm:px-5">
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4" />
+            {job.warnings.join(", ")}
+          </div>
+        </div>
+      ) : null}
+
+      <div className="sticky bottom-0 border-t border-border bg-background/95 px-4 py-3 backdrop-blur-md sm:px-5">
+        <div className="grid gap-2 sm:grid-cols-2">
+          {!job.isCurrentUserClocked ? (
+            <Button
+              onClick={onStart}
+              className="min-h-12 rounded-xl bg-emerald-600 text-white hover:bg-emerald-700"
+            >
+              <Play className="mr-2 h-4 w-4" />
+              {t("operations.start", "Start")}
+            </Button>
+          ) : (
+            <Button
+              onClick={onPause}
+              variant="outline"
+              className="min-h-12 rounded-xl"
+            >
+              <Pause className="mr-2 h-4 w-4" />
+              {t("operations.pause", "Pause")}
+            </Button>
+          )}
+
+          <Button
+            onClick={() => setIsQuantityModalOpen(true)}
+            variant="outline"
+            className="min-h-12 rounded-xl border-primary/30 text-primary hover:bg-primary/10"
+          >
+            <PackageCheck className="mr-2 h-4 w-4" />
+            {t("production.reportTitle", "Record output")}
+          </Button>
+
+          {showCompleteAction ? (
+            <Button
+              onClick={onComplete}
+              variant="outline"
+              className="min-h-12 rounded-xl"
+              disabled={completeDisabled}
+              title={completeTitle}
+            >
+              <Square className="mr-2 h-4 w-4" />
+              {t("production.complete", "Complete")}
+            </Button>
+          ) : null}
+
+          <Button
+            variant="outline"
+            onClick={() => {
+              setIssuePrefilledData(null);
+              setIsIssueModalOpen(true);
+            }}
+            className="min-h-12 rounded-xl border-amber-500/30 text-amber-600 hover:bg-amber-500/10 dark:text-amber-400"
+          >
+            <AlertTriangle className="mr-2 h-4 w-4" />
+            {t("issues.reportIssue", "Report issue")}
+          </Button>
+        </div>
+      </div>
+
+      <IssueForm
+        operationId={job.operationId}
+        open={isIssueModalOpen}
+        onOpenChange={(open) => {
+          setIsIssueModalOpen(open);
+          if (!open) setIssuePrefilledData(null);
+        }}
+        onSuccess={() => {
+          setIsIssueModalOpen(false);
+          setIssuePrefilledData(null);
+        }}
+        prefilledData={issuePrefilledData}
+      />
+
+      <ProductionQuantityModal
+        isOpen={isQuantityModalOpen}
+        onClose={() => setIsQuantityModalOpen(false)}
+        operationId={job.operationId}
+        operationName={job.currentOp}
+        partNumber={job.description}
+        plannedQuantity={job.quantity}
+        onSuccess={() => {
+          setIsQuantityModalOpen(false);
+          onDataRefresh?.();
+        }}
+        onFileIssue={(shortfallQuantity) => {
+          setIssuePrefilledData({
+            affectedQuantity: shortfallQuantity,
+            isShortfall: true,
+          });
+          setIsIssueModalOpen(true);
+        }}
+      />
+
+      {fullscreenViewer
+        ? createPortal(
+            <div
+              className="fixed inset-0 z-[100] bg-black/90 backdrop-blur-md"
+              onClick={() => setFullscreenViewer(null)}
+            >
+              <div
+                className="relative flex h-full flex-col overflow-hidden"
+                onClick={(event) => event.stopPropagation()}
+              >
+                <div className="flex items-center justify-between border-b border-white/10 px-4 py-3 text-white">
+                  <div>
+                    <div className="text-xs uppercase tracking-[0.18em] text-white/60">
+                      {job.jobCode}
+                    </div>
+                    <div className="text-sm font-semibold">
+                      {fullscreenViewer === "3d" ? "3D" : "PDF"}
+                    </div>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setFullscreenViewer(null)}
+                    className="h-10 w-10 rounded-full p-0 text-white hover:bg-white/10"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+                <div className="flex-1 overflow-hidden bg-background">
+                  {fullscreenViewer === "3d" && stepUrl ? (
+                    <STEPViewer
+                      url={stepUrl}
+                      title={job.jobCode}
+                      pmiData={pmiData}
+                      serverGeometry={serverGeometry}
+                      preferServerGeometry={true}
+                    />
+                  ) : null}
+                  {fullscreenViewer === "pdf" && pdfUrl ? (
+                    <PDFViewer url={pdfUrl} title={job.jobCode} />
+                  ) : null}
+                </div>
+              </div>
+            </div>,
+            document.body,
+          )
+        : null}
+    </div>
+  );
 }

--- a/src/components/terminal/DetailPanel.tsx
+++ b/src/components/terminal/DetailPanel.tsx
@@ -99,7 +99,12 @@ export function DetailPanel({
 
   useEffect(() => {
     const fetchSubsteps = async () => {
-      if (!profile?.tenant_id || operations.length === 0) return;
+      if (!profile?.tenant_id || operations.length === 0) {
+        setSubstepsByOperation({});
+        return;
+      }
+
+      setSubstepsByOperation({});
 
       const operationIds = operations.map((operation) => operation.id);
       const { data, error } = await supabase
@@ -121,10 +126,21 @@ export function DetailPanel({
         }
         grouped[substep.operation_id].push(substep);
       });
-      setSubstepsByOperation(grouped);
+
+      return grouped;
     };
 
-    void fetchSubsteps();
+    let isActive = true;
+
+    void fetchSubsteps().then((grouped) => {
+      if (isActive && grouped) {
+        setSubstepsByOperation(grouped);
+      }
+    });
+
+    return () => {
+      isActive = false;
+    };
   }, [operations, profile?.tenant_id]);
 
   const toggleOperationExpand = (operationId: string) => {

--- a/src/components/terminal/JobRow.tsx
+++ b/src/components/terminal/JobRow.tsx
@@ -1,141 +1,136 @@
-import React from 'react';
-import { TerminalJob } from '@/types/terminal';
-import { Badge } from '@/components/ui/badge';
-import { FileText, Box, AlertTriangle, Clock, User, Zap } from 'lucide-react';
-import { cn } from '@/lib/utils';
-import { useTranslation } from 'react-i18next';
+import { Badge } from "@/components/ui/badge";
+import { FileText, Box, AlertTriangle, Clock3, User, Zap, Layers3 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useTranslation } from "react-i18next";
+import { TerminalJob } from "@/types/terminal";
 
 interface JobRowProps {
-    job: TerminalJob;
-    isSelected: boolean;
-    onClick: () => void;
-    variant: 'process' | 'buffer' | 'expected';
+  job: TerminalJob;
+  isSelected: boolean;
+  onClick: () => void;
+  variant: "process" | "buffer" | "expected";
 }
 
-// Helper to get status badge colors based on operation/cell type
-const getOperationBadgeColor = (opName: string) => {
-    const name = opName.toLowerCase();
-    if (name.includes('frezen') || name.includes('mill')) return 'bg-operation-milling';
-    if (name.includes('afbramen') || name.includes('deburr')) return 'bg-status-completed';
-    if (name.includes('assemblage') || name.includes('assembly')) return 'bg-status-on-hold';
-    if (name.includes('lassen') || name.includes('weld')) return 'bg-operation-welding';
-    if (name.includes('autorisatie') || name.includes('auth')) return 'bg-operation-default';
-    return 'bg-operation-default';
+const variantClasses: Record<JobRowProps["variant"], string> = {
+  process: "border-amber-500/30 bg-amber-500/10",
+  buffer: "border-sky-500/30 bg-sky-500/10",
+  expected: "border-border bg-card",
+};
+
+const operationClasses: Record<JobRowProps["variant"], string> = {
+  process: "bg-amber-500/15 text-amber-600 dark:text-amber-400",
+  buffer: "bg-sky-500/15 text-sky-600 dark:text-sky-400",
+  expected: "bg-muted text-foreground",
 };
 
 export function JobRow({ job, isSelected, onClick, variant }: JobRowProps) {
-    const { t } = useTranslation();
+  const { t } = useTranslation();
+  const dueDate = new Date(job.dueDate);
 
-    return (
-        <tr
-            onClick={onClick}
-            className={cn(
-                "cursor-pointer transition-colors border-b border-border hover:bg-accent/30",
-                isSelected && "bg-accent/50 ring-1 ring-primary",
-                variant === 'process' && "bg-status-active/5",
-                job.isCurrentUserClocked && "bg-primary/10 ring-1 ring-primary/50",
-                job.isBulletCard && "bg-destructive/5 border-l-2 border-l-destructive",
-            )}
-        >
-            {/* Job Number with clocking indicator */}
-            <td className="px-2 py-1.5 text-sm font-medium text-foreground whitespace-nowrap">
-                <div className="flex items-center gap-2">
-                    {job.isBulletCard && (
-                        <Zap className="w-3.5 h-3.5 text-destructive shrink-0" />
-                    )}
-                    {job.isCurrentUserClocked && (
-                        <Badge
-                            className="bg-primary text-primary-foreground text-[10px] font-bold px-1.5 py-0 animate-pulse"
-                            title={t('terminal.youAreClockedOn')}
-                        >
-                            <Clock className="w-2.5 h-2.5 mr-0.5" />
-                            {t('terminal.you')}
-                        </Badge>
-                    )}
-                    {job.activeTimeEntryId && !job.isCurrentUserClocked && (
-                        <Badge
-                            variant="outline"
-                            className="text-[10px] px-1.5 py-0 border-muted-foreground/50"
-                            title={job.activeOperatorName}
-                        >
-                            <User className="w-2.5 h-2.5 mr-0.5" />
-                            {job.activeOperatorName?.split(' ')[0] || t('terminal.other')}
-                        </Badge>
-                    )}
-                    {job.jobCode}
-                </div>
-            </td>
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "w-full rounded-2xl border p-4 text-left transition-all hover:border-primary/30 hover:bg-muted/20",
+        variantClasses[variant],
+        isSelected && "border-primary bg-primary/10 shadow-[0_0_0_1px_hsl(var(--primary)/0.3)]",
+        job.isCurrentUserClocked && "border-primary/50 bg-primary/10",
+      )}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0 space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="font-mono text-base font-semibold text-foreground">
+              {job.jobCode}
+            </div>
+            {job.isBulletCard ? (
+              <Badge variant="destructive" className="gap-1 rounded-full">
+                <Zap className="h-3.5 w-3.5" />
+                {t("terminal.bulletCard")}
+              </Badge>
+            ) : null}
+            {job.isCurrentUserClocked ? (
+              <Badge className="gap-1 rounded-full bg-primary text-primary-foreground">
+                <Clock3 className="h-3.5 w-3.5" />
+                {t("terminal.you")}
+              </Badge>
+            ) : null}
+            {job.activeTimeEntryId && !job.isCurrentUserClocked ? (
+              <Badge variant="outline" className="gap-1 rounded-full">
+                <User className="h-3.5 w-3.5" />
+                {job.activeOperatorName?.split(" ")[0] || t("terminal.other")}
+              </Badge>
+            ) : null}
+          </div>
 
-            {/* Part Number */}
-            <td className="px-2 py-1.5 text-sm text-foreground whitespace-nowrap">
-                {job.description}
-            </td>
+          <div>
+            <div className="text-sm font-semibold text-foreground">{job.description}</div>
+            <div className="text-sm text-muted-foreground">{job.currentOp}</div>
+          </div>
+        </div>
 
-            {/* Operation */}
-            <td className="px-2 py-1.5">
-                <Badge
-                    className={cn(
-                        "text-primary-foreground text-xs font-semibold px-2 py-0.5 whitespace-nowrap",
-                        getOperationBadgeColor(job.currentOp)
-                    )}
-                >
-                    {job.currentOp}
-                </Badge>
-            </td>
+        <div className="space-y-1 text-right">
+          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            {t("terminal.columns.dueDate")}
+          </div>
+          <div className="text-sm font-semibold text-foreground">
+            {dueDate.toLocaleDateString()}
+          </div>
+          <div className="text-xs text-muted-foreground">{job.hours}h remaining</div>
+        </div>
+      </div>
 
-            {/* Cell (Next Cell) */}
-            <td className="px-2 py-1.5 text-sm text-foreground whitespace-nowrap">
-                <span
-                    className="inline-block px-2 py-0.5 rounded text-xs font-medium"
-                    style={{
-                        backgroundColor: job.cellColor ? `${job.cellColor}20` : 'transparent',
-                        color: job.cellColor || 'inherit'
-                    }}
-                >
-                    {job.cellName || '-'}
-                </span>
-            </td>
+      <div className="mt-4 grid gap-2 text-sm text-muted-foreground sm:grid-cols-2 xl:grid-cols-4">
+        <div className="rounded-xl border border-border/80 bg-background/70 px-3 py-2">
+          <div className="text-[11px] uppercase tracking-[0.18em]">
+            {t("terminal.columns.cell")}
+          </div>
+          <div className="mt-1 flex items-center gap-2 font-medium text-foreground">
+            <span
+              className="h-2.5 w-2.5 rounded-full"
+              style={{ backgroundColor: job.cellColor || "currentColor" }}
+            />
+            {job.cellName || "-"}
+          </div>
+        </div>
+        <div className="rounded-xl border border-border/80 bg-background/70 px-3 py-2">
+          <div className="text-[11px] uppercase tracking-[0.18em]">
+            {t("terminal.columns.material")}
+          </div>
+          <div className="mt-1 font-medium text-foreground">{job.material || "-"}</div>
+        </div>
+        <div className="rounded-xl border border-border/80 bg-background/70 px-3 py-2">
+          <div className="text-[11px] uppercase tracking-[0.18em]">
+            {t("terminal.columns.quantity")}
+          </div>
+          <div className="mt-1 font-medium text-foreground">{job.quantity}</div>
+        </div>
+        <div className="rounded-xl border border-border/80 bg-background/70 px-3 py-2">
+          <div className="text-[11px] uppercase tracking-[0.18em]">
+            {t("terminal.packet", "Packet")}
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-2">
+            <span
+              className={cn(
+                "inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-semibold",
+                operationClasses[variant],
+              )}
+            >
+              <Layers3 className="h-3.5 w-3.5" />
+              {job.currentOp}
+            </span>
+            {job.hasPdf ? <FileText className="h-4 w-4 text-primary" /> : null}
+            {job.hasModel ? <Box className="h-4 w-4 text-sky-500" /> : null}
+            {job.warnings?.length ? (
+              <AlertTriangle className="h-4 w-4 text-amber-500" />
+            ) : null}
+          </div>
+        </div>
+      </div>
 
-            {/* Material */}
-            <td className="px-2 py-1.5 text-sm text-foreground whitespace-nowrap">
-                {job.material || '-'}
-            </td>
-
-            {/* Quantity */}
-            <td className="px-2 py-1.5 text-sm text-foreground text-center whitespace-nowrap">
-                {job.quantity}
-            </td>
-
-            {/* Remaining Hours */}
-            <td className="px-2 py-1.5 text-sm font-mono text-foreground text-right whitespace-nowrap">
-                {job.hours}h
-            </td>
-
-            {/* Due Date */}
-            <td className="px-2 py-1.5 text-sm text-foreground whitespace-nowrap">
-                {new Date(job.dueDate).toLocaleDateString('nl-NL', { day: '2-digit', month: '2-digit', year: 'numeric' })}
-            </td>
-
-            {/* Files - Icons & Badges */}
-            <td className="px-2 py-1.5">
-                <div className="flex items-center gap-1.5 justify-center">
-                    {job.hasPdf && (
-                        <div title="PDF Available">
-                            <FileText className="w-3.5 h-3.5 text-brand-primary" />
-                        </div>
-                    )}
-                    {job.hasModel && (
-                        <div title="3D Model">
-                            <Box className="w-3.5 h-3.5 text-accent" />
-                        </div>
-                    )}
-                    {job.warnings && job.warnings.length > 0 && (
-                        <div title={job.warnings.join(', ')}>
-                            <AlertTriangle className="w-3.5 h-3.5 text-warning" />
-                        </div>
-                    )}
-                </div>
-            </td>
-        </tr>
-    );
+      {job.notes ? (
+        <div className="mt-3 line-clamp-2 text-sm text-muted-foreground">{job.notes}</div>
+      ) : null}
+    </button>
+  );
 }

--- a/src/components/terminal/JobRow.tsx
+++ b/src/components/terminal/JobRow.tsx
@@ -25,7 +25,9 @@ const operationClasses: Record<JobRowProps["variant"], string> = {
 
 export function JobRow({ job, isSelected, onClick, variant }: JobRowProps) {
   const { t } = useTranslation();
-  const dueDate = new Date(job.dueDate);
+  const dueDate = job.dueDate ? new Date(job.dueDate) : null;
+  const hasValidDueDate =
+    dueDate !== null && Number.isFinite(dueDate.getTime());
 
   return (
     <button
@@ -74,9 +76,11 @@ export function JobRow({ job, isSelected, onClick, variant }: JobRowProps) {
             {t("terminal.columns.dueDate")}
           </div>
           <div className="text-sm font-semibold text-foreground">
-            {dueDate.toLocaleDateString()}
+            {hasValidDueDate ? dueDate.toLocaleDateString() : "-"}
           </div>
-          <div className="text-xs text-muted-foreground">{job.hours}h remaining</div>
+          <div className="text-xs text-muted-foreground">
+            {job.hours}h {t("operator.remaining", "remaining")}
+          </div>
         </div>
       </div>
 

--- a/src/components/ui/status-badge.test.tsx
+++ b/src/components/ui/status-badge.test.tsx
@@ -18,6 +18,41 @@ describe("StatusBadge", () => {
     expect(screen.getByText("rejected")).toBeInTheDocument();
   });
 
+  it("renders additional status variants and supports iconless output", () => {
+    const { rerender } = render(<StatusBadge status="pending" />);
+    expect(screen.getByText("pending")).toBeInTheDocument();
+
+    rerender(<StatusBadge status="completed" />);
+    expect(screen.getByText("completed")).toBeInTheDocument();
+
+    rerender(<StatusBadge status="on-hold" />);
+    expect(screen.getByText("on hold")).toBeInTheDocument();
+
+    rerender(<StatusBadge status="cancelled" showIcon={false} />);
+    const badge = screen.getByText("cancelled").closest("span");
+    expect(badge?.querySelector("svg")).not.toBeInTheDocument();
+  });
+
+  it("applies size and custom className variants", () => {
+    const { rerender } = render(
+      <StatusBadge status="active" size="sm" className="custom-badge" />,
+    );
+
+    expect(screen.getByText("active").closest("span")).toHaveClass(
+      "text-[10px]",
+      "px-1.5",
+      "py-0.5",
+      "custom-badge",
+    );
+
+    rerender(<SeverityBadge severity="high" size="lg" label="High" />);
+    expect(screen.getByText("High").closest("span")).toHaveClass(
+      "text-sm",
+      "px-2.5",
+      "py-1",
+    );
+  });
+
   it("supports severity badges", () => {
     render(<SeverityBadge severity="critical" label="Critical" />);
 

--- a/src/components/ui/status-badge.test.tsx
+++ b/src/components/ui/status-badge.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@/test/utils";
+import { SeverityBadge, StatusBadge } from "./status-badge";
+
+describe("StatusBadge", () => {
+  it("renders a translated label with icon by default", () => {
+    render(<StatusBadge status="active" label="In progress" />);
+
+    expect(screen.getByText("In progress")).toBeInTheDocument();
+    expect(screen.getByText("In progress").closest("span")?.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("renders approved and rejected variants", () => {
+    const { rerender } = render(<StatusBadge status="approved" />);
+    expect(screen.getByText("approved")).toBeInTheDocument();
+
+    rerender(<StatusBadge status="rejected" />);
+    expect(screen.getByText("rejected")).toBeInTheDocument();
+  });
+
+  it("supports severity badges", () => {
+    render(<SeverityBadge severity="critical" label="Critical" />);
+
+    expect(screen.getByText("Critical")).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/status-badge.tsx
+++ b/src/components/ui/status-badge.tsx
@@ -20,20 +20,24 @@ export type StatusType =
   | 'completed'
   | 'on-hold'
   | 'cancelled'
+  | 'approved'
+  | 'rejected'
   | 'high'
   | 'medium'
   | 'low'
   | 'critical';
 
 const statusBadgeVariants = cva(
-  'inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-semibold capitalize',
+  'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold capitalize',
   {
     variants: {
       status: {
         success: 'bg-green-500/10 text-green-600 dark:text-green-400',
         completed: 'bg-green-500/10 text-green-600 dark:text-green-400',
+        approved: 'bg-green-500/10 text-green-600 dark:text-green-400',
         error: 'bg-red-500/10 text-red-600 dark:text-red-400',
         critical: 'bg-red-500/15 text-red-600 dark:text-red-400',
+        rejected: 'bg-red-500/10 text-red-600 dark:text-red-400',
         warning: 'bg-yellow-500/10 text-yellow-600 dark:text-yellow-400',
         high: 'bg-yellow-500/10 text-yellow-600 dark:text-yellow-400',
         info: 'bg-blue-500/10 text-blue-600 dark:text-blue-400',
@@ -60,8 +64,10 @@ const statusBadgeVariants = cva(
 const statusIcons: Record<StatusType, React.ComponentType<{ className?: string }>> = {
   success: CheckCircle,
   completed: CheckCircle,
+  approved: CheckCircle,
   error: XCircle,
   critical: XCircle,
+  rejected: XCircle,
   warning: AlertTriangle,
   high: AlertTriangle,
   info: Info,
@@ -142,4 +148,4 @@ const SeverityBadge = React.forwardRef<HTMLSpanElement, SeverityBadgeProps>(
 );
 SeverityBadge.displayName = 'SeverityBadge';
 
-export { StatusBadge, PriorityBadge, SeverityBadge, statusBadgeVariants };
+export { StatusBadge, PriorityBadge, SeverityBadge };

--- a/src/components/ui/status-badge.tsx
+++ b/src/components/ui/status-badge.tsx
@@ -28,7 +28,7 @@ export type StatusType =
   | 'critical';
 
 const statusBadgeVariants = cva(
-  'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold capitalize',
+  'inline-flex items-center gap-1.5 rounded-full border font-semibold capitalize',
   {
     variants: {
       status: {

--- a/src/hooks/useInvitations.ts
+++ b/src/hooks/useInvitations.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
@@ -25,8 +25,13 @@ export function useInvitations() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const loadInvitations = async () => {
-    if (!profile?.tenant_id) return;
+  const loadInvitations = useCallback(async () => {
+    if (!profile?.tenant_id) {
+      setInvitations([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
 
     setLoading(true);
     setError(null);
@@ -47,9 +52,9 @@ export function useInvitations() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [profile?.tenant_id]);
 
-  const createInvitation = async (email: string, role: 'operator' | 'admin' = 'operator') => {
+  const createInvitation = useCallback(async (email: string, role: 'operator' | 'admin' = 'operator') => {
     if (!profile?.tenant_id) {
       toast.error(t('notifications.noTenantFound'));
       return null;
@@ -100,9 +105,9 @@ export function useInvitations() {
       logger.error('useInvitations', 'Error creating invitation', err);
       return null;
     }
-  };
+  }, [loadInvitations, profile?.tenant_id, t]);
 
-  const cancelInvitation = async (invitationId: string): Promise<void> => {
+  const cancelInvitation = useCallback(async (invitationId: string): Promise<void> => {
     try {
       const { data, error: rpcError } = await supabase.rpc('cancel_invitation', {
         p_invitation_id: invitationId,
@@ -119,9 +124,9 @@ export function useInvitations() {
       toast.error(message);
       logger.error('useInvitations', 'Error cancelling invitation', err);
     }
-  };
+  }, [loadInvitations, t]);
 
-  const getInvitationByToken = async (token: string) => {
+  const getInvitationByToken = useCallback(async (token: string) => {
     try {
       const { data, error: rpcError } = await supabase.rpc('get_invitation_by_token', {
         p_token: token,
@@ -140,9 +145,9 @@ export function useInvitations() {
       logger.error('useInvitations', 'Error getting invitation', err);
       return null;
     }
-  };
+  }, [t]);
 
-  const acceptInvitation = async (token: string, userId: string) => {
+  const acceptInvitation = useCallback(async (token: string, userId: string) => {
     try {
       const { data, error: rpcError } = await supabase.rpc('accept_invitation', {
         p_token: token,
@@ -158,13 +163,11 @@ export function useInvitations() {
       logger.error('useInvitations', 'Error accepting invitation', err);
       return null;
     }
-  };
+  }, [t]);
 
   useEffect(() => {
-    if (profile?.tenant_id) {
-      loadInvitations();
-    }
-  }, [profile?.tenant_id]);
+    void loadInvitations();
+  }, [loadInvitations]);
 
   return {
     invitations,

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -27,7 +27,7 @@ const NotFound = () => {
           <h1 className="mt-2 text-3xl font-semibold tracking-tight text-foreground">
             {t("common.pageNotFound")}
           </h1>
-          <p className="mt-2 max-w-md text-sm text-muted-foreground">
+          <p className="mt-2 max-w-md break-words whitespace-normal text-sm text-muted-foreground">
             {location.pathname}
           </p>
           <Button asChild className="mt-6 min-h-11 rounded-xl px-4">

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,6 +1,9 @@
-import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
-import { useTranslation } from 'react-i18next';
+import { Link, useLocation } from "react-router-dom";
+import { Compass, ArrowLeft } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import { logger } from "@/lib/logger";
 
 const NotFound = () => {
@@ -8,18 +11,33 @@ const NotFound = () => {
   const location = useLocation();
 
   useEffect(() => {
-    logger.warn('Router', '404: User accessed non-existent route', location.pathname);
+    logger.warn("Router", "404: User accessed non-existent route", location.pathname);
   }, [location.pathname]);
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background">
-      <div className="text-center">
-        <h1 className="mb-4 text-4xl font-bold">404</h1>
-        <p className="mb-4 text-xl text-muted-foreground">{t('common.pageNotFound')}</p>
-        <a href="/" className="text-primary underline hover:text-primary/80">
-          {t('common.returnToHome')}
-        </a>
-      </div>
+    <div className="flex min-h-screen items-center justify-center bg-background px-4">
+      <Card className="w-full max-w-xl rounded-3xl border-border/80 bg-card/95 p-8 shadow-sm">
+        <div className="flex flex-col items-center text-center">
+          <div className="flex h-16 w-16 items-center justify-center rounded-2xl border border-border bg-muted/30">
+            <Compass className="h-8 w-8 text-primary" />
+          </div>
+          <div className="mt-6 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+            404
+          </div>
+          <h1 className="mt-2 text-3xl font-semibold tracking-tight text-foreground">
+            {t("common.pageNotFound")}
+          </h1>
+          <p className="mt-2 max-w-md text-sm text-muted-foreground">
+            {location.pathname}
+          </p>
+          <Button asChild className="mt-6 min-h-11 rounded-xl px-4">
+            <Link to="/">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              {t("common.returnToHome")}
+            </Link>
+          </Button>
+        </div>
+      </Card>
     </div>
   );
 };

--- a/src/pages/admin/IssueQueue.tsx
+++ b/src/pages/admin/IssueQueue.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useState, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { ColumnDef } from "@tanstack/react-table";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
-import { Badge } from "@/components/ui/badge";
+import { SeverityBadge, StatusBadge } from "@/components/ui/status-badge";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -19,13 +19,10 @@ import {
   CheckCircle,
   XCircle,
   Clock,
-  AlertTriangle,
   AlertOctagon,
-  Eye,
 } from "lucide-react";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
-import { cn } from "@/lib/utils";
 import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
 import { PageStatsRow } from "@/components/admin/PageStatsRow";
 import { DataTable } from "@/components/ui/data-table/DataTable";
@@ -63,44 +60,7 @@ export default function IssueQueue() {
   const [actionLoading, setActionLoading] = useState(false);
   const [imageUrls, setImageUrls] = useState<string[]>([]);
 
-  const [statusFilter, setStatusFilter] = useState<
-    "approved" | "closed" | "pending" | "rejected" | "all"
-  >("pending");
-  const [severityFilter, setSeverityFilter] = useState<
-    "critical" | "high" | "low" | "medium" | "all"
-  >("all");
-  const [searchQuery, setSearchQuery] = useState("");
-
-  useEffect(() => {
-    if (!profile?.tenant_id) return;
-    loadIssues();
-    return setupRealtime();
-  }, [profile?.tenant_id, statusFilter, severityFilter, searchQuery]);
-
-  // Load signed URLs for issue images
-  useEffect(() => {
-    const loadImageUrls = async () => {
-      if (!selectedIssue?.image_paths || selectedIssue.image_paths.length === 0) {
-        setImageUrls([]);
-        return;
-      }
-
-      const urls = await Promise.all(
-        selectedIssue.image_paths.map(async (path) => {
-          const { data } = await supabase.storage
-            .from("issues")
-            .createSignedUrl(path, 3600); // 1 hour expiry
-          return data?.signedUrl || "";
-        })
-      );
-
-      setImageUrls(urls.filter(url => url !== ""));
-    };
-
-    loadImageUrls();
-  }, [selectedIssue?.id]);
-
-  const loadIssues = async () => {
+  const loadIssues = useCallback(async () => {
     if (!profile?.tenant_id) return;
 
     let query = supabase
@@ -120,20 +80,6 @@ export default function IssueQueue() {
       )
       .eq("tenant_id", profile.tenant_id);
 
-    if (statusFilter !== "all") {
-      query = query.eq("status", statusFilter);
-    }
-
-    if (severityFilter !== "all") {
-      query = query.eq("severity", severityFilter);
-    }
-
-    if (searchQuery) {
-      query = query.or(
-        `operation.part.job.job_number.ilike.%${searchQuery}%,operation.part.part_number.ilike.%${searchQuery}%,operation.operation_name.ilike.%${searchQuery}%`,
-      );
-    }
-
     query = query
       .order("severity", { ascending: false })
       .order("created_at", { ascending: true });
@@ -146,9 +92,9 @@ export default function IssueQueue() {
       setIssues(data || []);
     }
     setLoading(false);
-  };
+  }, [profile?.tenant_id]);
 
-  const setupRealtime = () => {
+  const setupRealtime = useCallback(() => {
     const channel = supabase
       .channel("issue-queue")
       .on(
@@ -166,7 +112,35 @@ export default function IssueQueue() {
     return () => {
       supabase.removeChannel(channel);
     };
-  };
+  }, [loadIssues, profile?.tenant_id]);
+
+  useEffect(() => {
+    if (!profile?.tenant_id) return;
+    void loadIssues();
+    return setupRealtime();
+  }, [loadIssues, profile?.tenant_id, setupRealtime]);
+
+  useEffect(() => {
+    const loadImageUrls = async () => {
+      if (!selectedIssue?.image_paths || selectedIssue.image_paths.length === 0) {
+        setImageUrls([]);
+        return;
+      }
+
+      const urls = await Promise.all(
+        selectedIssue.image_paths.map(async (path) => {
+          const { data } = await supabase.storage
+            .from("issues")
+            .createSignedUrl(path, 3600);
+          return data?.signedUrl || "";
+        }),
+      );
+
+      setImageUrls(urls.filter((url) => url !== ""));
+    };
+
+    void loadImageUrls();
+  }, [selectedIssue?.id, selectedIssue?.image_paths]);
 
   const handleReview = async (action: "approved" | "rejected" | "closed") => {
     if (!selectedIssue || !profile?.id || !resolutionNotes.trim()) {
@@ -193,7 +167,7 @@ export default function IssueQueue() {
       );
       setSelectedIssue(null);
       setResolutionNotes("");
-      loadIssues();
+      await loadIssues();
     } catch (error: unknown) {
       toast.error(error instanceof Error ? error.message : t("issues.failedToUpdateIssue"));
     } finally {
@@ -201,32 +175,31 @@ export default function IssueQueue() {
     }
   };
 
-  const severityColors: Record<string, string> = {
-    low: "bg-severity-low",
-    medium: "bg-severity-medium",
-    high: "bg-severity-high",
-    critical: "bg-severity-critical",
-  };
+  const getSeverityBadge = useCallback((severity: string) => (
+    <SeverityBadge
+      severity={
+        (["critical", "high", "medium", "low"].includes(severity)
+          ? severity
+          : "low") as "critical" | "high" | "medium" | "low"
+      }
+      label={t(`issues.severity.${severity}`, severity)}
+    />
+  ), [t]);
 
-  const getSeverityBadge = (severity: string) => (
-    <Badge className={cn("text-xs", severityColors[severity] || "bg-muted")}>
-      {t(`issues.severity.${severity}`, severity)}
-    </Badge>
-  );
-
-  const getStatusBadge = (status: string) => {
-    const statusStyles: Record<string, string> = {
-      pending: "bg-[hsl(var(--color-warning))]/20 text-[hsl(var(--color-warning))]",
-      approved: "bg-[hsl(var(--color-success))]/20 text-[hsl(var(--color-success))]",
-      rejected: "bg-[hsl(var(--color-error))]/20 text-[hsl(var(--color-error))]",
-      closed: "bg-muted text-muted-foreground",
+  const getStatusBadge = useCallback((status: string) => {
+    const badgeStatus: Record<string, "pending" | "approved" | "rejected" | "cancelled"> = {
+      pending: "pending",
+      approved: "approved",
+      rejected: "rejected",
+      closed: "cancelled",
     };
     return (
-      <Badge className={cn("text-xs", statusStyles[status] || "bg-muted")}>
-        {t(`issues.status.${status}`, status)}
-      </Badge>
+      <StatusBadge
+        status={badgeStatus[status] || "pending"}
+        label={t(`issues.status.${status}`, status)}
+      />
     );
-  };
+  }, [t]);
 
   const columns: ColumnDef<Issue>[] = useMemo(() => [
     {
@@ -297,7 +270,7 @@ export default function IssueQueue() {
       cell: ({ row }) => getStatusBadge(row.getValue("status")),
       filterFn: (row, id, value) => value.includes(row.getValue(id)),
     },
-  ], [t]);
+  ], [getSeverityBadge, getStatusBadge, t]);
 
   const filterableColumns: DataTableFilterableColumn[] = useMemo(() => [
     {
@@ -322,62 +295,23 @@ export default function IssueQueue() {
     },
   ], [t]);
 
-  const [allIssues, setAllIssues] = useState<Issue[]>([]);
-
-  useEffect(() => {
-    const loadAllIssues = async () => {
-      if (!profile?.tenant_id) return;
-      const { data } = await supabase
-        .from("issues")
-        .select(`
-          id,
-          severity,
-          status,
-          created_at
-        `)
-        .eq("tenant_id", profile.tenant_id);
-      setAllIssues((data as Issue[]) || []);
-    };
-    loadAllIssues();
-  }, [profile?.tenant_id]);
-
   const analytics = useMemo(() => {
-    const total = allIssues.length;
+    const total = issues.length;
     const byStatus = {
-      pending: allIssues.filter((i) => i.status === "pending").length,
-      approved: allIssues.filter((i) => i.status === "approved").length,
-      rejected: allIssues.filter((i) => i.status === "rejected").length,
-      closed: allIssues.filter((i) => i.status === "closed").length,
+      pending: issues.filter((i) => i.status === "pending").length,
+      approved: issues.filter((i) => i.status === "approved").length,
+      rejected: issues.filter((i) => i.status === "rejected").length,
+      closed: issues.filter((i) => i.status === "closed").length,
     };
-    const bySeverity = {
-      critical: allIssues.filter((i) => i.severity === "critical").length,
-      high: allIssues.filter((i) => i.severity === "high").length,
-      medium: allIssues.filter((i) => i.severity === "medium").length,
-      low: allIssues.filter((i) => i.severity === "low").length,
-    };
-
-    // Calculate resolution rate
-    const resolved = byStatus.approved + byStatus.rejected + byStatus.closed;
-    const resolutionRate = total > 0 ? (resolved / total) * 100 : 0;
-
-    // Calculate average time to resolution (for resolved issues)
-    const resolvedIssues = allIssues.filter(
-      (i) => i.status === "approved" || i.status === "rejected" || i.status === "closed"
-    );
 
     return {
       total,
       byStatus,
-      bySeverity,
-      resolutionRate,
-      criticalPending: allIssues.filter(
+      criticalPending: issues.filter(
         (i) => i.severity === "critical" && i.status === "pending"
       ).length,
-      highPending: allIssues.filter(
-        (i) => i.severity === "high" && i.status === "pending"
-      ).length,
     };
-  }, [allIssues]);
+  }, [issues]);
 
   if (loading) {
     return (
@@ -432,16 +366,9 @@ export default function IssueQueue() {
 
           {selectedIssue && (
             <div className="flex-1 overflow-y-auto min-h-0 space-y-4">
-              <div className="flex items-center gap-2">
-                <Badge
-                  className={
-                    severityColors[
-                    selectedIssue.severity as keyof typeof severityColors
-                    ]
-                  }
-                >
-                  {t(`issues.severity.${selectedIssue.severity}`)}
-                </Badge>
+              <div className="flex flex-wrap items-center gap-2">
+                {getSeverityBadge(selectedIssue.severity)}
+                {getStatusBadge(selectedIssue.status)}
               </div>
 
               <div>

--- a/src/pages/admin/IssueQueue.tsx
+++ b/src/pages/admin/IssueQueue.tsx
@@ -61,7 +61,13 @@ export default function IssueQueue() {
   const [imageUrls, setImageUrls] = useState<string[]>([]);
 
   const loadIssues = useCallback(async () => {
-    if (!profile?.tenant_id) return;
+    if (!profile?.tenant_id) {
+      setIssues([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
 
     let query = supabase
       .from("issues")
@@ -122,8 +128,9 @@ export default function IssueQueue() {
 
   useEffect(() => {
     const loadImageUrls = async () => {
+      setImageUrls([]);
+
       if (!selectedIssue?.image_paths || selectedIssue.image_paths.length === 0) {
-        setImageUrls([]);
         return;
       }
 
@@ -136,13 +143,23 @@ export default function IssueQueue() {
         }),
       );
 
-      setImageUrls(urls.filter((url) => url !== ""));
+      return urls.filter((url) => url !== "");
     };
 
-    void loadImageUrls();
+    let isActive = true;
+
+    void loadImageUrls().then((urls) => {
+      if (isActive && urls) {
+        setImageUrls(urls);
+      }
+    });
+
+    return () => {
+      isActive = false;
+    };
   }, [selectedIssue?.id, selectedIssue?.image_paths]);
 
-  const handleReview = async (action: "approved" | "rejected" | "closed") => {
+  const handleReview = async (action: "approved" | "rejected") => {
     if (!selectedIssue || !profile?.id || !resolutionNotes.trim()) {
       toast.error(t("issues.pleaseProvideResolutionNotes"));
       return;
@@ -218,6 +235,7 @@ export default function IssueQueue() {
       cell: ({ row }) => (
         <span className="font-medium">{row.original.operation?.part?.job?.job_number || "-"}</span>
       ),
+      accessorFn: (row) => row.operation?.part?.job?.job_number || "",
     },
     {
       id: "part",
@@ -225,6 +243,7 @@ export default function IssueQueue() {
         <DataTableColumnHeader column={column} title={t("common.part", "Part")} />
       ),
       cell: ({ row }) => row.original.operation?.part?.part_number || "-",
+      accessorFn: (row) => row.operation?.part?.part_number || "",
     },
     {
       id: "operation",
@@ -232,6 +251,7 @@ export default function IssueQueue() {
         <DataTableColumnHeader column={column} title={t("common.operation", "Operation")} />
       ),
       cell: ({ row }) => row.original.operation?.operation_name || "-",
+      accessorFn: (row) => row.operation?.operation_name || "",
     },
     {
       accessorKey: "description",
@@ -250,6 +270,7 @@ export default function IssueQueue() {
       cell: ({ row }) => (
         <span className="text-sm text-muted-foreground">{row.original.creator?.full_name || "-"}</span>
       ),
+      accessorFn: (row) => row.creator?.full_name || "",
     },
     {
       accessorKey: "created_at",
@@ -342,6 +363,13 @@ export default function IssueQueue() {
           columns={columns}
           data={issues}
           filterableColumns={filterableColumns}
+          searchableColumns={[
+            { id: "job", title: t("common.job", "Job") },
+            { id: "part", title: t("common.part", "Part") },
+            { id: "operation", title: t("common.operation", "Operation") },
+            { id: "reporter", title: t("issues.reporter", "Reporter") },
+            { id: "description", title: t("issues.description", "Description") },
+          ]}
           searchPlaceholder={t("issues.searchPlaceholder", "Search issues...")}
           emptyMessage={t("issues.noIssuesFound", "No issues found")}
           loading={loading}

--- a/src/pages/admin/Jobs.tsx
+++ b/src/pages/admin/Jobs.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { ColumnDef } from "@tanstack/react-table";
@@ -9,6 +9,7 @@ import { useResponsiveColumns } from "@/hooks/useResponsiveColumns";
 import { logger } from "@/lib/logger";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { StatusBadge } from "@/components/ui/status-badge";
 import { useNavigate } from "react-router-dom";
 import {
   Calendar,
@@ -148,7 +149,7 @@ export default function Jobs() {
 
   const { routings, loading: routingsLoading } = useMultipleJobsRouting(jobIds, profile?.tenant_id ?? null);
 
-  const handleSetOnHold = async (jobId: string) => {
+  const handleSetOnHold = useCallback(async (jobId: string) => {
     const { error } = await supabase.from("jobs").update({ status: "on_hold" }).eq("id", jobId);
     if (error) {
       toast.error(t("notifications.error"), { description: error.message });
@@ -156,9 +157,9 @@ export default function Jobs() {
     }
     refetch();
     toast.success(t("jobs.statusUpdated"), { description: t("jobs.jobOnHold") });
-  };
+  }, [refetch, t]);
 
-  const handleResume = async (jobId: string) => {
+  const handleResume = useCallback(async (jobId: string) => {
     const { error } = await supabase.from("jobs").update({ status: "in_progress" }).eq("id", jobId);
     if (error) {
       toast.error(t("notifications.error"), { description: error.message });
@@ -166,9 +167,9 @@ export default function Jobs() {
     }
     refetch();
     toast.success(t("jobs.statusUpdated"), { description: t("jobs.jobResumed") });
-  };
+  }, [refetch, t]);
 
-  const handleViewFile = async (filePath: string) => {
+  const handleViewFile = useCallback(async (filePath: string) => {
     try {
       const fileExt = filePath.split(".").pop()?.toLowerCase();
       const fileType =
@@ -207,7 +208,7 @@ export default function Jobs() {
       logger.error('Jobs', 'Error opening file', error);
       toast.error(t("notifications.error"), { description: t("notifications.failedToOpenFileViewer") });
     }
-  };
+  }, [t]);
 
   const handleFileDialogClose = () => {
     setFileViewerOpen(false);
@@ -219,12 +220,12 @@ export default function Jobs() {
     setCurrentFileTitle("");
   };
 
-  const getStatusBadge = (status: string) => {
-    const config: Record<string, { variant: "default" | "secondary" | "destructive" | "outline"; className: string }> = {
-      not_started: { variant: "secondary", className: "bg-muted/50" },
-      in_progress: { variant: "default", className: "bg-[hsl(var(--brand-primary))]/20 text-[hsl(var(--brand-primary))] border-[hsl(var(--brand-primary))]/30" },
-      completed: { variant: "outline", className: "bg-[hsl(var(--color-success))]/20 text-[hsl(var(--color-success))] border-[hsl(var(--color-success))]/30" },
-      on_hold: { variant: "destructive", className: "bg-[hsl(var(--color-warning))]/20 text-[hsl(var(--color-warning))] border-[hsl(var(--color-warning))]/30" },
+  const getStatusBadge = useCallback((status: string) => {
+    const badgeStatus: Record<string, "pending" | "active" | "completed" | "on-hold"> = {
+      not_started: "pending",
+      in_progress: "active",
+      completed: "completed",
+      on_hold: "on-hold",
     };
     const statusLabels: Record<string, string> = {
       not_started: t("operations.status.notStarted"),
@@ -232,13 +233,13 @@ export default function Jobs() {
       completed: t("operations.status.completed"),
       on_hold: t("operations.status.onHold"),
     };
-    const { variant, className } = config[status] || config.not_started;
     return (
-      <Badge variant={variant} className={cn("font-medium", className)}>
-        {statusLabels[status] || status}
-      </Badge>
+      <StatusBadge
+        status={badgeStatus[status] || "pending"}
+        label={statusLabels[status] || status}
+      />
     );
-  };
+  }, [t]);
 
   const getDueDateDisplay = (job: JobData) => {
     const dueDate = new Date(job.due_date_override || job.due_date);
@@ -451,7 +452,7 @@ export default function Jobs() {
       },
       size: 50,
     },
-  ], [t, routings, routingsLoading]);
+  ], [getStatusBadge, handleResume, handleSetOnHold, handleViewFile, routings, routingsLoading, t]);
 
   const filterableColumns: DataTableFilterableColumn[] = useMemo(() => [
     {

--- a/src/pages/admin/Operations.tsx
+++ b/src/pages/admin/Operations.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useCallback } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { ColumnDef } from "@tanstack/react-table";
 import { supabase } from "@/integrations/supabase/client";
@@ -173,7 +173,7 @@ export const Operations: React.FC = () => {
     URL.revokeObjectURL(url);
   };
 
-  const getStatusBadge = (status: string) => {
+  const getStatusBadge = useCallback((status: string) => {
     const badgeStatus: Record<string, "pending" | "active" | "completed" | "on-hold"> = {
       not_started: "pending",
       in_progress: "active",
@@ -183,10 +183,10 @@ export const Operations: React.FC = () => {
     return (
       <StatusBadge
         status={badgeStatus[status] || "pending"}
-        label={status.replace("_", " ")}
+        label={status.replaceAll("_", " ")}
       />
     );
-  };
+  }, []);
 
   const columns: ColumnDef<Operation>[] = useMemo(() => [
     {
@@ -325,7 +325,7 @@ export const Operations: React.FC = () => {
         return value.includes(row.getValue(id));
       },
     },
-  ], [navigate, t]);
+  ], [getStatusBadge, navigate, t]);
 
   const uniqueCells = useMemo(() =>
     [...new Set(operations.map((op) => op.cell))],

--- a/src/pages/admin/Operations.tsx
+++ b/src/pages/admin/Operations.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useResponsiveColumns } from "@/hooks/useResponsiveColumns";
 import { useNavigate } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
+import { StatusBadge } from "@/components/ui/status-badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Loader2, Download, Wrench, PlayCircle, CheckCircle2, UserCheck, PlusCircle } from "lucide-react";
@@ -173,16 +174,17 @@ export const Operations: React.FC = () => {
   };
 
   const getStatusBadge = (status: string) => {
-    const variants: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
-      not_started: "secondary",
-      in_progress: "default",
-      completed: "outline",
-      on_hold: "destructive",
+    const badgeStatus: Record<string, "pending" | "active" | "completed" | "on-hold"> = {
+      not_started: "pending",
+      in_progress: "active",
+      completed: "completed",
+      on_hold: "on-hold",
     };
     return (
-      <Badge variant={variants[status] || "default"}>
-        {status.replace("_", " ").toUpperCase()}
-      </Badge>
+      <StatusBadge
+        status={badgeStatus[status] || "pending"}
+        label={status.replace("_", " ")}
+      />
     );
   };
 

--- a/src/pages/admin/Parts.tsx
+++ b/src/pages/admin/Parts.tsx
@@ -201,15 +201,16 @@ export default function Parts() {
   };
 
   const getStatusBadge = useCallback((status: string) => {
-    const badgeStatus: Record<string, "pending" | "active" | "completed"> = {
+    const badgeStatus: Record<string, "pending" | "active" | "completed" | "on-hold"> = {
       not_started: "pending",
       in_progress: "active",
       completed: "completed",
+      on_hold: "on-hold",
     };
     return (
       <StatusBadge
         status={badgeStatus[status] || "pending"}
-        label={status.replace("_", " ")}
+        label={status.replaceAll("_", " ")}
       />
     );
   }, []);
@@ -388,6 +389,7 @@ export default function Parts() {
       options: [
         { label: t("parts.status.notStarted"), value: "not_started" },
         { label: t("parts.status.inProgress"), value: "in_progress" },
+        { label: t("parts.status.onHold", "On hold"), value: "on_hold" },
         { label: t("parts.status.completed"), value: "completed" },
       ],
     },

--- a/src/pages/admin/Parts.tsx
+++ b/src/pages/admin/Parts.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { ColumnDef } from "@tanstack/react-table";
@@ -9,6 +9,7 @@ import { useResponsiveColumns } from "@/hooks/useResponsiveColumns";
 import { logger } from "@/lib/logger";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { StatusBadge } from "@/components/ui/status-badge";
 import PartDetailModal from "@/components/admin/PartDetailModal";
 import {
   Package,
@@ -148,7 +149,7 @@ export default function Parts() {
     },
   });
 
-  const handleViewFile = async (filePath: string) => {
+  const handleViewFile = useCallback(async (filePath: string) => {
     try {
       const fileExt = filePath.split(".").pop()?.toLowerCase();
       const fileType =
@@ -187,7 +188,7 @@ export default function Parts() {
       logger.error('Parts', 'Error opening file', error);
       toast.error(t("notifications.error"), { description: t("notifications.failedToOpenFileViewer") });
     }
-  };
+  }, [t]);
 
   const handleFileDialogClose = () => {
     setFileViewerOpen(false);
@@ -199,18 +200,19 @@ export default function Parts() {
     setCurrentFileTitle("");
   };
 
-  const getStatusBadge = (status: string) => {
-    const variants: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
-      not_started: "secondary",
-      in_progress: "default",
-      completed: "outline",
+  const getStatusBadge = useCallback((status: string) => {
+    const badgeStatus: Record<string, "pending" | "active" | "completed"> = {
+      not_started: "pending",
+      in_progress: "active",
+      completed: "completed",
     };
     return (
-      <Badge variant={variants[status] || "default"}>
-        {status.replace("_", " ").toUpperCase()}
-      </Badge>
+      <StatusBadge
+        status={badgeStatus[status] || "pending"}
+        label={status.replace("_", " ")}
+      />
     );
-  };
+  }, []);
 
   const columns: ColumnDef<PartData>[] = useMemo(() => [
     {
@@ -377,7 +379,7 @@ export default function Parts() {
         );
       },
     },
-  ], [t]);
+  ], [getStatusBadge, handleViewFile, t]);
 
   const filterableColumns: DataTableFilterableColumn[] = useMemo(() => [
     {

--- a/src/pages/auth/AcceptInvitation.tsx
+++ b/src/pages/auth/AcceptInvitation.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -9,7 +9,8 @@ import { useInvitations } from '@/hooks/useInvitations';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
-import AnimatedBackground from '@/components/AnimatedBackground';
+import { LanguageSwitcher } from '@/components/LanguageSwitcher';
+import { AuthCardHeader, AuthShell } from '@/components/auth/AuthShell';
 import { logger } from '@/lib/logger';
 
 export default function AcceptInvitation() {
@@ -32,11 +33,7 @@ export default function AcceptInvitation() {
   const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    loadInvitation();
-  }, [token]);
-
-  const loadInvitation = async () => {
+  const loadInvitation = useCallback(async () => {
     if (!token) {
       setError(t('invitation.invalidLink'));
       setLoading(false);
@@ -53,7 +50,11 @@ export default function AcceptInvitation() {
     }
 
     setLoading(false);
-  };
+  }, [getInvitationByToken, t, token]);
+
+  useEffect(() => {
+    void loadInvitation();
+  }, [loadInvitation]);
 
   const handleAccept = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -116,72 +117,56 @@ export default function AcceptInvitation() {
 
   if (loading) {
     return (
-      <>
-        <AnimatedBackground />
-        <div className="relative min-h-screen flex items-center justify-center">
+      <AuthShell
+        topRight={<LanguageSwitcher />}
+        containerClassName="items-center"
+        cardClassName="max-w-sm py-10"
+      >
+        <div className="flex flex-col items-center gap-4 py-4">
+          <Factory className="h-12 w-12 text-primary" strokeWidth={1.5} />
           <Loader2 className="h-8 w-8 animate-spin text-primary" />
         </div>
-      </>
+      </AuthShell>
     );
   }
 
   if (error && !invitation) {
     return (
-      <>
-        <AnimatedBackground />
-        <div className="relative min-h-screen flex items-start justify-center p-8 pt-20">
-          <div className="onboarding-card">
-            <div className="inline-flex items-center justify-center mb-4">
-              <Factory className="w-12 h-12 text-destructive" strokeWidth={1.5} />
-            </div>
+      <AuthShell topRight={<LanguageSwitcher />} cardClassName="max-w-[440px]">
+        <AuthCardHeader
+          icon={Factory}
+          appName={t('auth.appName')}
+          eyebrow={t('invitation.youreInvited')}
+          title={t('invitation.invalidTitle')}
+          description={error}
+          descriptionClassName="mt-2 text-center text-sm text-muted-foreground"
+          iconClassName="h-12 w-12"
+        />
 
-            <h1 className="text-2xl font-bold mb-2">{t('invitation.invalidTitle')}</h1>
-            <p className="text-sm text-muted-foreground mb-6">{error}</p>
-
-            <Button onClick={() => navigate('/auth')} className="w-full cta-button">
-              {t('invitation.goToLogin')}
-              <ArrowRight className="ml-2 h-4 w-4 arrow-icon" />
-            </Button>
-          </div>
-        </div>
-      </>
+        <Button onClick={() => navigate('/auth')} className="w-full cta-button">
+          {t('invitation.goToLogin')}
+          <ArrowRight className="ml-2 h-4 w-4 arrow-icon" />
+        </Button>
+      </AuthShell>
     );
   }
 
   return (
-    <>
-      <AnimatedBackground />
+    <AuthShell topRight={<LanguageSwitcher />} cardClassName="max-w-[540px]">
+      <AuthCardHeader
+        icon={Factory}
+        appName={t('auth.appName')}
+        eyebrow={t('invitation.youreInvited')}
+        title={t('invitation.joinYourTeam')}
+        description={t('invitation.welcomeToEryxon')}
+        descriptionClassName="mb-6 text-center text-base text-foreground/80"
+        iconClassName="h-12 w-12"
+      />
 
-      <div className="relative min-h-screen flex items-start justify-center p-8 pt-20">
-        {/* Main Invitation Card */}
-        <div className="onboarding-card">
-          {/* Icon/Logo */}
-          <div className="inline-flex items-center justify-center mb-4">
-            <Factory className="w-12 h-12 text-primary" strokeWidth={1.5} />
-          </div>
-
-          {/* Welcome Text */}
-          <p className="text-xs font-medium text-muted-foreground uppercase tracking-widest mb-2">
-            {t('invitation.youreInvited')}
-          </p>
-
-          {/* Hero Title */}
-          <h1 className="hero-title">
-            {t('invitation.joinYourTeam')}
-          </h1>
-
-          {/* Tagline */}
-          <p className="text-base text-foreground/80 mb-6">
-            {t('invitation.welcomeToEryxon')}
-          </p>
-
-          {/* Divider */}
-          <hr className="title-divider" />
-
-          {invitation && (
-            <div className="space-y-6">
-              {/* Invitation Details */}
-              <div className="bg-muted/30 backdrop-blur-sm p-5 rounded-xl space-y-4 border border-border-subtle text-left">
+      {invitation && (
+        <div className="space-y-6">
+          <div className="glass-card rounded-2xl border border-border/80 p-5 text-left shadow-sm">
+            <div className="space-y-4">
                 <div className="flex items-start gap-3">
                   <UserCheck className="h-5 w-5 text-primary mt-0.5 flex-shrink-0" />
                   <div className="min-w-0 flex-1">
@@ -219,63 +204,62 @@ export default function AcceptInvitation() {
                 </div>
               </div>
 
-              {/* Signup Form */}
-              <form onSubmit={handleAccept} className="space-y-4 text-left">
-                <div className="space-y-2">
-                  <Label htmlFor="password" className="text-sm font-medium">
-                    {t('invitation.createPassword')}
-                  </Label>
-                  <Input
-                    id="password"
-                    type="password"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    required
-                    minLength={6}
-                    placeholder="••••••••"
-                    className="bg-input-background border-input"
-                  />
-                  <p className="text-xs text-muted-foreground">{t('auth.passwordRequirements')}</p>
-                </div>
+          </div>
 
-                <div className="space-y-2">
-                  <Label htmlFor="confirmPassword" className="text-sm font-medium">
-                    {t('invitation.confirmPassword')}
-                  </Label>
-                  <Input
-                    id="confirmPassword"
-                    type="password"
-                    value={confirmPassword}
-                    onChange={(e) => setConfirmPassword(e.target.value)}
-                    required
-                    minLength={6}
-                    placeholder="••••••••"
-                    className="bg-input-background border-input"
-                  />
-                </div>
-
-                {error && (
-                  <Alert variant="destructive">
-                    <AlertDescription>{error}</AlertDescription>
-                  </Alert>
-                )}
-
-                <div className="pt-2">
-                  <Button type="submit" className="w-full cta-button" disabled={submitting}>
-                    {submitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                    {t('invitation.acceptAndJoin')}
-                    <ArrowRight className="ml-2 h-4 w-4 arrow-icon" />
-                  </Button>
-                </div>
-
-                <p className="text-xs text-center text-muted-foreground pt-4">
-                  {t('invitation.acceptTerms', { tenantName: invitation.tenant_name })}
-                </p>
-              </form>
+          <form onSubmit={handleAccept} className="space-y-4 text-left">
+            <div className="space-y-2">
+              <Label htmlFor="password" className="text-sm font-medium">
+                {t('invitation.createPassword')}
+              </Label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                minLength={6}
+                placeholder="••••••••"
+                className="bg-input-background border-input"
+              />
+              <p className="text-xs text-muted-foreground">{t('auth.passwordRequirements')}</p>
             </div>
-          )}
+
+            <div className="space-y-2">
+              <Label htmlFor="confirmPassword" className="text-sm font-medium">
+                {t('invitation.confirmPassword')}
+              </Label>
+              <Input
+                id="confirmPassword"
+                type="password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                required
+                minLength={6}
+                placeholder="••••••••"
+                className="bg-input-background border-input"
+              />
+            </div>
+
+            {error && (
+              <Alert variant="destructive">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            <div className="pt-2">
+              <Button type="submit" className="w-full cta-button" disabled={submitting}>
+                {submitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {t('invitation.acceptAndJoin')}
+                <ArrowRight className="ml-2 h-4 w-4 arrow-icon" />
+              </Button>
+            </div>
+
+            <p className="pt-4 text-center text-xs text-muted-foreground">
+              {t('invitation.acceptTerms', { tenantName: invitation.tenant_name })}
+            </p>
+          </form>
         </div>
-      </div>
-    </>
+      )}
+    </AuthShell>
   );
 }

--- a/src/pages/auth/AcceptInvitation.tsx
+++ b/src/pages/auth/AcceptInvitation.tsx
@@ -35,6 +35,7 @@ export default function AcceptInvitation() {
 
   const loadInvitation = useCallback(async () => {
     if (!token) {
+      setInvitation(null);
       setError(t('invitation.invalidLink'));
       setLoading(false);
       return;
@@ -45,7 +46,9 @@ export default function AcceptInvitation() {
 
     if (data) {
       setInvitation(data);
+      setError(null);
     } else {
+      setInvitation(null);
       setError(t('invitation.notFoundOrExpired'));
     }
 
@@ -217,7 +220,7 @@ export default function AcceptInvitation() {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 required
-                minLength={6}
+                minLength={12}
                 placeholder="••••••••"
                 className="bg-input-background border-input"
               />
@@ -234,7 +237,7 @@ export default function AcceptInvitation() {
                 value={confirmPassword}
                 onChange={(e) => setConfirmPassword(e.target.value)}
                 required
-                minLength={6}
+                minLength={12}
                 placeholder="••••••••"
                 className="bg-input-background border-input"
               />

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -10,7 +10,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Loader2, ArrowRight, Factory, CheckCircle2, Info, Monitor } from "lucide-react";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
-import AnimatedBackground from "@/components/AnimatedBackground";
+import { AuthCardHeader, AuthShell } from "@/components/auth/AuthShell";
 import { Link } from "react-router-dom";
 import { ROUTES } from "@/routes";
 
@@ -126,138 +126,112 @@ export default function Auth() {
   };
 
   return (
-    <>
-      <AnimatedBackground />
+    <AuthShell topRight={<LanguageSwitcher />}>
+      <AuthCardHeader
+        icon={Factory}
+        appName={t("auth.appName")}
+        badge={t("auth.subtitle")}
+        title={isLogin ? t("auth.signIn") : t("auth.signUp")}
+      />
 
-      <div className="landing-container">
-        {/* Language Switcher - Top Right */}
-        <div className="absolute top-4 right-4 z-10">
-          <LanguageSwitcher />
+      {success && (
+        <Alert className="mb-4 border-green-500/50 bg-green-500/10">
+          <CheckCircle2 className="h-4 w-4 text-green-500" />
+          <AlertDescription className="text-green-200">
+            {success}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-4 text-left">
+        {!isLogin && (
+          <>
+            <div className="space-y-2">
+              <Label htmlFor="fullName" className="text-sm font-medium">
+                {t("auth.fullName")} <span className="text-red-400">*</span>
+              </Label>
+              <Input
+                id="fullName"
+                type="text"
+                value={fullName}
+                onChange={(e) => setFullName(e.target.value)}
+                required
+                placeholder={t("auth.fullNamePlaceholder")}
+                className="bg-input-background border-input"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="companyName" className="text-sm font-medium">
+                {t("auth.companyNameLabel")} <span className="text-red-400">*</span>
+              </Label>
+              <Input
+                id="companyName"
+                type="text"
+                value={companyName}
+                onChange={(e) => setCompanyName(e.target.value)}
+                required
+                placeholder={t("auth.companyNamePlaceholder")}
+                className="bg-input-background border-input"
+              />
+            </div>
+          </>
+        )}
+
+        <div className="space-y-2">
+          <Label htmlFor="email" className="text-sm font-medium">
+            {t("auth.email")} <span className="text-red-400">*</span>
+          </Label>
+          <Input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            placeholder={t("auth.emailPlaceholder")}
+            className="bg-input-background border-input"
+          />
         </div>
 
-        {/* Main Auth Card */}
-        <div className="onboarding-card">
-          {/* Icon/Logo */}
-          <div className="icon-container">
-            <Factory className="w-20 h-20 text-primary browser-icon" strokeWidth={1.5} />
-          </div>
-
-          {/* Title Container with Preview Pill */}
-          <div className="title-container">
-            <h1 className="main-title">{t("auth.appName")}</h1>
-            <p className="preview-pill">{t("auth.subtitle")}</p>
-          </div>
-
-          {/* Divider */}
-          <hr className="title-divider" />
-
-          {/* Hero Section Title */}
-          <h2 className="hero-title">
-            {isLogin ? t("auth.signIn") : t("auth.signUp")}
-          </h2>
-
-          {/* Success Message */}
-          {success && (
-            <Alert className="mb-4 border-green-500/50 bg-green-500/10">
-              <CheckCircle2 className="h-4 w-4 text-green-500" />
-              <AlertDescription className="text-green-200">
-                {success}
-              </AlertDescription>
-            </Alert>
+        <div className="space-y-2">
+          <Label htmlFor="password" className="text-sm font-medium">
+            {t("auth.password")} <span className="text-red-400">*</span>
+          </Label>
+          <Input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            minLength={6}
+            placeholder={t("auth.passwordPlaceholder")}
+            className="bg-input-background border-input"
+          />
+          {isLogin && (
+            <div className="text-right">
+              <Link
+                to={ROUTES.FORGOT_PASSWORD}
+                className="text-xs text-primary hover:underline"
+              >
+                {t("auth.forgotPassword")}
+              </Link>
+            </div>
           )}
+        </div>
 
-          {/* Auth Form */}
-          <form onSubmit={handleSubmit} className="space-y-4 text-left">
-            {!isLogin && (
-              <>
-                <div className="space-y-2">
-                  <Label htmlFor="fullName" className="text-sm font-medium">
-                    {t("auth.fullName")} <span className="text-red-400">*</span>
-                  </Label>
-                  <Input
-                    id="fullName"
-                    type="text"
-                    value={fullName}
-                    onChange={(e) => setFullName(e.target.value)}
-                    required
-                    placeholder={t("auth.fullNamePlaceholder")}
-                    className="bg-input-background border-input"
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="companyName" className="text-sm font-medium">
-                    {t("auth.companyNameLabel")} <span className="text-red-400">*</span>
-                  </Label>
-                  <Input
-                    id="companyName"
-                    type="text"
-                    value={companyName}
-                    onChange={(e) => setCompanyName(e.target.value)}
-                    required
-                    placeholder={t("auth.companyNamePlaceholder")}
-                    className="bg-input-background border-input"
-                  />
-                </div>
-              </>
-            )}
-
-            <div className="space-y-2">
-              <Label htmlFor="email" className="text-sm font-medium">
-                {t("auth.email")} <span className="text-red-400">*</span>
-              </Label>
-              <Input
-                id="email"
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-                placeholder={t("auth.emailPlaceholder")}
-                className="bg-input-background border-input"
+        {!isLogin && (
+          <div className="space-y-4 pt-2">
+            <div className="flex items-start gap-3">
+              <Checkbox
+                id="termsAgreed"
+                checked={termsAgreed}
+                onCheckedChange={(checked) => setTermsAgreed(checked === true)}
+                className="mt-1"
               />
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="password" className="text-sm font-medium">
-                {t("auth.password")} <span className="text-red-400">*</span>
-              </Label>
-              <Input
-                id="password"
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                minLength={6}
-                placeholder={t("auth.passwordPlaceholder")}
-                className="bg-input-background border-input"
-              />
-              {isLogin && (
-                <div className="text-right">
-                  <Link
-                    to={ROUTES.FORGOT_PASSWORD}
-                    className="text-xs text-primary hover:underline"
-                  >
-                    {t("auth.forgotPassword")}
-                  </Link>
-                </div>
-              )}
-            </div>
-
-            {/* GDPR Checkboxes - Only show on Sign Up */}
-            {!isLogin && (
-              <div className="space-y-4 pt-2">
-                {/* Terms and Privacy Policy Agreement */}
-                <div className="flex items-start gap-3">
-                  <Checkbox
-                    id="termsAgreed"
-                    checked={termsAgreed}
-                    onCheckedChange={(checked) => setTermsAgreed(checked === true)}
-                    className="mt-1"
-                  />
-                  <Label
-                    htmlFor="termsAgreed"
-                    className="text-sm text-muted-foreground leading-relaxed cursor-pointer"
-                  >
+              <Label
+                htmlFor="termsAgreed"
+                className="text-sm text-muted-foreground leading-relaxed cursor-pointer"
+              >
                     {t("auth.agreeToTerms")}{" "}
                     <Link
                       to={ROUTES.COMMON.PRIVACY_POLICY}
@@ -276,90 +250,86 @@ export default function Auth() {
                     </Link>
                     {t("auth.emailConsent")}
                     <span className="text-red-400"> *</span>
-                  </Label>
-                </div>
-
-                {/* GDPR Notice */}
-                <div className="flex items-start gap-2 p-3 rounded-lg bg-blue-500/10 border border-blue-500/20">
-                  <Info className="h-4 w-4 text-blue-400 mt-0.5 flex-shrink-0" />
-                  <p className="text-xs text-muted-foreground leading-relaxed">
-                    {t("auth.gdprNotice")}
-                  </p>
-                </div>
-              </div>
-            )}
-
-            {error && (
-              <Alert variant="destructive">
-                <AlertDescription>{error}</AlertDescription>
-              </Alert>
-            )}
-
-            {TURNSTILE_ENABLED && LazyTurnstile && (
-              <Suspense fallback={<div className="flex justify-center py-2"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>}>
-                <div className="flex justify-center">
-                  <LazyTurnstile
-                    ref={turnstileRef}
-                    siteKey={import.meta.env.VITE_TURNSTILE_SITE_KEY!}
-                    onSuccess={(token: string) => setCaptchaToken(token)}
-                    onError={() => {
-                      setError(t("auth.captchaError"));
-                      setCaptchaToken(null);
-                    }}
-                    onExpire={() => {
-                      setCaptchaToken(null);
-                      turnstileRef.current?.reset();
-                    }}
-                    options={{
-                      theme: "dark",
-                      size: "normal",
-                    }}
-                  />
-                </div>
-              </Suspense>
-            )}
-
-            <div className="pt-2">
-              <Button
-                type="submit"
-                className="w-full cta-button"
-                disabled={loading || (!isLogin && !termsAgreed) || (TURNSTILE_ENABLED && !captchaToken)}
-              >
-                {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                {isLogin ? t("auth.signIn") : t("auth.signUp")}
-                <ArrowRight className="ml-2 h-4 w-4 arrow-icon" />
-              </Button>
+              </Label>
             </div>
 
-            <div className="text-center pt-2">
-              <button
-                type="button"
-                onClick={() => {
-                  setIsLogin(!isLogin);
-                  setError(null);
-                  setSuccess(null);
-                }}
-                className="text-sm text-primary hover:underline"
-              >
-                {isLogin ? t("auth.noAccount") : t("auth.haveAccount")}
-              </button>
-            </div>
-          </form>
-
-          {/* Shop Floor Terminal Info */}
-          {isLogin && (
-            <div className="mt-4 pt-4 border-t border-white/10">
-              <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
-                <Monitor className="h-4 w-4" />
-                <span>{t("auth.shopFloorTerminal")}</span>
-              </div>
-              <p className="text-xs text-muted-foreground/60 text-center mt-2 leading-relaxed">
-                {t("auth.shopFloorTerminalHint")}
+            <div className="flex items-start gap-2 rounded-lg border border-blue-500/20 bg-blue-500/10 p-3">
+              <Info className="mt-0.5 h-4 w-4 flex-shrink-0 text-blue-400" />
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                {t("auth.gdprNotice")}
               </p>
             </div>
-          )}
+          </div>
+        )}
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {TURNSTILE_ENABLED && LazyTurnstile && (
+          <Suspense fallback={<div className="flex justify-center py-2"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>}>
+            <div className="flex justify-center">
+              <LazyTurnstile
+                ref={turnstileRef}
+                siteKey={import.meta.env.VITE_TURNSTILE_SITE_KEY!}
+                onSuccess={(token: string) => setCaptchaToken(token)}
+                onError={() => {
+                  setError(t("auth.captchaError"));
+                  setCaptchaToken(null);
+                }}
+                onExpire={() => {
+                  setCaptchaToken(null);
+                  turnstileRef.current?.reset();
+                }}
+                options={{
+                  theme: "dark",
+                  size: "normal",
+                }}
+              />
+            </div>
+          </Suspense>
+        )}
+
+        <div className="pt-2">
+          <Button
+            type="submit"
+            className="w-full cta-button"
+            disabled={loading || (!isLogin && !termsAgreed) || (TURNSTILE_ENABLED && !captchaToken)}
+          >
+            {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {isLogin ? t("auth.signIn") : t("auth.signUp")}
+            <ArrowRight className="ml-2 h-4 w-4 arrow-icon" />
+          </Button>
         </div>
-      </div>
-    </>
+
+        <div className="pt-2 text-center">
+          <button
+            type="button"
+            onClick={() => {
+              setIsLogin(!isLogin);
+              setError(null);
+              setSuccess(null);
+            }}
+            className="text-sm text-primary hover:underline"
+          >
+            {isLogin ? t("auth.noAccount") : t("auth.haveAccount")}
+          </button>
+        </div>
+      </form>
+
+      {isLogin && (
+        <div className="mt-4 border-t border-white/10 pt-4">
+          <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+            <Monitor className="h-4 w-4" />
+            <span>{t("auth.shopFloorTerminal")}</span>
+          </div>
+          <p className="mt-2 text-center text-xs leading-relaxed text-muted-foreground/60">
+            {t("auth.shopFloorTerminalHint")}
+          </p>
+        </div>
+      )}
+    </AuthShell>
   );
 }

--- a/src/pages/auth/ForgotPassword.tsx
+++ b/src/pages/auth/ForgotPassword.tsx
@@ -9,7 +9,7 @@ import { Label } from "@/components/ui/label";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Loader2, ArrowLeft, Factory, CheckCircle2, Mail } from "lucide-react";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
-import AnimatedBackground from "@/components/AnimatedBackground";
+import { AuthCardHeader, AuthShell } from "@/components/auth/AuthShell";
 import { ROUTES } from "@/routes";
 import { logger } from "@/lib/logger";
 
@@ -67,134 +67,112 @@ export default function ForgotPassword() {
   };
 
   return (
-    <>
-      <AnimatedBackground />
+    <AuthShell topRight={<LanguageSwitcher />}>
+      <AuthCardHeader
+        icon={Factory}
+        appName={t("auth.appName")}
+        title={t("auth.forgotPasswordTitle")}
+        description={t("auth.forgotPasswordDescription")}
+      />
 
-      <div className="landing-container">
-        <div className="absolute top-4 right-4 z-10">
-          <LanguageSwitcher />
+      {success ? (
+        <div className="space-y-4">
+          <Alert className="border-green-500/50 bg-green-500/10">
+            <CheckCircle2 className="h-4 w-4 text-green-500" />
+            <AlertDescription className="text-green-200">
+              {t("auth.resetLinkSent")}
+            </AlertDescription>
+          </Alert>
+
+          <div className="flex justify-center pt-2">
+            <Mail className="h-12 w-12 text-primary opacity-60" />
+          </div>
+
+          <div className="pt-2 text-center">
+            <Link
+              to={ROUTES.AUTH}
+              className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+            >
+              <ArrowLeft className="h-3 w-3" />
+              {t("auth.backToSignIn")}
+            </Link>
+          </div>
         </div>
-
-        <div className="onboarding-card">
-          <div className="icon-container">
-            <Factory
-              className="w-20 h-20 text-primary browser-icon"
-              strokeWidth={1.5}
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-4 text-left">
+          <div className="space-y-2">
+            <Label htmlFor="email" className="text-sm font-medium">
+              {t("auth.email")} <span className="text-red-400">*</span>
+            </Label>
+            <Input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              placeholder={t("auth.emailPlaceholder")}
+              className="bg-input-background border-input"
             />
           </div>
 
-          <div className="title-container">
-            <h1 className="main-title">{t("auth.appName")}</h1>
-          </div>
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
 
-          <hr className="title-divider" />
-
-          <h2 className="hero-title">{t("auth.forgotPasswordTitle")}</h2>
-
-          <p className="informational-text">
-            {t("auth.forgotPasswordDescription")}
-          </p>
-
-          {success ? (
-            <div className="space-y-4">
-              <Alert className="border-green-500/50 bg-green-500/10">
-                <CheckCircle2 className="h-4 w-4 text-green-500" />
-                <AlertDescription className="text-green-200">
-                  {t("auth.resetLinkSent")}
-                </AlertDescription>
-              </Alert>
-
-              <div className="flex justify-center pt-2">
-                <Mail className="h-12 w-12 text-primary opacity-60" />
-              </div>
-
-              <div className="text-center pt-2">
-                <Link
-                  to={ROUTES.AUTH}
-                  className="text-sm text-primary hover:underline inline-flex items-center gap-1"
-                >
-                  <ArrowLeft className="h-3 w-3" />
-                  {t("auth.backToSignIn")}
-                </Link>
-              </div>
-            </div>
-          ) : (
-            <form onSubmit={handleSubmit} className="space-y-4 text-left">
-              <div className="space-y-2">
-                <Label htmlFor="email" className="text-sm font-medium">
-                  {t("auth.email")} <span className="text-red-400">*</span>
-                </Label>
-                <Input
-                  id="email"
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  required
-                  placeholder={t("auth.emailPlaceholder")}
-                  className="bg-input-background border-input"
+          {TURNSTILE_ENABLED && LazyTurnstile && (
+            <Suspense
+              fallback={
+                <div className="flex justify-center py-2">
+                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                </div>
+              }
+            >
+              <div className="flex justify-center">
+                <LazyTurnstile
+                  ref={turnstileRef}
+                  siteKey={import.meta.env.VITE_TURNSTILE_SITE_KEY!}
+                  onSuccess={(token: string) => setCaptchaToken(token)}
+                  onError={() => {
+                    setError(t("auth.captchaError"));
+                    setCaptchaToken(null);
+                  }}
+                  onExpire={() => {
+                    setCaptchaToken(null);
+                    turnstileRef.current?.reset();
+                  }}
+                  options={{
+                    theme: "dark",
+                    size: "normal",
+                  }}
                 />
               </div>
-
-              {error && (
-                <Alert variant="destructive">
-                  <AlertDescription>{error}</AlertDescription>
-                </Alert>
-              )}
-
-              {TURNSTILE_ENABLED && LazyTurnstile && (
-                <Suspense
-                  fallback={
-                    <div className="flex justify-center py-2">
-                      <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-                    </div>
-                  }
-                >
-                  <div className="flex justify-center">
-                    <LazyTurnstile
-                      ref={turnstileRef}
-                      siteKey={import.meta.env.VITE_TURNSTILE_SITE_KEY!}
-                      onSuccess={(token: string) => setCaptchaToken(token)}
-                      onError={() => {
-                        setError(t("auth.captchaError"));
-                        setCaptchaToken(null);
-                      }}
-                      onExpire={() => {
-                        setCaptchaToken(null);
-                        turnstileRef.current?.reset();
-                      }}
-                      options={{
-                        theme: "dark",
-                        size: "normal",
-                      }}
-                    />
-                  </div>
-                </Suspense>
-              )}
-
-              <div className="pt-2">
-                <Button
-                  type="submit"
-                  className="w-full cta-button"
-                  disabled={loading || (TURNSTILE_ENABLED && !captchaToken)}
-                >
-                  {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                  {t("auth.sendResetLink")}
-                </Button>
-              </div>
-
-              <div className="text-center pt-2">
-                <Link
-                  to={ROUTES.AUTH}
-                  className="text-sm text-primary hover:underline inline-flex items-center gap-1"
-                >
-                  <ArrowLeft className="h-3 w-3" />
-                  {t("auth.backToSignIn")}
-                </Link>
-              </div>
-            </form>
+            </Suspense>
           )}
-        </div>
-      </div>
-    </>
+
+          <div className="pt-2">
+            <Button
+              type="submit"
+              className="w-full cta-button"
+              disabled={loading || (TURNSTILE_ENABLED && !captchaToken)}
+            >
+              {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {t("auth.sendResetLink")}
+            </Button>
+          </div>
+
+          <div className="pt-2 text-center">
+            <Link
+              to={ROUTES.AUTH}
+              className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+            >
+              <ArrowLeft className="h-3 w-3" />
+              {t("auth.backToSignIn")}
+            </Link>
+          </div>
+        </form>
+      )}
+    </AuthShell>
   );
 }

--- a/src/pages/auth/ResetPassword.tsx
+++ b/src/pages/auth/ResetPassword.tsx
@@ -8,7 +8,7 @@ import { Label } from "@/components/ui/label";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Loader2, ArrowRight, Factory, CheckCircle2 } from "lucide-react";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
-import AnimatedBackground from "@/components/AnimatedBackground";
+import { AuthCardHeader, AuthShell } from "@/components/auth/AuthShell";
 import { ROUTES } from "@/routes";
 import { logger } from "@/lib/logger";
 
@@ -70,118 +70,97 @@ export default function ResetPassword() {
   };
 
   return (
-    <>
-      <AnimatedBackground />
+    <AuthShell topRight={<LanguageSwitcher />}>
+      <AuthCardHeader
+        icon={Factory}
+        appName={t("auth.appName")}
+        title={success ? t("auth.passwordUpdated") : t("auth.forgotPasswordTitle")}
+        description={!success ? t("auth.resetPasswordDescription") : undefined}
+      />
 
-      <div className="landing-container">
-        <div className="absolute top-4 right-4 z-10">
-          <LanguageSwitcher />
+      {success ? (
+        <div className="space-y-4">
+          <Alert className="border-green-500/50 bg-green-500/10">
+            <CheckCircle2 className="h-4 w-4 text-green-500" />
+            <AlertDescription className="text-green-200">
+              {t("auth.passwordUpdatedDescription")}
+            </AlertDescription>
+          </Alert>
+
+          <div className="pt-2">
+            <Button
+              onClick={() => navigate(ROUTES.AUTH)}
+              className="w-full cta-button"
+            >
+              {t("auth.signIn")}
+              <ArrowRight className="ml-2 h-4 w-4 arrow-icon" />
+            </Button>
+          </div>
         </div>
-
-        <div className="onboarding-card">
-          <div className="icon-container">
-            <Factory className="w-20 h-20 text-primary browser-icon" strokeWidth={1.5} />
-          </div>
-
-          <div className="title-container">
-            <h1 className="main-title">{t("auth.appName")}</h1>
-          </div>
-
-          <hr className="title-divider" />
-
-          {success ? (
-            <div className="space-y-4">
-              <h2 className="hero-title">{t("auth.passwordUpdated")}</h2>
-
-              <Alert className="border-green-500/50 bg-green-500/10">
-                <CheckCircle2 className="h-4 w-4 text-green-500" />
-                <AlertDescription className="text-green-200">
-                  {t("auth.passwordUpdatedDescription")}
-                </AlertDescription>
-              </Alert>
-
-              <div className="pt-2">
-                <Button
-                  onClick={() => navigate(ROUTES.AUTH)}
-                  className="w-full cta-button"
-                >
-                  {t("auth.signIn")}
-                  <ArrowRight className="ml-2 h-4 w-4 arrow-icon" />
-                </Button>
-              </div>
-            </div>
-          ) : (
-            <>
-              <h2 className="hero-title">{t("auth.forgotPasswordTitle")}</h2>
-
-              <p className="informational-text">
-                {t("auth.resetPasswordDescription")}
-              </p>
-
-              {!isRecoverySession && (
-                <Alert className="mb-4 border-yellow-500/50 bg-yellow-500/10">
-                  <AlertDescription className="text-yellow-200">
-                    <Loader2 className="inline mr-2 h-4 w-4 animate-spin" />
-                    {t("auth.forgotPasswordDescription")}
-                  </AlertDescription>
-                </Alert>
-              )}
-
-              <form onSubmit={handleSubmit} className="space-y-4 text-left">
-                <div className="space-y-2">
-                  <Label htmlFor="password" className="text-sm font-medium">
-                    {t("auth.newPassword")} <span className="text-red-400">*</span>
-                  </Label>
-                  <Input
-                    id="password"
-                    type="password"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    required
-                    minLength={6}
-                    placeholder={t("auth.newPasswordPlaceholder")}
-                    className="bg-input-background border-input"
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="confirmPassword" className="text-sm font-medium">
-                    {t("auth.confirmNewPassword")} <span className="text-red-400">*</span>
-                  </Label>
-                  <Input
-                    id="confirmPassword"
-                    type="password"
-                    value={confirmPassword}
-                    onChange={(e) => setConfirmPassword(e.target.value)}
-                    required
-                    minLength={6}
-                    placeholder={t("auth.confirmNewPasswordPlaceholder")}
-                    className="bg-input-background border-input"
-                  />
-                </div>
-
-                {error && (
-                  <Alert variant="destructive">
-                    <AlertDescription>{error}</AlertDescription>
-                  </Alert>
-                )}
-
-                <div className="pt-2">
-                  <Button
-                    type="submit"
-                    className="w-full cta-button"
-                    disabled={loading || !isRecoverySession}
-                  >
-                    {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                    {t("auth.updatePassword")}
-                    <ArrowRight className="ml-2 h-4 w-4 arrow-icon" />
-                  </Button>
-                </div>
-              </form>
-            </>
+      ) : (
+        <>
+          {!isRecoverySession && (
+            <Alert className="mb-4 border-yellow-500/50 bg-yellow-500/10">
+              <AlertDescription className="text-yellow-200">
+                <Loader2 className="inline mr-2 h-4 w-4 animate-spin" />
+                {t("auth.forgotPasswordDescription")}
+              </AlertDescription>
+            </Alert>
           )}
-        </div>
-      </div>
-    </>
+
+          <form onSubmit={handleSubmit} className="space-y-4 text-left">
+            <div className="space-y-2">
+              <Label htmlFor="password" className="text-sm font-medium">
+                {t("auth.newPassword")} <span className="text-red-400">*</span>
+              </Label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                minLength={6}
+                placeholder={t("auth.newPasswordPlaceholder")}
+                className="bg-input-background border-input"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="confirmPassword" className="text-sm font-medium">
+                {t("auth.confirmNewPassword")} <span className="text-red-400">*</span>
+              </Label>
+              <Input
+                id="confirmPassword"
+                type="password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                required
+                minLength={6}
+                placeholder={t("auth.confirmNewPasswordPlaceholder")}
+                className="bg-input-background border-input"
+              />
+            </div>
+
+            {error && (
+              <Alert variant="destructive">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            <div className="pt-2">
+              <Button
+                type="submit"
+                className="w-full cta-button"
+                disabled={loading || !isRecoverySession}
+              >
+                {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {t("auth.updatePassword")}
+                <ArrowRight className="ml-2 h-4 w-4 arrow-icon" />
+              </Button>
+            </div>
+          </form>
+        </>
+      )}
+    </AuthShell>
   );
 }

--- a/src/pages/operator/MyActivity.tsx
+++ b/src/pages/operator/MyActivity.tsx
@@ -1,12 +1,19 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { format, subDays } from "date-fns";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
-import { Card } from "@/components/ui/card";
+import { useOperator } from "@/contexts/OperatorContext";
 import { Badge } from "@/components/ui/badge";
-import { format, subDays } from "date-fns";
-import { Clock, CheckCircle } from "lucide-react";
+import { Clock3, CheckCircle2, CalendarDays, PackageSearch } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { logger } from "@/lib/logger";
+import {
+  OperatorEmptyState,
+  OperatorPageHeader,
+  OperatorPanel,
+  OperatorStatCard,
+  OperatorStatusChip,
+} from "@/components/operator/OperatorStation";
 
 interface TimeEntry {
   id: string;
@@ -38,25 +45,17 @@ interface DayGroup {
   completedCount: number;
 }
 
-const getStageClass = (cellName: string) => {
-  const name = cellName.toLowerCase();
-  if (name.includes('cut')) return 'stage-cutting';
-  if (name.includes('bend')) return 'stage-bending';
-  if (name.includes('weld')) return 'stage-welding';
-  if (name.includes('assembl')) return 'stage-assembly';
-  if (name.includes('finish')) return 'stage-finishing';
-  return 'muted';
-};
-
 export default function MyActivity() {
   const { t } = useTranslation();
   const { profile } = useAuth();
+  const { activeOperator } = useOperator();
+  const operatorId = activeOperator?.id || profile?.id;
   const [entries, setEntries] = useState<TimeEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [days] = useState(7);
 
-  const loadActivity = async () => {
-    if (!profile?.id) return;
+  const loadActivity = useCallback(async () => {
+    if (!operatorId) return;
 
     const startDate = subDays(new Date(), days - 1);
 
@@ -74,30 +73,28 @@ export default function MyActivity() {
           cell:cells!inner(name, color)
         )
       `)
-      .eq("operator_id", profile.id)
+      .eq("operator_id", operatorId)
       .gte("start_time", startDate.toISOString())
       .order("start_time", { ascending: false });
 
     if (error) {
       logger.error("MyActivity", "Error loading activity", error);
     } else {
-      setEntries(data || []);
+      setEntries((data as TimeEntry[]) || []);
     }
     setLoading(false);
-  };
+  }, [days, operatorId]);
 
   useEffect(() => {
-    if (profile?.id) {
-      const loadTimeout = window.setTimeout(() => {
-        void loadActivity();
-      }, 0);
-      return () => clearTimeout(loadTimeout);
-    }
-    return;
-  }, [profile?.id, days]);
+    if (!operatorId) return;
+    const loadTimeout = window.setTimeout(() => {
+      void loadActivity();
+    }, 0);
+    return () => clearTimeout(loadTimeout);
+  }, [loadActivity, operatorId]);
 
   const groupByDate = (): DayGroup[] => {
-    const groups: { [key: string]: TimeEntry[] } = {};
+    const groups: Record<string, TimeEntry[]> = {};
 
     entries.forEach((entry) => {
       const date = format(new Date(entry.start_time), "yyyy-MM-dd");
@@ -108,9 +105,16 @@ export default function MyActivity() {
     });
 
     return Object.entries(groups).map(([date, dayEntries]) => {
-      const totalMinutes = dayEntries.reduce((sum, e) => sum + (e.duration || 0), 0);
-      const uniqueOperations = new Set(dayEntries.map((e) => e.operation.operation_name));
-      const completedOperations = dayEntries.filter((e) => e.operation.status === "completed");
+      const totalMinutes = dayEntries.reduce(
+        (sum, entry) => sum + (entry.duration || 0),
+        0,
+      );
+      const uniqueOperations = new Set(
+        dayEntries.map((entry) => entry.operation.operation_name),
+      );
+      const completedOperations = dayEntries.filter(
+        (entry) => entry.operation.status === "completed",
+      );
 
       return {
         date,
@@ -132,147 +136,164 @@ export default function MyActivity() {
   };
 
   const dayGroups = groupByDate();
-
-  const todayTotal = dayGroups.find((g) => g.date === format(new Date(), "yyyy-MM-dd"))?.totalMinutes || 0;
-  const weekTotal = dayGroups.reduce((sum, g) => sum + g.totalMinutes, 0);
-  const todayCompleted = dayGroups.find((g) => g.date === format(new Date(), "yyyy-MM-dd"))?.completedCount || 0;
-  const weekCompleted = dayGroups.reduce((sum, g) => sum + g.completedCount, 0);
+  const today = format(new Date(), "yyyy-MM-dd");
+  const todayTotal = dayGroups.find((group) => group.date === today)?.totalMinutes || 0;
+  const weekTotal = dayGroups.reduce((sum, group) => sum + group.totalMinutes, 0);
+  const todayCompleted =
+    dayGroups.find((group) => group.date === today)?.completedCount || 0;
+  const weekCompleted = dayGroups.reduce(
+    (sum, group) => sum + group.completedCount,
+    0,
+  );
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center min-h-[400px]">
+      <OperatorPanel className="flex min-h-[420px] items-center justify-center">
         <div className="flex flex-col items-center gap-3">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[hsl(var(--brand-primary))]" />
-          <p className="text-sm text-muted-foreground">Loading activity...</p>
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+          <p className="text-sm text-muted-foreground">
+            {t("myActivity.loading", "Loading activity")}
+          </p>
         </div>
-      </div>
+      </OperatorPanel>
     );
   }
 
   return (
-    <>
-      <div className="p-6 space-y-8">
-        <div>
-          <h1 className="text-4xl font-bold bg-gradient-to-r from-foreground via-foreground to-foreground/70 bg-clip-text text-transparent mb-2">
-            {t("myActivity.title")}
-          </h1>
-          <p className="text-muted-foreground text-lg">{t("myActivity.description")}</p>
-        </div>
+    <div className="space-y-4">
+      <OperatorPageHeader
+        eyebrow={t("navigation.myActivity")}
+        title={t("myActivity.title")}
+        description={t(
+          "myActivity.description",
+          "Review the active operator's recent work by day, with completed operations and time captured in the same production workspace format as the queue.",
+        )}
+        meta={
+          activeOperator ? (
+            <OperatorStatusChip
+              tone="active"
+              label={`${activeOperator.full_name} • ${activeOperator.employee_id}`}
+            />
+          ) : undefined
+        }
+      />
 
-        <hr className="title-divider" />
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <OperatorStatCard
+          label={t("myActivity.todayTime")}
+          value={formatDuration(todayTotal)}
+          icon={Clock3}
+          tone="active"
+        />
+        <OperatorStatCard
+          label={t("myActivity.weekTime")}
+          value={formatDuration(weekTotal)}
+          icon={CalendarDays}
+        />
+        <OperatorStatCard
+          label={t("myActivity.todayCompleted")}
+          value={todayCompleted}
+          icon={CheckCircle2}
+          tone="success"
+        />
+        <OperatorStatCard
+          label={t("myActivity.weekCompleted")}
+          value={weekCompleted}
+          icon={CheckCircle2}
+          tone="success"
+        />
+      </div>
 
-        {/* Summary Stats */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
-          <Card className="glass-card p-6 transition-smooth hover:scale-[1.02]">
-            <div className="flex items-center gap-3">
-              <div className="p-3 rounded-xl bg-[hsl(var(--brand-primary))]/10">
-                <Clock className="h-6 w-6 text-[hsl(var(--brand-primary))]" />
-              </div>
-              <div>
-                <div className="text-2xl font-bold">{formatDuration(todayTotal)}</div>
-                <div className="text-sm text-muted-foreground">{t("myActivity.todayTime")}</div>
-              </div>
-            </div>
-          </Card>
-          <Card className="glass-card p-6 transition-smooth hover:scale-[1.02]">
-            <div className="flex items-center gap-3">
-              <div className="p-3 rounded-xl bg-[hsl(var(--color-info))]/10">
-                <Clock className="h-6 w-6 text-[hsl(var(--color-info))]" />
-              </div>
-              <div>
-                <div className="text-2xl font-bold">{formatDuration(weekTotal)}</div>
-                <div className="text-sm text-muted-foreground">{t("myActivity.weekTime")}</div>
-              </div>
-            </div>
-          </Card>
-          <Card className="glass-card p-6 transition-smooth hover:scale-[1.02]">
-            <div className="flex items-center gap-3">
-              <div className="p-3 rounded-xl bg-[hsl(var(--color-success))]/10">
-                <CheckCircle className="h-6 w-6 text-[hsl(var(--color-success))]" />
-              </div>
-              <div>
-                <div className="text-2xl font-bold">{todayCompleted}</div>
-                <div className="text-sm text-muted-foreground">{t("myActivity.todayCompleted")}</div>
-              </div>
-            </div>
-          </Card>
-          <Card className="glass-card p-6 transition-smooth hover:scale-[1.02]">
-            <div className="flex items-center gap-3">
-              <div className="p-3 rounded-xl bg-[hsl(var(--color-warning))]/10">
-                <CheckCircle className="h-6 w-6 text-[hsl(var(--color-warning))]" />
-              </div>
-              <div>
-                <div className="text-2xl font-bold">{weekCompleted}</div>
-                <div className="text-sm text-muted-foreground">{t("myActivity.weekCompleted")}</div>
-              </div>
-            </div>
-          </Card>
-        </div>
-
-        {/* Activity List */}
-        {dayGroups.length === 0 ? (
-          <Card className="glass-card p-12 text-center">
-            <Clock className="h-12 w-12 mx-auto mb-4 text-[hsl(var(--foreground))]/40" />
-            <h3 className="text-lg font-medium mb-2">{t("myActivity.noActivity")}</h3>
-            <p className="text-sm text-muted-foreground">{t("myActivity.noActivityDescription")}</p>
-          </Card>
-        ) : (
-          <div className="space-y-6">
-            {dayGroups.map((group) => (
-              <div key={group.date}>
-                <div className="flex items-center justify-between mb-4">
-                  <h2 className="text-xl font-semibold">{format(new Date(group.date), "EEEE, MMMM d, yyyy")}</h2>
-                  <div className="flex items-center gap-4 text-sm text-muted-foreground">
-                    <span>{t("myActivity.total")}: {formatDuration(group.totalMinutes)}</span>
-                    <span>•</span>
-                    <span>{group.tasksCount} {t("myActivity.operations")}</span>
-                    <span>•</span>
-                    <span>{group.completedCount} {t("myActivity.completed")}</span>
-                  </div>
+      {dayGroups.length === 0 ? (
+        <OperatorEmptyState
+          icon={PackageSearch}
+          title={t("myActivity.noActivity")}
+          description={t("myActivity.noActivityDescription")}
+        />
+      ) : (
+        <div className="space-y-4">
+          {dayGroups.map((group) => (
+            <OperatorPanel key={group.date} className="space-y-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h2 className="text-lg font-semibold text-foreground">
+                    {format(new Date(group.date), "EEEE, MMMM d, yyyy")}
+                  </h2>
+                  <p className="text-sm text-muted-foreground">
+                    {group.tasksCount} {t("myActivity.operations")} •{" "}
+                    {group.completedCount} {t("myActivity.completed")}
+                  </p>
                 </div>
+                <OperatorStatusChip
+                  tone="info"
+                  label={`${t("myActivity.total")}: ${formatDuration(group.totalMinutes)}`}
+                />
+              </div>
 
-                <div className="grid gap-3">
-                  {group.entries.map((entry) => (
-                    <Card key={entry.id} className="glass-card p-4 transition-smooth hover:bg-[hsl(var(--surface-elevated))]">
-                      <div className="flex items-start justify-between gap-4">
-                        <div className="flex-1">
-                          <div className="flex items-center gap-2 mb-2">
-                            <Badge
-                              className="bg-[hsl(var(--stage-cutting))]/10 text-[hsl(var(--stage-cutting))] border-[hsl(var(--stage-cutting))]/20"
-                            >
-                              {entry.operation.cell.name}
+              <div className="grid gap-3">
+                {group.entries.map((entry) => (
+                  <div
+                    key={entry.id}
+                    className="rounded-2xl border border-border bg-background/70 p-4"
+                  >
+                    <div className="flex flex-wrap items-start justify-between gap-4">
+                      <div className="space-y-2">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Badge variant="outline" className="rounded-full">
+                            <span
+                              className="mr-2 h-2.5 w-2.5 rounded-full"
+                              style={{
+                                backgroundColor:
+                                  entry.operation.cell.color || "currentColor",
+                              }}
+                            />
+                            {entry.operation.cell.name}
+                          </Badge>
+                          {entry.operation.status === "completed" ? (
+                            <Badge className="rounded-full bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/10 dark:text-emerald-400">
+                              <CheckCircle2 className="mr-1 h-3.5 w-3.5" />
+                              {t("myActivity.completed")}
                             </Badge>
-                            {entry.operation.status === "completed" && (
-                              <CheckCircle className="h-4 w-4 text-[hsl(var(--status-completed))]" />
-                            )}
-                          </div>
-                          <div className="font-medium mb-1">{entry.operation.operation_name}</div>
-                          <div className="text-sm text-muted-foreground">
-                            {entry.operation.part.job.job_number} • {entry.operation.part.part_number}
-                          </div>
-                          {entry.notes && (
-                            <div className="text-sm text-muted-foreground mt-2 italic">{entry.notes}</div>
-                          )}
+                          ) : null}
                         </div>
-                        <div className="text-right shrink-0">
-                          <div className="text-sm font-medium flex items-center gap-1">
-                            <Clock className="h-3 w-3 text-[hsl(var(--brand-primary))]" />
-                            {entry.duration ? formatDuration(entry.duration) : t("myActivity.inProgress")}
+                        <div>
+                          <div className="text-base font-semibold text-foreground">
+                            {entry.operation.operation_name}
                           </div>
-                          <div className="text-xs text-muted-foreground">
-                            {format(new Date(entry.start_time), "h:mm a")}
-                            {entry.end_time && ` - ${format(new Date(entry.end_time), "h:mm a")}`}
+                          <div className="text-sm text-muted-foreground">
+                            {entry.operation.part.job.job_number} •{" "}
+                            {entry.operation.part.part_number}
                           </div>
+                        </div>
+                        {entry.notes ? (
+                          <div className="text-sm text-muted-foreground">
+                            {entry.notes}
+                          </div>
+                        ) : null}
+                      </div>
+
+                      <div className="rounded-xl border border-border bg-muted/20 px-3 py-2 text-right">
+                        <div className="flex items-center justify-end gap-2 text-sm font-semibold text-foreground">
+                          <Clock3 className="h-4 w-4 text-primary" />
+                          {entry.duration
+                            ? formatDuration(entry.duration)
+                            : t("myActivity.inProgress")}
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {format(new Date(entry.start_time), "h:mm a")}
+                          {entry.end_time
+                            ? ` - ${format(new Date(entry.end_time), "h:mm a")}`
+                            : ""}
                         </div>
                       </div>
-                    </Card>
-                  ))}
-                </div>
+                    </div>
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
-        )}
-      </div>
-    </>
+            </OperatorPanel>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/pages/operator/MyActivity.tsx
+++ b/src/pages/operator/MyActivity.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { format, subDays } from "date-fns";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
@@ -53,11 +53,29 @@ export default function MyActivity() {
   const [entries, setEntries] = useState<TimeEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [days] = useState(7);
+  const operatorIdRef = useRef<string | null>(operatorId || null);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    operatorIdRef.current = operatorId || null;
+    requestIdRef.current += 1;
+    queueMicrotask(() => {
+      setEntries([]);
+      setLoading(Boolean(operatorId));
+    });
+  }, [operatorId]);
 
   const loadActivity = useCallback(async () => {
-    if (!operatorId) return;
+    if (!operatorId) {
+      setEntries([]);
+      setLoading(false);
+      return;
+    }
 
     const startDate = subDays(new Date(), days - 1);
+    const requestId = ++requestIdRef.current;
+    const requestedOperatorId = operatorId;
+    setLoading(true);
 
     const { data, error } = await supabase
       .from("time_entries")
@@ -73,9 +91,16 @@ export default function MyActivity() {
           cell:cells!inner(name, color)
         )
       `)
-      .eq("operator_id", operatorId)
+      .eq("operator_id", requestedOperatorId)
       .gte("start_time", startDate.toISOString())
       .order("start_time", { ascending: false });
+
+    if (
+      requestIdRef.current !== requestId ||
+      operatorIdRef.current !== requestedOperatorId
+    ) {
+      return;
+    }
 
     if (error) {
       logger.error("MyActivity", "Error loading activity", error);
@@ -87,13 +112,12 @@ export default function MyActivity() {
 
   useEffect(() => {
     if (!operatorId) return;
-    const loadTimeout = window.setTimeout(() => {
+    queueMicrotask(() => {
       void loadActivity();
-    }, 0);
-    return () => clearTimeout(loadTimeout);
+    });
   }, [loadActivity, operatorId]);
 
-  const groupByDate = (): DayGroup[] => {
+  const dayGroups = useMemo<DayGroup[]>(() => {
     const groups: Record<string, TimeEntry[]> = {};
 
     entries.forEach((entry) => {
@@ -124,7 +148,7 @@ export default function MyActivity() {
         completedCount: completedOperations.length,
       };
     });
-  };
+  }, [entries]);
 
   const formatDuration = (minutes: number) => {
     const hours = Math.floor(minutes / 60);
@@ -135,7 +159,6 @@ export default function MyActivity() {
     return `${mins}m`;
   };
 
-  const dayGroups = groupByDate();
   const today = format(new Date(), "yyyy-MM-dd");
   const todayTotal = dayGroups.find((group) => group.date === today)?.totalMinutes || 0;
   const weekTotal = dayGroups.reduce((sum, group) => sum + group.totalMinutes, 0);

--- a/src/pages/operator/MyIssues.tsx
+++ b/src/pages/operator/MyIssues.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { format } from "date-fns";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
@@ -50,11 +50,26 @@ export default function MyIssues() {
   const [selectedIssue, setSelectedIssue] = useState<Issue | null>(null);
   const [loading, setLoading] = useState(true);
   const [imageUrls, setImageUrls] = useState<string[]>([]);
+  const operatorIdRef = useRef<string | null>(operatorId || null);
+  const requestIdRef = useRef(0);
 
   useEffect(() => {
+    operatorIdRef.current = operatorId || null;
+    requestIdRef.current += 1;
+    queueMicrotask(() => {
+      setIssues([]);
+      setSelectedIssue(null);
+      setLoading(Boolean(operatorId));
+    });
+  }, [operatorId]);
+
+  useEffect(() => {
+    let isActive = true;
+
     const loadImageUrls = async () => {
+      setImageUrls([]);
+
       if (!selectedIssue?.image_paths || selectedIssue.image_paths.length === 0) {
-        setImageUrls([]);
         return;
       }
 
@@ -67,14 +82,28 @@ export default function MyIssues() {
         }),
       );
 
-      setImageUrls(urls.filter(Boolean));
+      if (isActive) {
+        setImageUrls(urls.filter(Boolean));
+      }
     };
 
     void loadImageUrls();
+
+    return () => {
+      isActive = false;
+    };
   }, [selectedIssue?.id, selectedIssue?.image_paths]);
 
   const loadIssues = useCallback(async () => {
-    if (!operatorId) return;
+    if (!operatorId) {
+      setIssues([]);
+      setLoading(false);
+      return;
+    }
+
+    const requestId = ++requestIdRef.current;
+    const requestedOperatorId = operatorId;
+    setLoading(true);
 
     const { data, error } = await supabase
       .from("issues")
@@ -88,8 +117,15 @@ export default function MyIssues() {
           )
         )
       `)
-      .eq("created_by", operatorId)
+      .eq("created_by", requestedOperatorId)
       .order("created_at", { ascending: false });
+
+    if (
+      requestIdRef.current !== requestId ||
+      operatorIdRef.current !== requestedOperatorId
+    ) {
+      return;
+    }
 
     if (error) {
       logger.error("MyIssues", "Error loading issues", error);
@@ -123,12 +159,11 @@ export default function MyIssues() {
 
   useEffect(() => {
     if (!operatorId) return;
-    const loadTimeout = window.setTimeout(() => {
+    queueMicrotask(() => {
       void loadIssues();
-    }, 0);
+    });
     const cleanup = setupRealtime();
     return () => {
-      clearTimeout(loadTimeout);
       cleanup?.();
     };
   }, [loadIssues, operatorId, setupRealtime]);

--- a/src/pages/operator/MyIssues.tsx
+++ b/src/pages/operator/MyIssues.tsx
@@ -1,13 +1,25 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { format } from "date-fns";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
-import { Card } from "@/components/ui/card";
+import { useOperator } from "@/contexts/OperatorContext";
 import { Badge } from "@/components/ui/badge";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { format } from "date-fns";
-import { AlertCircle } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { AlertCircle, CheckCircle2, Clock3, ShieldAlert, PackageSearch } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { logger } from "@/lib/logger";
+import {
+  OperatorEmptyState,
+  OperatorPageHeader,
+  OperatorPanel,
+  OperatorStatCard,
+  OperatorStatusChip,
+} from "@/components/operator/OperatorStation";
 
 interface Issue {
   id: string;
@@ -32,6 +44,8 @@ interface Issue {
 export default function MyIssues() {
   const { t } = useTranslation();
   const { profile } = useAuth();
+  const { activeOperator } = useOperator();
+  const operatorId = activeOperator?.id || profile?.id;
   const [issues, setIssues] = useState<Issue[]>([]);
   const [selectedIssue, setSelectedIssue] = useState<Issue | null>(null);
   const [loading, setLoading] = useState(true);
@@ -48,19 +62,19 @@ export default function MyIssues() {
         selectedIssue.image_paths.map(async (path) => {
           const { data } = await supabase.storage
             .from("issues")
-            .createSignedUrl(path, 3600); // 1 hour expiry
+            .createSignedUrl(path, 3600);
           return data?.signedUrl || "";
-        })
+        }),
       );
 
-      setImageUrls(urls.filter(url => url !== ""));
+      setImageUrls(urls.filter(Boolean));
     };
 
-    loadImageUrls();
-  }, [selectedIssue?.id]);
+    void loadImageUrls();
+  }, [selectedIssue?.id, selectedIssue?.image_paths]);
 
-  const loadIssues = async () => {
-    if (!profile?.id) return;
+  const loadIssues = useCallback(async () => {
+    if (!operatorId) return;
 
     const { data, error } = await supabase
       .from("issues")
@@ -74,18 +88,20 @@ export default function MyIssues() {
           )
         )
       `)
-      .eq("created_by", profile.id)
+      .eq("created_by", operatorId)
       .order("created_at", { ascending: false });
 
     if (error) {
       logger.error("MyIssues", "Error loading issues", error);
     } else {
-      setIssues(data || []);
+      setIssues((data as Issue[]) || []);
     }
     setLoading(false);
-  };
+  }, [operatorId]);
 
-  const setupRealtime = () => {
+  const setupRealtime = useCallback(() => {
+    if (!operatorId) return;
+
     const channel = supabase
       .channel("my-issues")
       .on(
@@ -94,174 +110,262 @@ export default function MyIssues() {
           event: "*",
           schema: "public",
           table: "issues",
-          filter: `created_by=eq.${profile?.id}`,
+          filter: `created_by=eq.${operatorId}`,
         },
-        () => loadIssues()
+        () => void loadIssues(),
       )
       .subscribe();
 
     return () => {
       supabase.removeChannel(channel);
     };
-  };
+  }, [loadIssues, operatorId]);
 
   useEffect(() => {
-    if (!profile?.id) return;
+    if (!operatorId) return;
     const loadTimeout = window.setTimeout(() => {
       void loadIssues();
     }, 0);
     const cleanup = setupRealtime();
     return () => {
       clearTimeout(loadTimeout);
-      cleanup();
+      cleanup?.();
     };
-  }, [profile?.id]);
+  }, [loadIssues, operatorId, setupRealtime]);
 
   const severityColors = {
-    low: "bg-severity-low",
-    medium: "bg-severity-medium",
-    high: "bg-severity-high",
-    critical: "bg-severity-critical",
+    low: "border-border bg-background/70 text-muted-foreground",
+    medium: "border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400",
+    high: "border-orange-500/30 bg-orange-500/10 text-orange-600 dark:text-orange-400",
+    critical: "border-destructive/30 bg-destructive/10 text-destructive",
   };
 
   const statusColors = {
-    pending: "bg-issue-pending",
-    approved: "bg-issue-approved",
-    rejected: "bg-issue-rejected",
-    closed: "bg-issue-closed",
+    pending: "border-sky-500/30 bg-sky-500/10 text-sky-600 dark:text-sky-400",
+    approved: "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+    rejected: "border-destructive/30 bg-destructive/10 text-destructive",
+    closed: "border-border bg-background/70 text-muted-foreground",
   };
+
+  const pendingCount = issues.filter((issue) => issue.status === "pending").length;
+  const resolvedCount = issues.filter(
+    (issue) => issue.status === "approved" || issue.status === "closed",
+  ).length;
+  const criticalCount = issues.filter(
+    (issue) => issue.severity === "critical" || issue.severity === "high",
+  ).length;
+
+  const latestIssueDate = useMemo(() => {
+    if (!issues.length) return null;
+    return format(new Date(issues[0].created_at), "MMM d, yyyy");
+  }, [issues]);
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
-      </div>
+      <OperatorPanel className="flex min-h-[420px] items-center justify-center">
+        <div className="flex flex-col items-center gap-3">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+          <p className="text-sm text-muted-foreground">
+            {t("myIssues.loading", "Loading issues")}
+          </p>
+        </div>
+      </OperatorPanel>
     );
   }
 
   return (
     <>
-      <div className="p-6 space-y-8">
-        <div>
-          <h1 className="text-4xl font-bold bg-gradient-to-r from-foreground via-foreground to-foreground/70 bg-clip-text text-transparent mb-2">
-            {t("myIssues.title")}
-          </h1>
-          <p className="text-muted-foreground text-lg">{t("myIssues.description")}</p>
+      <div className="space-y-4">
+        <OperatorPageHeader
+          eyebrow={t("navigation.myIssues")}
+          title={t("myIssues.title")}
+          description={t(
+            "myIssues.description",
+            "Track operator-reported issues with clear severity, review status, and supporting photos without leaving the shop-floor flow.",
+          )}
+          meta={
+            activeOperator ? (
+              <OperatorStatusChip
+                tone="active"
+                label={`${activeOperator.full_name} • ${activeOperator.employee_id}`}
+              />
+            ) : undefined
+          }
+        />
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <OperatorStatCard
+            label={t("myIssues.openIssues", "Open issues")}
+            value={pendingCount}
+            icon={Clock3}
+            tone="warning"
+          />
+          <OperatorStatCard
+            label={t("myIssues.resolvedIssues", "Resolved")}
+            value={resolvedCount}
+            icon={CheckCircle2}
+            tone="success"
+          />
+          <OperatorStatCard
+            label={t("myIssues.highSeverity", "High severity")}
+            value={criticalCount}
+            icon={ShieldAlert}
+            tone="danger"
+          />
+          <OperatorStatCard
+            label={t("myIssues.lastReported", "Last reported")}
+            value={latestIssueDate || "-"}
+            icon={AlertCircle}
+          />
         </div>
 
-        <hr className="title-divider" />
-
         {issues.length === 0 ? (
-          <Card className="glass-card p-12 text-center">
-            <AlertCircle className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
-            <h3 className="text-lg font-medium mb-2">{t("myIssues.noIssues")}</h3>
-            <p className="text-sm text-muted-foreground">
-              {t("myIssues.noIssuesDescription")}
-            </p>
-          </Card>
+          <OperatorEmptyState
+            icon={PackageSearch}
+            title={t("myIssues.noIssues")}
+            description={t("myIssues.noIssuesDescription")}
+          />
         ) : (
           <div className="grid gap-4">
             {issues.map((issue) => (
-              <Card
+              <OperatorPanel
                 key={issue.id}
-                className="glass-card p-4 cursor-pointer hover:shadow-xl hover:scale-105 transition-all hover:border-white/20"
+                className="cursor-pointer transition-colors hover:border-primary/30 hover:bg-muted/20"
                 onClick={() => setSelectedIssue(issue)}
               >
-                <div className="flex items-start justify-between gap-4">
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 mb-2">
-                      <Badge className={severityColors[issue.severity as keyof typeof severityColors]}>
+                <div className="flex flex-wrap items-start justify-between gap-4">
+                  <div className="min-w-0 space-y-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge
+                        variant="outline"
+                        className={`rounded-full ${severityColors[issue.severity as keyof typeof severityColors]}`}
+                      >
                         {issue.severity}
                       </Badge>
-                      <Badge variant="outline" className={statusColors[issue.status as keyof typeof statusColors]}>
+                      <Badge
+                        variant="outline"
+                        className={`rounded-full ${statusColors[issue.status as keyof typeof statusColors]}`}
+                      >
                         {issue.status}
                       </Badge>
                     </div>
-                    <div className="font-medium mb-1">
-                      {issue.operation.part.job.job_number} • {issue.operation.part.part_number} • {issue.operation.operation_name}
+                    <div className="text-base font-semibold text-foreground">
+                      {issue.operation.part.job.job_number} •{" "}
+                      {issue.operation.part.part_number}
                     </div>
-                    <p className="text-sm text-muted-foreground line-clamp-2">
+                    <div className="text-sm text-muted-foreground">
+                      {issue.operation.operation_name}
+                    </div>
+                    <p className="line-clamp-2 text-sm text-muted-foreground">
                       {issue.description}
                     </p>
                   </div>
-                  <div className="text-right text-sm text-muted-foreground shrink-0">
+                  <div className="rounded-xl border border-border bg-background/70 px-3 py-2 text-right text-sm text-muted-foreground">
                     {format(new Date(issue.created_at), "MMM d, yyyy")}
                   </div>
                 </div>
-              </Card>
-          ))}
-        </div>
-      )}
+              </OperatorPanel>
+            ))}
+          </div>
+        )}
       </div>
 
-      {/* Issue Detail Modal */}
-      <Dialog open={!!selectedIssue} onOpenChange={() => setSelectedIssue(null)}>
-        <DialogContent className="glass-card max-w-2xl overflow-hidden flex flex-col">
-          <DialogHeader className="shrink-0">
+      <Dialog open={Boolean(selectedIssue)} onOpenChange={() => setSelectedIssue(null)}>
+        <DialogContent className="max-w-2xl border-border/80 bg-popover">
+          <DialogHeader>
             <DialogTitle>{t("myIssues.issueDetails")}</DialogTitle>
           </DialogHeader>
 
-          {selectedIssue && (
-            <div className="flex-1 overflow-y-auto min-h-0 space-y-4">
-              <div className="flex items-center gap-2">
-                <Badge className={severityColors[selectedIssue.severity as keyof typeof severityColors]}>
+          {selectedIssue ? (
+            <div className="space-y-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge
+                  variant="outline"
+                  className={`rounded-full ${severityColors[selectedIssue.severity as keyof typeof severityColors]}`}
+                >
                   {selectedIssue.severity}
                 </Badge>
-                <Badge variant="outline" className={statusColors[selectedIssue.status as keyof typeof statusColors]}>
+                <Badge
+                  variant="outline"
+                  className={`rounded-full ${statusColors[selectedIssue.status as keyof typeof statusColors]}`}
+                >
                   {selectedIssue.status}
                 </Badge>
               </div>
 
-              <div>
-                <div className="text-sm text-muted-foreground mb-1">{t("myIssues.operation")}</div>
-                <div className="font-medium">
-                  {selectedIssue.operation.part.job.job_number} • {selectedIssue.operation.part.part_number} •{" "}
-                  {selectedIssue.operation.operation_name}
-                </div>
-              </div>
-
-              <div>
-                <div className="text-sm text-muted-foreground mb-1">{t("myIssues.description")}</div>
-                <div className="text-sm p-3 bg-muted rounded">{selectedIssue.description}</div>
-              </div>
-
-              <div className="grid grid-cols-2 gap-4">
+              <OperatorPanel className="space-y-3 p-4">
                 <div>
-                  <div className="text-sm text-muted-foreground mb-1">{t("myIssues.created")}</div>
-                  <div className="text-sm">{format(new Date(selectedIssue.created_at), "PPp")}</div>
-                </div>
-                {selectedIssue.reviewed_at && (
-                  <div>
-                    <div className="text-sm text-muted-foreground mb-1">{t("myIssues.reviewed")}</div>
-                    <div className="text-sm">{format(new Date(selectedIssue.reviewed_at), "PPp")}</div>
+                  <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                    {t("myIssues.operation")}
                   </div>
-                )}
-              </div>
-
-              {selectedIssue.resolution_notes && (
-                <div>
-                  <div className="text-sm text-muted-foreground mb-1">{t("myIssues.resolutionNotes")}</div>
-                  <div className="text-sm p-3 bg-muted rounded">{selectedIssue.resolution_notes}</div>
+                  <div className="mt-1 font-semibold text-foreground">
+                    {selectedIssue.operation.part.job.job_number} •{" "}
+                    {selectedIssue.operation.part.part_number} •{" "}
+                    {selectedIssue.operation.operation_name}
+                  </div>
                 </div>
-              )}
 
-              {imageUrls.length > 0 && (
                 <div>
-                  <div className="text-sm text-muted-foreground mb-2">{t("myIssues.attachedPhotos")}</div>
-                  <div className="grid grid-cols-2 gap-2">
+                  <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                    {t("myIssues.description")}
+                  </div>
+                  <div className="mt-1 text-sm text-muted-foreground">
+                    {selectedIssue.description}
+                  </div>
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div>
+                    <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                      {t("myIssues.created")}
+                    </div>
+                    <div className="mt-1 text-sm text-foreground">
+                      {format(new Date(selectedIssue.created_at), "PPp")}
+                    </div>
+                  </div>
+                  {selectedIssue.reviewed_at ? (
+                    <div>
+                      <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                        {t("myIssues.reviewed")}
+                      </div>
+                      <div className="mt-1 text-sm text-foreground">
+                        {format(new Date(selectedIssue.reviewed_at), "PPp")}
+                      </div>
+                    </div>
+                  ) : null}
+                </div>
+
+                {selectedIssue.resolution_notes ? (
+                  <div>
+                    <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                      {t("myIssues.resolutionNotes")}
+                    </div>
+                    <div className="mt-1 text-sm text-muted-foreground">
+                      {selectedIssue.resolution_notes}
+                    </div>
+                  </div>
+                ) : null}
+              </OperatorPanel>
+
+              {imageUrls.length > 0 ? (
+                <div className="space-y-2">
+                  <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                    {t("myIssues.attachedPhotos")}
+                  </div>
+                  <div className="grid gap-3 sm:grid-cols-2">
                     {imageUrls.map((url, index) => (
                       <img
-                        key={index}
+                        key={url}
                         src={url}
                         alt={`${t("myIssues.issuePhoto")} ${index + 1}`}
-                        className="rounded border"
+                        className="rounded-2xl border border-border object-cover"
                       />
                     ))}
                   </div>
                 </div>
-              )}
+              ) : null}
             </div>
-          )}
+          ) : null}
         </DialogContent>
       </Dialog>
     </>

--- a/src/pages/operator/OperatorView.test.tsx
+++ b/src/pages/operator/OperatorView.test.tsx
@@ -65,9 +65,7 @@ const mockCells = [
 const createQueryBuilder = (data: unknown[]) => ({
   select: vi.fn().mockReturnThis(),
   eq: vi.fn().mockReturnThis(),
-  order: vi.fn().mockReturnThis(),
-  then: (resolve: (value: { data: unknown[]; error: null }) => unknown) =>
-    Promise.resolve(resolve({ data, error: null })),
+  order: vi.fn().mockResolvedValue({ data, error: null }),
 });
 
 vi.mock("@/integrations/supabase/client", () => ({

--- a/src/pages/operator/OperatorView.test.tsx
+++ b/src/pages/operator/OperatorView.test.tsx
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@/test/utils";
+import OperatorView from "./OperatorView";
+
+const mockFetchOperationsWithDetails = vi.fn();
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    profile: {
+      id: "profile-1",
+      tenant_id: "tenant-1",
+      role: "operator",
+      full_name: "Shared Terminal",
+      email: "terminal@example.com",
+    },
+  }),
+}));
+
+vi.mock("@/contexts/OperatorContext", () => ({
+  useOperator: () => ({
+    activeOperator: {
+      id: "operator-1",
+      employee_id: "OP-100",
+      full_name: "Alex Operator",
+    },
+  }),
+}));
+
+vi.mock("@/hooks/useCADProcessing", () => ({
+  useCADProcessing: () => ({
+    processCAD: vi.fn(),
+    isProcessing: false,
+  }),
+  isCADServiceEnabled: () => false,
+}));
+
+vi.mock("@/lib/database", () => ({
+  fetchOperationsWithDetails: (...args: unknown[]) =>
+    mockFetchOperationsWithDetails(...args),
+  startTimeTracking: vi.fn(),
+  stopTimeTracking: vi.fn(),
+  completeOperation: vi.fn(),
+}));
+
+vi.mock("@/components/terminal/DetailPanel", () => ({
+  DetailPanel: ({ job }: { job: { jobCode: string; currentOp: string } }) => (
+    <div data-testid="detail-panel">
+      {job.jobCode}::{job.currentOp}
+    </div>
+  ),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const mockCells = [
+  { id: "cell-1", name: "Laser", color: "#2563eb" },
+  { id: "cell-2", name: "Brake", color: "#16a34a" },
+];
+
+const createQueryBuilder = (data: unknown[]) => ({
+  select: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  order: vi.fn().mockReturnThis(),
+  then: (resolve: (value: { data: unknown[]; error: null }) => unknown) =>
+    Promise.resolve(resolve({ data, error: null })),
+});
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    from: vi.fn((table: string) => {
+      if (table === "cells") {
+        return createQueryBuilder(mockCells);
+      }
+      return createQueryBuilder([]);
+    }),
+    channel: vi.fn(() => ({
+      on: vi.fn().mockReturnThis(),
+      subscribe: vi.fn().mockReturnThis(),
+    })),
+    removeChannel: vi.fn(),
+    storage: {
+      from: vi.fn(() => ({
+        createSignedUrl: vi.fn().mockResolvedValue({ data: { signedUrl: null } }),
+      })),
+    },
+  },
+}));
+
+const createOperation = (
+  id: string,
+  status: "in_progress" | "not_started",
+  sequence: number,
+  cellId = "cell-1",
+) =>
+  ({
+    id,
+    status,
+    operation_name: `Op ${sequence}`,
+    sequence,
+    estimated_time: 2,
+    actual_time: status === "in_progress" ? 0.5 : 0,
+    notes: `note-${id}`,
+    cell_id: cellId,
+    cell: mockCells.find((cell) => cell.id === cellId),
+    active_time_entry:
+      status === "in_progress"
+        ? {
+            id: `time-${id}`,
+            operator_id: "operator-1",
+            operator: { full_name: "Alex Operator" },
+          }
+        : null,
+    part: {
+      id: `part-${id}`,
+      part_number: `PART-${id}`,
+      material: "Steel",
+      quantity: sequence,
+      file_paths: [],
+      drawing_no: null,
+      cnc_program_name: null,
+      is_bullet_card: false,
+      job: {
+        id: `job-${id}`,
+        job_number: `JOB-${sequence}`,
+        due_date: "2026-03-20T00:00:00.000Z",
+      },
+    },
+  }) as any;
+
+describe("OperatorView", () => {
+  beforeEach(() => {
+    mockFetchOperationsWithDetails.mockResolvedValue([
+      createOperation("1", "in_progress", 1),
+      createOperation("2", "not_started", 2),
+      createOperation("3", "not_started", 3),
+      createOperation("4", "not_started", 4),
+      createOperation("5", "not_started", 5),
+      createOperation("6", "not_started", 6),
+      createOperation("7", "not_started", 7),
+    ]);
+    window.localStorage.clear();
+  });
+
+  it("loads queue groups and lets the user select a work packet", async () => {
+    render(<OperatorView />);
+
+    await waitFor(() => {
+      expect(screen.getByText("JOB-1")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("JOB-1"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("detail-panel")).toHaveTextContent("JOB-1::Op 1");
+    });
+  });
+
+  it("summarizes buffer and expected queue counts", async () => {
+    render(<OperatorView />);
+
+    await waitFor(() => {
+      expect(screen.getByText("JOB-1")).toBeInTheDocument();
+    });
+
+    const queueTabs = screen.getAllByRole("tab");
+    expect(queueTabs[1]).toHaveTextContent("5");
+    expect(queueTabs[2]).toHaveTextContent("1");
+  });
+});

--- a/src/pages/operator/OperatorView.tsx
+++ b/src/pages/operator/OperatorView.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useState,
-  useEffect,
-  useMemo,
-  useCallback,
-  useRef,
-} from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useOperator } from "@/contexts/OperatorContext";
 import { supabase } from "@/integrations/supabase/client";
@@ -19,7 +13,7 @@ import {
   startTimeTracking,
   stopTimeTracking,
   completeOperation,
-  OperationWithDetails,
+  type OperationWithDetails,
 } from "@/lib/database";
 import { JobRow } from "@/components/terminal/JobRow";
 import { DetailPanel } from "@/components/terminal/DetailPanel";
@@ -31,19 +25,34 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useTranslation } from "react-i18next";
-import { ChevronLeft, ChevronRight, GripVertical } from "lucide-react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
+import {
+  Clock3,
+  Boxes,
+  FileStack,
+  Gauge,
+  PackageSearch,
+  RefreshCw,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { logger } from "@/lib/logger";
-
 import { TerminalJob } from "@/types/terminal";
+import {
+  OperatorEmptyState,
+  OperatorPageHeader,
+  OperatorPanel,
+  OperatorStatCard,
+  OperatorStatusChip,
+} from "@/components/operator/OperatorStation";
 
 interface Cell {
   id: string;
   name: string;
   color: string | null;
 }
+
+type QueueTab = "in_progress" | "in_buffer" | "expected";
 
 export default function OperatorView() {
   const { t } = useTranslation();
@@ -57,72 +66,18 @@ export default function OperatorView() {
   );
   const [loading, setLoading] = useState(true);
   const [selectedJobId, setSelectedJobId] = useState<string | null>(null);
+  const [queueTab, setQueueTab] = useState<QueueTab>("in_progress");
 
   const [pdfUrl, setPdfUrl] = useState<string | null>(null);
   const [stepUrl, setStepUrl] = useState<string | null>(null);
-  const [signedStepUrl, setSignedStepUrl] = useState<string | null>(null);
   const [pmiData, setPmiData] = useState<PMIData | null>(null);
   const [geometryData, setGeometryData] = useState<GeometryData | null>(null);
 
-  const { processCAD, isProcessing: cadProcessing } = useCADProcessing();
+  const { processCAD } = useCADProcessing();
 
-  const [rightPanelCollapsed, setRightPanelCollapsed] = useState(false);
-  const [leftPanelWidth, setLeftPanelWidth] = useState(70); // percentage
-  const [isDragging, setIsDragging] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  const handleMouseDown = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    setIsDragging(true);
-  }, []);
-
-  const handleMouseMove = useCallback(
-    (e: MouseEvent) => {
-      if (!isDragging || !containerRef.current) return;
-      const rect = containerRef.current.getBoundingClientRect();
-      const newWidth = ((e.clientX - rect.left) / rect.width) * 100;
-      setLeftPanelWidth(Math.min(Math.max(newWidth, 40), 85)); // Clamp between 40% and 85%
-    },
-    [isDragging],
-  );
-
-  const handleMouseUp = useCallback(() => {
-    setIsDragging(false);
-  }, []);
-
-  const handleTouchStart = useCallback((e: React.TouchEvent) => {
-    e.preventDefault();
-    setIsDragging(true);
-  }, []);
-
-  const handleTouchMove = useCallback(
-    (e: TouchEvent) => {
-      if (!isDragging || !containerRef.current) return;
-      const touch = e.touches[0];
-      const rect = containerRef.current.getBoundingClientRect();
-      const newWidth = ((touch.clientX - rect.left) / rect.width) * 100;
-      setLeftPanelWidth(Math.min(Math.max(newWidth, 40), 85));
-    },
-    [isDragging],
-  );
-
-  useEffect(() => {
-    if (isDragging) {
-      window.addEventListener("mousemove", handleMouseMove);
-      window.addEventListener("mouseup", handleMouseUp);
-      window.addEventListener("touchmove", handleTouchMove);
-      window.addEventListener("touchend", handleMouseUp);
-    }
-    return () => {
-      window.removeEventListener("mousemove", handleMouseMove);
-      window.removeEventListener("mouseup", handleMouseUp);
-      window.removeEventListener("touchmove", handleTouchMove);
-      window.removeEventListener("touchend", handleMouseUp);
-    };
-  }, [isDragging, handleMouseMove, handleMouseUp, handleTouchMove]);
-
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
     if (!profile?.tenant_id) return;
+
     try {
       setLoading(true);
 
@@ -144,10 +99,10 @@ export default function OperatorView() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [profile?.tenant_id, t]);
 
   useEffect(() => {
-    loadData();
+    void loadData();
 
     if (!profile?.tenant_id) return;
     const channel = supabase
@@ -160,7 +115,7 @@ export default function OperatorView() {
           table: "operations",
           filter: `tenant_id=eq.${profile.tenant_id}`,
         },
-        () => loadData(),
+        () => void loadData(),
       )
       .on(
         "postgres_changes",
@@ -170,46 +125,37 @@ export default function OperatorView() {
           table: "time_entries",
           filter: `tenant_id=eq.${profile.tenant_id}`,
         },
-        () => loadData(),
+        () => void loadData(),
       )
       .subscribe();
 
     return () => {
       supabase.removeChannel(channel);
     };
-  }, [profile?.tenant_id]);
+  }, [loadData, profile?.tenant_id]);
 
   const handleCellChange = (value: string) => {
     setSelectedCellId(value);
     localStorage.setItem("operator_selected_cell", value);
-    setSelectedJobId(null); // Clear selection when changing cells
+    setSelectedJobId(null);
   };
 
-  const mapOperationToJob = (op: OperationWithDetails): TerminalJob => {
-    if (op.part.file_paths && op.part.file_paths.length > 0) {
-      logger.debug(
-        "OperatorView",
-        "Mapping op with files",
-        { id: op.id, partNumber: op.part.part_number, filePaths: op.part.file_paths },
-      );
-    }
-
+  const mapOperationToJob = useCallback((op: OperationWithDetails): TerminalJob => {
     const hasPdf =
-      op.part.file_paths?.some((p) => p.toLowerCase().endsWith(".pdf")) ||
+      op.part.file_paths?.some((path) => path.toLowerCase().endsWith(".pdf")) ||
       false;
     const hasModel =
-      op.part.file_paths?.some(
-        (p) =>
-          p.toLowerCase().endsWith(".step") || p.toLowerCase().endsWith(".stp"),
-      ) || false;
+      op.part.file_paths?.some((path) => {
+        const lowerPath = path.toLowerCase();
+        return lowerPath.endsWith(".step") || lowerPath.endsWith(".stp");
+      }) || false;
 
     let status: TerminalJob["status"] = "expected";
     if (op.status === "in_progress") status = "in_progress";
     else if (op.status === "on_hold") status = "on_hold";
     else if (op.status === "not_started") status = "in_buffer";
-    else if (op.status === "completed") status = "expected"; // Will be filtered out
+    else if (op.status === "completed") status = "expected";
 
-    // If there's an active time entry, the operation should be considered in_progress
     if (op.active_time_entry) status = "in_progress";
 
     const estimated = op.estimated_time || 0;
@@ -217,19 +163,19 @@ export default function OperatorView() {
     const remaining = Math.max(0, estimated - actual);
 
     return {
-      id: op.id, // Use operation ID as the unique key
+      id: op.id,
       operationId: op.id,
       partId: op.part.id,
       jobId: op.part.job.id,
       jobCode: op.part.job.job_number,
-      description: op.part.part_number, // Or op.operation_name? Design showed Part Name as description
+      description: op.part.part_number,
       material: op.part.material,
       quantity: op.part.quantity,
       currentOp: op.operation_name,
-      totalOps: 0, // Placeholder
-      hours: Number(remaining.toFixed(1)), // Format to 1 decimal place
+      totalOps: 0,
+      hours: Number(remaining.toFixed(1)),
       dueDate: op.part.job.due_date || new Date().toISOString(),
-      status: status,
+      status,
       hasPdf,
       hasModel,
       filePaths: op.part.file_paths || [],
@@ -242,16 +188,15 @@ export default function OperatorView() {
       cellColor: op.cell.color || "#3b82f6",
       cellId: op.cell_id,
       currentSequence: op.sequence,
-      // New part fields
       drawingNo: op.part.drawing_no,
       cncProgramName: op.part.cnc_program_name,
       isBulletCard: op.part.is_bullet_card,
     };
-  };
+  }, [operatorId]);
 
   const allJobs = useMemo(
     () => operations.map(mapOperationToJob),
-    [operations, operatorId],
+    [mapOperationToJob, operations],
   );
 
   const filteredJobs = useMemo(() => {
@@ -259,20 +204,37 @@ export default function OperatorView() {
     return allJobs.filter((job) => job.cellId === selectedCellId);
   }, [allJobs, selectedCellId]);
 
-  const inProcessJobs = filteredJobs.filter((j) => j.status === "in_progress");
+  const inProcessJobs = filteredJobs.filter((job) => job.status === "in_progress");
 
-  // First 5 not-started operations go to Buffer, rest to Expected
   const notStartedJobs = filteredJobs.filter(
-    (j) => j.status === "in_buffer" || j.status === "expected",
+    (job) => job.status === "in_buffer" || job.status === "expected",
   );
   const inBufferJobs = notStartedJobs
     .slice(0, 5)
-    .map((j) => ({ ...j, status: "in_buffer" as const }));
+    .map((job) => ({ ...job, status: "in_buffer" as const }));
   const expectedJobs = notStartedJobs
     .slice(5)
-    .map((j) => ({ ...j, status: "expected" as const }));
+    .map((job) => ({ ...job, status: "expected" as const }));
 
-  const selectedJob = allJobs.find((j) => j.id === selectedJobId) || null;
+  const queueGroups = useMemo<Record<QueueTab, TerminalJob[]>>(
+    () => ({
+      in_progress: inProcessJobs,
+      in_buffer: inBufferJobs,
+      expected: expectedJobs,
+    }),
+    [expectedJobs, inBufferJobs, inProcessJobs],
+  );
+
+  useEffect(() => {
+    if (queueGroups[queueTab].length > 0) return;
+    const nextTab =
+      (Object.entries(queueGroups).find(([, jobs]) => jobs.length > 0)?.[0] as
+        | QueueTab
+        | undefined) || "in_progress";
+    if (nextTab !== queueTab) setQueueTab(nextTab);
+  }, [queueGroups, queueTab]);
+
+  const selectedJob = allJobs.find((job) => job.id === selectedJobId) || null;
 
   const selectedPartOperations = useMemo(() => {
     if (!selectedJob) return [];
@@ -281,22 +243,24 @@ export default function OperatorView() {
       .sort((a, b) => a.sequence - b.sequence);
   }, [selectedJob, operations]);
 
+  const selectedCellName =
+    selectedCellId === "all"
+      ? t("common.all", "All")
+      : cells.find((cell) => cell.id === selectedCellId)?.name ||
+        t("common.unknown", "Unknown");
+
+  const docsCount = filteredJobs.filter((job) => job.hasPdf || job.hasModel).length;
+  const activeCellCount = new Set(filteredJobs.map((job) => job.cellId)).size;
+
   useEffect(() => {
     const loadFiles = async () => {
       if (!selectedJob?.filePaths?.length) {
-        logger.debug("OperatorView", "No file paths for job", selectedJob?.jobCode);
         setPdfUrl(null);
         setStepUrl(null);
-        setSignedStepUrl(null);
         setPmiData(null);
+        setGeometryData(null);
         return;
       }
-
-      logger.debug(
-        "OperatorView",
-        "Loading files for job",
-        { jobCode: selectedJob.jobCode, filePaths: selectedJob.filePaths },
-      );
 
       try {
         let pdf: string | null = null;
@@ -305,24 +269,21 @@ export default function OperatorView() {
         let stepFileName: string | null = null;
 
         for (const path of selectedJob.filePaths) {
-          const ext = path.toLowerCase();
-          logger.debug("OperatorView", "Checking file", { path, ext });
+          const lowerPath = path.toLowerCase();
 
-          if (ext.endsWith(".pdf") && !pdf) {
+          if (lowerPath.endsWith(".pdf") && !pdf) {
             const { data } = await supabase.storage
               .from("parts-cad")
               .createSignedUrl(path, 3600);
             if (data?.signedUrl) pdf = data.signedUrl;
-          } else if ((ext.endsWith(".step") || ext.endsWith(".stp")) && !step) {
+          } else if (
+            (lowerPath.endsWith(".step") || lowerPath.endsWith(".stp")) &&
+            !step
+          ) {
             const { data } = await supabase.storage
               .from("parts-cad")
               .createSignedUrl(path, 3600);
             if (data?.signedUrl) {
-              logger.debug(
-                "OperatorView",
-                "Found STEP file, creating blob URL",
-                data.signedUrl,
-              );
               signedStep = data.signedUrl;
               stepFileName = path.split("/").pop() || "model.step";
               const response = await fetch(data.signedUrl);
@@ -331,43 +292,26 @@ export default function OperatorView() {
             }
           }
         }
+
         setPdfUrl(pdf);
         setStepUrl(step);
-        setSignedStepUrl(signedStep);
-
-        setSignedStepUrl(signedStep);
-        setStepUrl(step);
-
 
         if (signedStep && stepFileName && isCADServiceEnabled()) {
-          logger.debug("OperatorView", "Calling backend for PMI extraction", signedStep);
           try {
             const result = await processCAD(signedStep, stepFileName, {
-              includeGeometry: true, // Server handles geometry
+              includeGeometry: true,
               includePMI: true,
               generateThumbnail: false,
             });
             if (result.success) {
-              logger.debug("OperatorView", "CAD processing successful", result);
-              if (result.pmi) setPmiData(result.pmi);
-              if (result.geometry) setGeometryData(result.geometry);
-            } else if (result.error) {
-              logger.warn("OperatorView", "CAD processing failed", result.error);
-              if (
-                result.error.includes("invalid geometry") ||
-                result.error.includes("segfault")
-              ) {
-                toast.error(t("production.cadProcessingFailed"));
-              } else if (result.error.includes("Unsupported")) {
-                toast.error(t("production.unsupportedCadFormat"));
-              } else {
-                toast.error(t("production.cadProcessingFailed"));
-              }
+              setPmiData(result.pmi ?? null);
+              setGeometryData(result.geometry ?? null);
+            } else {
               setPmiData(null);
               setGeometryData(null);
             }
-          } catch (pmiError) {
-            logger.error("OperatorView", "Error during CAD processing", pmiError);
+          } catch (error) {
+            logger.error("OperatorView", "Error during CAD processing", error);
             toast.error(t("production.cadProcessingFailed"));
             setPmiData(null);
             setGeometryData(null);
@@ -376,13 +320,13 @@ export default function OperatorView() {
           setPmiData(null);
           setGeometryData(null);
         }
-      } catch (e) {
-        logger.error("OperatorView", "Error loading file URLs", e);
+      } catch (error) {
+        logger.error("OperatorView", "Error loading file URLs", error);
       }
     };
 
-    loadFiles();
-  }, [selectedJob, processCAD]);
+    void loadFiles();
+  }, [selectedJob, processCAD, t]);
 
   const handleStart = async () => {
     if (!selectedJob || !operatorId || !profile?.tenant_id) return;
@@ -394,7 +338,9 @@ export default function OperatorView() {
       );
       toast.success(t("notifications.success"));
     } catch (error: unknown) {
-      toast.error(error instanceof Error ? error.message : t("notifications.failed"));
+      toast.error(
+        error instanceof Error ? error.message : t("notifications.failed"),
+      );
     }
   };
 
@@ -404,7 +350,9 @@ export default function OperatorView() {
       await stopTimeTracking(selectedJob.operationId, operatorId);
       toast.success(t("production.operationPaused"));
     } catch (error: unknown) {
-      toast.error(error instanceof Error ? error.message : t("notifications.failed"));
+      toast.error(
+        error instanceof Error ? error.message : t("notifications.failed"),
+      );
     }
   };
 
@@ -417,47 +365,92 @@ export default function OperatorView() {
         operatorId,
       );
       toast.success(t("production.operationCompleted"));
-      setSelectedJobId(null); // Deselect
+      setSelectedJobId(null);
     } catch (error: unknown) {
-      toast.error(error instanceof Error ? error.message : t("notifications.failed"));
+      toast.error(
+        error instanceof Error ? error.message : t("notifications.failed"),
+      );
     }
   };
 
-  return (
-    <div
-      ref={containerRef}
-      className={cn(
-        "flex h-[calc(100vh-160px)] w-full bg-background text-foreground overflow-hidden font-sans relative",
-        isDragging && "select-none cursor-col-resize",
-      )}
-    >
-      {loading && (
-        <div className="absolute inset-0 bg-background/80 z-50 flex items-center justify-center backdrop-blur-sm">
+  const renderQueue = (
+    jobs: TerminalJob[],
+    variant: "process" | "buffer" | "expected",
+    emptyTitle: string,
+    emptyDescription: string,
+  ) => {
+    if (jobs.length === 0) {
+      return (
+        <OperatorEmptyState
+          icon={PackageSearch}
+          title={emptyTitle}
+          description={emptyDescription}
+          className="min-h-[260px]"
+        />
+      );
+    }
+
+    return (
+      <div className="grid gap-3">
+        {jobs.map((job) => (
+          <JobRow
+            key={job.id}
+            job={job}
+            isSelected={selectedJobId === job.id}
+            onClick={() => setSelectedJobId(job.id)}
+            variant={variant}
+          />
+        ))}
+      </div>
+    );
+  };
+
+  if (loading && operations.length === 0) {
+    return (
+      <OperatorPanel className="flex min-h-[420px] items-center justify-center">
           <div className="flex flex-col items-center gap-4">
-            <div className="w-12 h-12 border-4 border-primary border-t-transparent rounded-full animate-spin"></div>
-            <p className="text-primary font-medium animate-pulse">
-              Loading Terminal Data...
-            </p>
+            <div className="h-10 w-10 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+            <div className="text-sm font-medium text-muted-foreground">
+            {t("terminal.loading", "Loading operator workspace")}
+            </div>
           </div>
-        </div>
-      )}
-      {/* LEFT PANEL - Resizable */}
-      <div
-        className="flex flex-col border-r border-border transition-all duration-200"
-        style={{ width: rightPanelCollapsed ? "100%" : `${leftPanelWidth}%` }}
-      >
-        {/* HEADER / CELL SELECTOR */}
-        <div className="h-12 border-b border-border bg-card/80 backdrop-blur-sm flex items-center px-4 justify-between shrink-0">
-          <div className="flex items-center gap-4">
-            <span className="text-muted-foreground font-medium">
-              Terminal View:
-            </span>
+        </OperatorPanel>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <OperatorPageHeader
+        eyebrow={t("navigation.terminalView", "Terminal View")}
+        title={t("terminal.operatorStation", "Operator workspace")}
+        description={t(
+          "terminal.operatorStationDescription",
+          "Focus the queue on the active cell, select one work packet, and keep the next operator action obvious.",
+        )}
+        meta={
+          <>
+            <OperatorStatusChip
+              tone="info"
+              label={`${selectedCellName} • ${filteredJobs.length} ${t(
+                "terminal.jobsFound",
+              )}`}
+            />
+            {selectedJob ? (
+              <OperatorStatusChip
+                tone="active"
+                label={`${selectedJob.jobCode} • ${selectedJob.currentOp}`}
+              />
+            ) : null}
+          </>
+        }
+        actions={
+          <>
             <Select value={selectedCellId} onValueChange={handleCellChange}>
-              <SelectTrigger className="w-[200px] bg-card border-input text-foreground">
-                <SelectValue placeholder="Select Cell" />
+              <SelectTrigger className="min-h-11 w-[220px] rounded-xl border-border/80 bg-card">
+                <SelectValue placeholder={t("terminal.selectCell", "Select cell")} />
               </SelectTrigger>
-              <SelectContent className="bg-card border-border text-foreground">
-                <SelectItem value="all">All Cells</SelectItem>
+              <SelectContent>
+                <SelectItem value="all">{t("terminal.allCells", "All Cells")}</SelectItem>
                 {cells.map((cell) => (
                   <SelectItem key={cell.id} value={cell.id}>
                     {cell.name}
@@ -465,263 +458,180 @@ export default function OperatorView() {
                 ))}
               </SelectContent>
             </Select>
-          </div>
-          <div className="text-xs text-muted-foreground">
-            {filteredJobs.length} {t("terminal.jobsFound")}
-          </div>
-        </div>
+            <Button
+              variant="outline"
+              onClick={() => void loadData()}
+              className="min-h-11 rounded-xl"
+            >
+              <RefreshCw className="mr-2 h-4 w-4" />
+              {t("common.refresh", "Refresh")}
+            </Button>
+          </>
+        }
+      />
 
-        {/* 1. IN PROCESS */}
-        <div className="flex-1 flex flex-col min-h-0 border-b border-border bg-gradient-to-b from-status-active/5 to-transparent overflow-hidden">
-          <div className="px-3 py-1.5 bg-status-active/10 backdrop-blur-sm border-l-2 border-status-active flex items-center justify-between shrink-0">
-            <h2 className="text-sm font-semibold text-status-active">
-              {t("terminal.inProcess")} ({inProcessJobs.length})
-            </h2>
-          </div>
-          <div className="flex-1 overflow-auto">
-            <table className="w-full text-left border-collapse">
-              <thead className="bg-muted/50 sticky top-0 z-10">
-                <tr className="border-b border-border">
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
-                    {t("terminal.columns.jobNumber")}
-                  </th>
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
-                    {t("terminal.columns.partNumber")}
-                  </th>
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
-                    {t("terminal.columns.operation")}
-                  </th>
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
-                    {t("terminal.columns.cell")}
-                  </th>
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
-                    {t("terminal.columns.material")}
-                  </th>
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground text-center">
-                    {t("terminal.columns.quantity")}
-                  </th>
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground text-right">
-                    {t("terminal.columns.hours")}
-                  </th>
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
-                    {t("terminal.columns.dueDate")}
-                  </th>
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground text-center">
-                    {t("terminal.columns.files")}
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {inProcessJobs.length === 0 ? (
-                  <tr>
-                    <td
-                      colSpan={9}
-                      className="text-center py-8 text-muted-foreground italic"
-                    >
-                      {t("terminal.noActiveJobs")}
-                    </td>
-                  </tr>
-                ) : (
-                  inProcessJobs.map((job) => (
-                    <JobRow
-                      key={job.id}
-                      job={job}
-                      isSelected={selectedJobId === job.id}
-                      onClick={() => setSelectedJobId(job.id)}
-                      variant="process"
-                    />
-                  ))
-                )}
-              </tbody>
-            </table>
-          </div>
-        </div>
-
-        {/* 2. IN BUFFER */}
-        <div className="flex-1 flex flex-col min-h-0 border-b border-border bg-gradient-to-b from-info/5 to-transparent overflow-hidden">
-          <div className="px-3 py-1.5 bg-alert-info-bg/80 backdrop-blur-sm border-l-2 border-alert-info-border flex items-center justify-between shrink-0">
-            <h2 className="text-sm font-semibold text-info">
-              {t("terminal.inBuffer")} ({inBufferJobs.length})
-            </h2>
-          </div>
-          <div className="flex-1 overflow-auto">
-            <table className="w-full text-left border-collapse">
-              <thead className="bg-muted/50 sticky top-0 z-10">
-                <tr className="border-b border-border">
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
-                    {t("terminal.columns.jobNumber")}
-                  </th>
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
-                    {t("terminal.columns.partNumber")}
-                  </th>
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
-                    {t("terminal.columns.operation")}
-                  </th>
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
-                    {t("terminal.columns.cell")}
-                  </th>
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
-                    {t("terminal.columns.material")}
-                  </th>
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground text-center">
-                    {t("terminal.columns.quantity")}
-                  </th>
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground text-right">
-                    {t("terminal.columns.hours")}
-                  </th>
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
-                    {t("terminal.columns.dueDate")}
-                  </th>
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground text-center">
-                    {t("terminal.columns.files")}
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {inBufferJobs.map((job) => (
-                  <JobRow
-                    key={job.id}
-                    job={job}
-                    isSelected={selectedJobId === job.id}
-                    onClick={() => setSelectedJobId(job.id)}
-                    variant="buffer"
-                  />
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
-
-        {/* 3. EXPECTED */}
-        <div className="flex-1 flex flex-col min-h-0 bg-gradient-to-b from-status-pending/5 to-transparent overflow-hidden">
-          <div className="px-3 py-1.5 bg-status-pending/10 backdrop-blur-sm border-l-2 border-status-pending flex items-center justify-between shrink-0">
-            <h2 className="text-sm font-semibold text-status-pending">
-              {t("terminal.expected")} ({expectedJobs.length})
-            </h2>
-          </div>
-          <div className="flex-1 overflow-auto">
-            <table className="w-full text-left border-collapse">
-              <thead className="bg-muted/50 sticky top-0 z-10">
-                <tr className="border-b border-border">
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
-                    {t("terminal.columns.jobNumber")}
-                  </th>
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
-                    {t("terminal.columns.partNumber")}
-                  </th>
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
-                    {t("terminal.columns.operation")}
-                  </th>
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
-                    {t("terminal.columns.cell")}
-                  </th>
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
-                    {t("terminal.columns.material")}
-                  </th>
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground text-center">
-                    {t("terminal.columns.quantity")}
-                  </th>
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground text-right">
-                    {t("terminal.columns.hours")}
-                  </th>
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
-                    {t("terminal.columns.dueDate")}
-                  </th>
-                  <th className="px-2 py-1.5 text-xs font-semibold text-muted-foreground text-center">
-                    {t("terminal.columns.files")}
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {expectedJobs.map((job) => (
-                  <JobRow
-                    key={job.id}
-                    job={job}
-                    isSelected={selectedJobId === job.id}
-                    onClick={() => setSelectedJobId(job.id)}
-                    variant="expected"
-                  />
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <OperatorStatCard
+          label={t("terminal.inProcess")}
+          value={inProcessJobs.length}
+          caption={t("terminal.liveWork", "Operations currently in work")}
+          icon={Clock3}
+          tone="warning"
+        />
+        <OperatorStatCard
+          label={t("terminal.inBuffer")}
+          value={inBufferJobs.length}
+          caption={t("terminal.readyNext", "Ready to start next")}
+          icon={Boxes}
+          tone="info"
+        />
+        <OperatorStatCard
+          label={t("terminal.expected")}
+          value={expectedJobs.length}
+          caption={t("terminal.upcomingLoad", "Later queue in this view")}
+          icon={Gauge}
+        />
+        <OperatorStatCard
+          label={t("terminal.packet", "Work packets")}
+          value={docsCount}
+          caption={t(
+            "terminal.packetCaption",
+            `${activeCellCount} active cells with drawings or models`,
+          )}
+          icon={FileStack}
+          tone="active"
+        />
       </div>
 
-      {/* RESIZABLE DIVIDER */}
-      {!rightPanelCollapsed && (
-        <div
-          className={cn(
-            "w-1 bg-border hover:bg-primary/50 cursor-col-resize flex items-center justify-center group transition-colors relative z-20",
-            isDragging && "bg-primary/50",
-          )}
-          onMouseDown={handleMouseDown}
-          onTouchStart={handleTouchStart}
-        >
-          <div className="absolute inset-y-0 -left-1 -right-1" />{" "}
-          {/* Larger touch target */}
-          <GripVertical className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
-        </div>
-      )}
-
-      {/* RIGHT PANEL - Resizable/Collapsible */}
-      <div
-        className={cn(
-          "bg-card flex flex-col border-l border-border shadow-2xl z-10 transition-all duration-200",
-          "backdrop-blur-md bg-card/95", // Glass morphism
-          rightPanelCollapsed ? "w-10" : "",
-        )}
-        style={{
-          width: rightPanelCollapsed ? "40px" : `${100 - leftPanelWidth}%`,
-        }}
-      >
-        {/* Collapse Toggle Button */}
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => setRightPanelCollapsed(!rightPanelCollapsed)}
-          className="absolute top-2 -left-3 z-30 h-6 w-6 p-0 rounded-full bg-card border border-border shadow-md hover:bg-accent"
-          style={{ marginLeft: rightPanelCollapsed ? "7px" : "0" }}
-        >
-          {rightPanelCollapsed ? (
-            <ChevronLeft className="h-3 w-3" />
-          ) : (
-            <ChevronRight className="h-3 w-3" />
-          )}
-        </Button>
-
-        {rightPanelCollapsed ? (
-          <div className="flex-1 flex flex-col items-center justify-center py-4">
-            <span className="text-muted-foreground text-[10px] [writing-mode:vertical-lr] rotate-180">
-              Details Panel
-            </span>
-          </div>
-        ) : selectedJob ? (
-          <DetailPanel
-            job={selectedJob}
-            onStart={handleStart}
-            onPause={handlePause}
-            onComplete={handleComplete}
-            stepUrl={stepUrl}
-            pdfUrl={pdfUrl}
-            pmiData={pmiData}
-            serverGeometry={geometryData}
-            operations={selectedPartOperations}
-            onDataRefresh={loadData}
-          />
-        ) : (
-          <div className="flex-1 flex flex-col items-center justify-center text-muted-foreground p-8 text-center">
-            <div className="w-16 h-16 rounded-full bg-accent/10 mb-4 flex items-center justify-center">
-              <span className="text-3xl">👈</span>
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_460px]">
+        <OperatorPanel className="overflow-hidden p-0">
+          <Tabs
+            value={queueTab}
+            onValueChange={(value) => setQueueTab(value as QueueTab)}
+            className="w-full"
+          >
+            <div className="border-b border-border px-4 py-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <div className="text-sm font-semibold text-foreground">
+                    {t("terminal.queueByStatus", "Queue by status")}
+                  </div>
+                  <div className="text-sm text-muted-foreground">
+                    {t(
+                      "terminal.queueByStatusDescription",
+                      "Operators should see active work first, then what is ready next.",
+                    )}
+                  </div>
+                </div>
+                {loading ? (
+                  <div className="text-sm text-muted-foreground">
+                    {t("common.refreshing", "Refreshing")}
+                  </div>
+                ) : null}
+              </div>
+              <TabsList className="mt-4 grid h-auto w-full grid-cols-3 gap-2 rounded-2xl bg-muted/30 p-1">
+                <TabsTrigger
+                  value="in_progress"
+                  className="min-h-16 rounded-xl data-[state=active]:bg-background"
+                >
+                  <div className="flex flex-col items-start">
+                    <span className="text-sm font-semibold">
+                      {t("terminal.inProcess")}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {inProcessJobs.length} {t("terminal.jobsFound")}
+                    </span>
+                  </div>
+                </TabsTrigger>
+                <TabsTrigger
+                  value="in_buffer"
+                  className="min-h-16 rounded-xl data-[state=active]:bg-background"
+                >
+                  <div className="flex flex-col items-start">
+                    <span className="text-sm font-semibold">{t("terminal.inBuffer")}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {inBufferJobs.length} {t("terminal.jobsFound")}
+                    </span>
+                  </div>
+                </TabsTrigger>
+                <TabsTrigger
+                  value="expected"
+                  className="min-h-16 rounded-xl data-[state=active]:bg-background"
+                >
+                  <div className="flex flex-col items-start">
+                    <span className="text-sm font-semibold">{t("terminal.expected")}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {expectedJobs.length} {t("terminal.jobsFound")}
+                    </span>
+                  </div>
+                </TabsTrigger>
+              </TabsList>
             </div>
-            <h3 className="text-xl font-medium text-foreground mb-2">
-              No Job Selected
-            </h3>
-            <p className="text-sm">
-              Select a job from the list to view details and controls.
-            </p>
-          </div>
-        )}
+
+            <div className="p-4">
+              <TabsContent value="in_progress" className="m-0">
+                {renderQueue(
+                  inProcessJobs,
+                  "process",
+                  t("terminal.noActiveJobs"),
+                  t(
+                    "terminal.noActiveJobsDescription",
+                    "Nothing is currently clocked in for this cell selection.",
+                  ),
+                )}
+              </TabsContent>
+              <TabsContent value="in_buffer" className="m-0">
+                {renderQueue(
+                  inBufferJobs,
+                  "buffer",
+                  t("terminal.noBufferJobs", "No jobs ready next"),
+                  t(
+                    "terminal.noBufferJobsDescription",
+                    "The immediate buffer is clear. Expected work will appear here as routing advances.",
+                  ),
+                )}
+              </TabsContent>
+              <TabsContent value="expected" className="m-0">
+                {renderQueue(
+                  expectedJobs,
+                  "expected",
+                  t("terminal.noExpectedJobs", "No upcoming jobs"),
+                  t(
+                    "terminal.noExpectedJobsDescription",
+                    "There is no later queue for this cell selection right now.",
+                  ),
+                )}
+              </TabsContent>
+            </div>
+          </Tabs>
+        </OperatorPanel>
+
+        <OperatorPanel className="overflow-hidden p-0">
+          {selectedJob ? (
+            <DetailPanel
+              job={selectedJob}
+              onStart={handleStart}
+              onPause={handlePause}
+              onComplete={handleComplete}
+              stepUrl={stepUrl}
+              pdfUrl={pdfUrl}
+              pmiData={pmiData}
+              serverGeometry={geometryData}
+              operations={selectedPartOperations}
+              onDataRefresh={() => void loadData()}
+            />
+          ) : (
+            <OperatorEmptyState
+              icon={Gauge}
+              title={t("terminal.noJobSelected", "Select a work packet")}
+              description={t(
+                "terminal.noJobSelectedDescription",
+                "Choose a job from the queue to show drawings, routing, production actions, and issue reporting in one place.",
+              )}
+              className="min-h-[720px] rounded-none border-0"
+            />
+          )}
+        </OperatorPanel>
       </div>
     </div>
   );

--- a/src/pages/operator/WorkQueue.tsx
+++ b/src/pages/operator/WorkQueue.tsx
@@ -1,15 +1,16 @@
-import { useEffect, useState, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useOperator } from "@/contexts/OperatorContext";
 import { supabase } from "@/integrations/supabase/client";
-import { fetchOperationsWithDetails, OperationWithDetails } from "@/lib/database";
+import {
+  fetchOperationsWithDetails,
+  type OperationWithDetails,
+} from "@/lib/database";
 import OperationCard from "@/components/operator/OperationCard";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Input } from "@/components/ui/input";
-import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Loader2, Search, Filter, Eye, EyeOff, LayoutGrid, List, UserCheck } from "lucide-react";
+import { Loader2, Search, Filter, ListFilter, Clock3, CheckCircle2, UserCheck, PackageSearch } from "lucide-react";
 import { toast } from "sonner";
 import {
   Select,
@@ -20,24 +21,33 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
-import { isAfter, isBefore, addDays, startOfToday, endOfToday } from "date-fns";
+import {
+  isAfter,
+  isBefore,
+  addDays,
+  startOfToday,
+  endOfToday,
+} from "date-fns";
 import { useTranslation } from "react-i18next";
 import { logger } from "@/lib/logger";
+import {
+  OperatorEmptyState,
+  OperatorPageHeader,
+  OperatorPanel,
+  OperatorStatCard,
+  OperatorStatusChip,
+} from "@/components/operator/OperatorStation";
 
 interface PartAssignment {
   part_id: string;
   assigned_by_name: string;
 }
 
-const getStageClass = (cellName: string) => {
-  const name = cellName.toLowerCase();
-  if (name.includes('cut')) return 'stage-cutting';
-  if (name.includes('bend')) return 'stage-bending';
-  if (name.includes('weld')) return 'stage-welding';
-  if (name.includes('assembl')) return 'stage-assembly';
-  if (name.includes('finish')) return 'stage-finishing';
-  return 'muted';
-};
+interface CellOption {
+  id: string;
+  name: string;
+  color: string | null;
+}
 
 export default function WorkQueue() {
   const { t } = useTranslation();
@@ -46,25 +56,18 @@ export default function WorkQueue() {
   const [operations, setOperations] = useState<OperationWithDetails[]>([]);
   const [loading, setLoading] = useState(true);
   const [selectedMaterial, setSelectedMaterial] = useState<string>("all");
+  const [selectedCell, setSelectedCell] = useState<string>("all");
   const [searchQuery, setSearchQuery] = useState<string>("");
-  const [cells, setCells] = useState<any[]>([]);
-  const [hiddenCells, setHiddenCells] = useState<Set<string>>(new Set());
+  const [cells, setCells] = useState<CellOption[]>([]);
   const [statusFilter, setStatusFilter] = useState<string>("all");
   const [assignedToMe, setAssignedToMe] = useState<boolean>(false);
   const [dueDateFilter, setDueDateFilter] = useState<string>("all");
   const [sortBy, setSortBy] = useState<string>("sequence");
   const [showCompleted, setShowCompleted] = useState<boolean>(true);
-  const [viewMode, setViewMode] = useState<"detailed" | "compact">("detailed");
   const [showFilters, setShowFilters] = useState<boolean>(false);
   const [myAssignments, setMyAssignments] = useState<PartAssignment[]>([]);
 
-  useEffect(() => {
-    if (!profile?.tenant_id) return;
-    loadData();
-    return setupRealtimeSubscriptions();
-  }, [profile?.tenant_id, activeOperator?.id]);
-
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
     if (!profile?.tenant_id) return;
 
     try {
@@ -72,7 +75,7 @@ export default function WorkQueue() {
         fetchOperationsWithDetails(profile.tenant_id),
         supabase
           .from("cells")
-          .select("*")
+          .select("id, name, color")
           .eq("tenant_id", profile.tenant_id)
           .eq("active", true)
           .order("sequence"),
@@ -95,12 +98,16 @@ export default function WorkQueue() {
         if (assignmentsData) {
           setMyAssignments(
             assignmentsData
-              .filter((a): a is { part_id: string; assigned_by_user: { full_name: string } } =>
-                a.part_id !== null && a.assigned_by_user !== null)
-              .map(a => ({
-                part_id: a.part_id,
-                assigned_by_name: a.assigned_by_user.full_name,
-              }))
+              .filter(
+                (assignment): assignment is {
+                  part_id: string;
+                  assigned_by_user: { full_name: string };
+                } => assignment.part_id !== null && assignment.assigned_by_user !== null,
+              )
+              .map((assignment) => ({
+                part_id: assignment.part_id,
+                assigned_by_name: assignment.assigned_by_user.full_name,
+              })),
           );
         }
       } else {
@@ -112,9 +119,9 @@ export default function WorkQueue() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [activeOperator?.id, profile?.tenant_id, t]);
 
-  const setupRealtimeSubscriptions = () => {
+  const setupRealtimeSubscriptions = useCallback(() => {
     if (!profile?.tenant_id) return;
 
     const operationsChannel = supabase
@@ -128,8 +135,8 @@ export default function WorkQueue() {
           filter: `tenant_id=eq.${profile.tenant_id}`,
         },
         () => {
-          loadData();
-        }
+          void loadData();
+        },
       )
       .subscribe();
 
@@ -144,8 +151,8 @@ export default function WorkQueue() {
           filter: `tenant_id=eq.${profile.tenant_id}`,
         },
         () => {
-          loadData();
-        }
+          void loadData();
+        },
       )
       .subscribe();
 
@@ -153,27 +160,29 @@ export default function WorkQueue() {
       supabase.removeChannel(operationsChannel);
       supabase.removeChannel(timeEntriesChannel);
     };
-  };
+  }, [loadData, profile?.tenant_id]);
 
-  const toggleCellVisibility = (cellId: string) => {
-    setHiddenCells((prev) => {
-      const newSet = new Set(prev);
-      if (newSet.has(cellId)) {
-        newSet.delete(cellId);
-      } else {
-        newSet.add(cellId);
-      }
-      return newSet;
-    });
-  };
+  useEffect(() => {
+    if (!profile?.tenant_id) return;
+    void loadData();
+    return setupRealtimeSubscriptions();
+  }, [loadData, profile?.tenant_id, setupRealtimeSubscriptions]);
 
   const materials = Array.from(
-    new Set(operations.map((operation) => operation.part.material))
+    new Set(operations.map((operation) => operation.part.material).filter(Boolean)),
   ).sort();
+
+  const assignedPartIds = useMemo(
+    () => new Set(myAssignments.map((assignment) => assignment.part_id)),
+    [myAssignments],
+  );
 
   const filteredOperations = operations.filter((operation) => {
     const matchesMaterial =
       selectedMaterial === "all" || operation.part.material === selectedMaterial;
+
+    const matchesCell =
+      selectedCell === "all" || operation.cell_id === selectedCell;
 
     const matchesSearch =
       searchQuery === "" ||
@@ -183,17 +192,18 @@ export default function WorkQueue() {
       (operation.part.job.customer &&
         operation.part.job.customer.toLowerCase().includes(searchQuery.toLowerCase()));
 
-    const matchesStatus =
-      statusFilter === "all" || operation.status === statusFilter;
-
+    const matchesStatus = statusFilter === "all" || operation.status === statusFilter;
     const matchesCompleted = showCompleted || operation.status !== "completed";
-
     const matchesAssigned =
-      !assignedToMe || operation.assigned_operator_id === profile?.id;
+      !assignedToMe ||
+      operation.assigned_operator_id === profile?.id ||
+      assignedPartIds.has(operation.part.id);
 
     let matchesDueDate = true;
     if (dueDateFilter !== "all") {
-      const dueDate = new Date(operation.part.job.due_date_override || operation.part.job.due_date);
+      const dueDate = new Date(
+        operation.part.job.due_date_override || operation.part.job.due_date,
+      );
       const today = startOfToday();
       const endToday = endOfToday();
       const weekFromNow = addDays(today, 7);
@@ -209,6 +219,7 @@ export default function WorkQueue() {
 
     return (
       matchesMaterial &&
+      matchesCell &&
       matchesSearch &&
       matchesStatus &&
       matchesCompleted &&
@@ -220,11 +231,13 @@ export default function WorkQueue() {
   const sortedOperations = [...filteredOperations].sort((a, b) => {
     if (sortBy === "sequence") {
       return a.sequence - b.sequence;
-    } else if (sortBy === "due_date") {
+    }
+    if (sortBy === "due_date") {
       const dateA = new Date(a.part.job.due_date_override || a.part.job.due_date);
       const dateB = new Date(b.part.job.due_date_override || b.part.job.due_date);
       return dateA.getTime() - dateB.getTime();
-    } else if (sortBy === "estimated_time") {
+    }
+    if (sortBy === "estimated_time") {
       return (a.estimated_time || 0) - (b.estimated_time || 0);
     }
     return 0;
@@ -232,241 +245,284 @@ export default function WorkQueue() {
 
   const assignmentsByPartId = useMemo(() => {
     const map = new Map<string, PartAssignment>();
-    myAssignments.forEach(a => map.set(a.part_id, a));
+    myAssignments.forEach((assignment) => map.set(assignment.part_id, assignment));
     return map;
   }, [myAssignments]);
 
-  const operationsByCell = cells
-    .filter((cell) => !hiddenCells.has(cell.id))
-    .map((cell) => ({
-      cell,
-      operations: sortedOperations.filter((operation) => operation.cell_id === cell.id),
-    }));
+  const operationsByCell = (selectedCell === "all"
+    ? cells
+    : cells.filter((cell) => cell.id === selectedCell)
+  ).map((cell) => ({
+    cell,
+    operations: sortedOperations.filter((operation) => operation.cell_id === cell.id),
+  }));
 
   const totalOperations = filteredOperations.length;
-  const inProgressOperations = filteredOperations.filter((o) => o.status === "in_progress").length;
-  const completedOperations = filteredOperations.filter((o) => o.status === "completed").length;
+  const inProgressOperations = filteredOperations.filter(
+    (operation) => operation.status === "in_progress",
+  ).length;
+  const completedOperations = filteredOperations.filter(
+    (operation) => operation.status === "completed",
+  ).length;
+  const assignedOperations = filteredOperations.filter((operation) =>
+    assignedPartIds.has(operation.part.id),
+  ).length;
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-96">
-        <Loader2 className="h-8 w-8 animate-spin text-brand-primary" />
-      </div>
+      <OperatorPanel className="flex min-h-[420px] items-center justify-center">
+        <div className="flex flex-col items-center gap-3">
+          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+          <p className="text-sm text-muted-foreground">
+            {t("workQueue.loading", "Loading work queue")}
+          </p>
+        </div>
+      </OperatorPanel>
     );
   }
 
   return (
-    <>
-      <div className="space-y-4">
-        {/* Stats Card */}
-        <Card className="glass-card p-6">
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-            <div>
-              <p className="text-sm text-muted-foreground">Total Operations</p>
-              <p className="text-3xl font-bold bg-gradient-to-br from-foreground to-foreground/70 bg-clip-text text-transparent">
-                {totalOperations}
-              </p>
-            </div>
-            <div>
-              <p className="text-sm text-muted-foreground">In Progress</p>
-              <p className="text-3xl font-bold bg-gradient-to-br from-foreground to-foreground/70 bg-clip-text text-transparent">
-                {inProgressOperations}
-              </p>
-            </div>
-            <div>
-              <p className="text-sm text-muted-foreground">Completed</p>
-              <p className="text-3xl font-bold text-status-completed">
-                {completedOperations}
-              </p>
-            </div>
-            <div>
-              <p className="text-sm text-muted-foreground">Not Started</p>
-              <p className="text-3xl font-bold text-muted-foreground">
-                {totalOperations - inProgressOperations - completedOperations}
-              </p>
-            </div>
-          </div>
-        </Card>
+    <div className="space-y-4">
+      <OperatorPageHeader
+        eyebrow={t("navigation.workQueue")}
+        title={t("workQueue.title", "Work queue")}
+        description={t(
+          "workQueue.description",
+          "Use the queue to scan work by cell, narrow it to what matters now, and open a packet only when the operator needs deeper detail.",
+        )}
+        meta={
+          <>
+            <OperatorStatusChip
+              tone="info"
+              label={`${cells.length} ${t("workQueue.cells", "cells")}`}
+            />
+            {assignedOperations > 0 ? (
+              <OperatorStatusChip
+                icon={UserCheck}
+                tone="active"
+                label={`${assignedOperations} ${t("operations.assignedToYou", "assigned to you")}`}
+              />
+            ) : null}
+          </>
+        }
+        actions={
+          <Button
+            variant={showFilters ? "default" : "outline"}
+            onClick={() => setShowFilters((prev) => !prev)}
+            className="min-h-11 rounded-xl"
+          >
+            <Filter className="mr-2 h-4 w-4" />
+            {showFilters
+              ? t("common.hideFilters", "Hide filters")
+              : t("common.showFilters", "Show filters")}
+          </Button>
+        }
+      />
 
-        {/* Search and Material Filter */}
-        <div className="glass-card rounded-lg p-6 space-y-4">
-          <div className="flex gap-2">
-            <div className="relative flex-1">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-              <Input
-                placeholder="Search by job, part, operation, or customer..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="pl-10"
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <OperatorStatCard
+          label={t("workQueue.totalOperations", "Total operations")}
+          value={totalOperations}
+          caption={t("workQueue.visibleInCurrentView", "Visible in current view")}
+          icon={ListFilter}
+        />
+        <OperatorStatCard
+          label={t("workQueue.inProgress", "In progress")}
+          value={inProgressOperations}
+          caption={t("workQueue.clockedOrRunning", "Clocked or currently running")}
+          icon={Clock3}
+          tone="warning"
+        />
+        <OperatorStatCard
+          label={t("workQueue.completed", "Completed")}
+          value={completedOperations}
+          caption={t("workQueue.finishedInCurrentFilter", "Finished in current filter")}
+          icon={CheckCircle2}
+          tone="success"
+        />
+        <OperatorStatCard
+          label={t("workQueue.assigned", "Assigned")}
+          value={assignedOperations}
+          caption={t("workQueue.partsAssignedToOperator", "Parts assigned to the active operator")}
+          icon={UserCheck}
+          tone="active"
+        />
+      </div>
+
+      <OperatorPanel className="space-y-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+          <div className="relative flex-1">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              placeholder={t(
+                "workQueue.searchPlaceholder",
+                "Search by job, part, operation, or customer",
+              )}
+              value={searchQuery}
+              onChange={(event) => setSearchQuery(event.target.value)}
+              className="min-h-11 rounded-xl border-border/80 pl-10"
+            />
+          </div>
+          <Select value={sortBy} onValueChange={setSortBy}>
+            <SelectTrigger className="min-h-11 w-full rounded-xl border-border/80 bg-card lg:w-[220px]">
+              <SelectValue placeholder={t("workQueue.sortBy", "Sort by")} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="sequence">{t("workQueue.sequence", "Sequence")}</SelectItem>
+              <SelectItem value="due_date">{t("workQueue.dueDate", "Due date")}</SelectItem>
+              <SelectItem value="estimated_time">
+                {t("workQueue.estimatedTime", "Estimated time")}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <Tabs value={selectedMaterial} onValueChange={setSelectedMaterial}>
+          <TabsList className="flex h-auto w-full flex-wrap justify-start gap-2 rounded-2xl bg-muted/30 p-1">
+            <TabsTrigger value="all" className="min-h-11 rounded-xl">
+              {t("workQueue.allMaterials", "All materials")}
+            </TabsTrigger>
+            {materials.map((material) => (
+              <TabsTrigger key={material} value={material} className="min-h-11 rounded-xl">
+                {material}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+
+        <Tabs value={selectedCell} onValueChange={setSelectedCell}>
+          <TabsList className="flex h-auto w-full flex-wrap justify-start gap-2 rounded-2xl bg-muted/30 p-1">
+            <TabsTrigger value="all" className="min-h-11 rounded-xl">
+              {t("workQueue.allCells", "All cells")}
+            </TabsTrigger>
+            {cells.map((cell) => (
+              <TabsTrigger key={cell.id} value={cell.id} className="min-h-11 rounded-xl">
+                <span
+                  className="mr-2 h-2.5 w-2.5 rounded-full"
+                  style={{ backgroundColor: cell.color || "currentColor" }}
+                />
+                {cell.name}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+
+        {showFilters ? (
+          <div className="grid gap-4 rounded-2xl border border-border bg-muted/20 p-4 md:grid-cols-2 xl:grid-cols-4">
+            <div className="space-y-2">
+              <Label htmlFor="status-filter">{t("workQueue.status", "Status")}</Label>
+              <Select value={statusFilter} onValueChange={setStatusFilter}>
+                <SelectTrigger id="status-filter" className="min-h-11 rounded-xl">
+                  <SelectValue placeholder={t("workQueue.allStatuses", "All statuses")} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">{t("workQueue.allStatuses", "All statuses")}</SelectItem>
+                  <SelectItem value="not_started">{t("workQueue.notStarted", "Not started")}</SelectItem>
+                  <SelectItem value="in_progress">{t("workQueue.inProgress", "In progress")}</SelectItem>
+                  <SelectItem value="completed">{t("workQueue.completed", "Completed")}</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="due-date-filter">{t("workQueue.dueDate", "Due date")}</Label>
+              <Select value={dueDateFilter} onValueChange={setDueDateFilter}>
+                <SelectTrigger id="due-date-filter" className="min-h-11 rounded-xl">
+                  <SelectValue placeholder={t("workQueue.allDates", "All dates")} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">{t("workQueue.allDates", "All dates")}</SelectItem>
+                  <SelectItem value="overdue">{t("workQueue.overdue", "Overdue")}</SelectItem>
+                  <SelectItem value="today">{t("workQueue.dueToday", "Due today")}</SelectItem>
+                  <SelectItem value="this_week">{t("workQueue.thisWeek", "This week")}</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="flex items-center justify-between rounded-xl border border-border bg-background/70 px-4 py-3">
+              <Label htmlFor="assigned-to-me" className="text-sm font-medium">
+                {t("workQueue.assignedToMe", "Assigned to me")}
+              </Label>
+              <Switch
+                id="assigned-to-me"
+                checked={assignedToMe}
+                onCheckedChange={setAssignedToMe}
               />
             </div>
-            <Button
-              variant={showFilters ? "default" : "outline"}
-              size="icon"
-              onClick={() => setShowFilters(!showFilters)}
-            >
-              <Filter className="h-4 w-4" />
-            </Button>
-            <Button
-              variant="outline"
-              size="icon"
-              onClick={() => setViewMode(viewMode === "detailed" ? "compact" : "detailed")}
-            >
-              {viewMode === "detailed" ? (
-                <LayoutGrid className="h-4 w-4" />
-              ) : (
-                <List className="h-4 w-4" />
-              )}
-            </Button>
-          </div>
 
-          {/* Material Tabs */}
-          <Tabs value={selectedMaterial} onValueChange={setSelectedMaterial}>
-            <TabsList className="w-full justify-start overflow-x-auto">
-              <TabsTrigger value="all">All Materials</TabsTrigger>
-              {materials.map((material) => (
-                <TabsTrigger key={material} value={material}>
-                  {material}
-                </TabsTrigger>
-              ))}
-            </TabsList>
-          </Tabs>
-
-          {/* Advanced Filters */}
-          {showFilters && (
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 pt-4 border-t">
-              <div>
-                <Label htmlFor="status-filter">Status</Label>
-                <Select value={statusFilter} onValueChange={setStatusFilter}>
-                  <SelectTrigger id="status-filter">
-                    <SelectValue placeholder="All Statuses" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All Statuses</SelectItem>
-                    <SelectItem value="not_started">Not Started</SelectItem>
-                    <SelectItem value="in_progress">In Progress</SelectItem>
-                    <SelectItem value="completed">Completed</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div>
-                <Label htmlFor="due-date-filter">Due Date</Label>
-                <Select value={dueDateFilter} onValueChange={setDueDateFilter}>
-                  <SelectTrigger id="due-date-filter">
-                    <SelectValue placeholder="All Dates" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All Dates</SelectItem>
-                    <SelectItem value="overdue">Overdue</SelectItem>
-                    <SelectItem value="today">Due Today</SelectItem>
-                    <SelectItem value="this_week">Due This Week</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div>
-                <Label htmlFor="sort-by">Sort By</Label>
-                <Select value={sortBy} onValueChange={setSortBy}>
-                  <SelectTrigger id="sort-by">
-                    <SelectValue placeholder="Sort by" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="sequence">Sequence</SelectItem>
-                    <SelectItem value="due_date">Due Date</SelectItem>
-                    <SelectItem value="estimated_time">Estimated Time</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div className="flex items-center space-x-2">
-                <Switch
-                  id="assigned-to-me"
-                  checked={assignedToMe}
-                  onCheckedChange={setAssignedToMe}
-                />
-                <Label htmlFor="assigned-to-me">Assigned to Me</Label>
-              </div>
-
-              <div className="flex items-center space-x-2">
-                <Switch
-                  id="show-completed"
-                  checked={showCompleted}
-                  onCheckedChange={setShowCompleted}
-                />
-                <Label htmlFor="show-completed">Show Completed</Label>
-              </div>
+            <div className="flex items-center justify-between rounded-xl border border-border bg-background/70 px-4 py-3">
+              <Label htmlFor="show-completed" className="text-sm font-medium">
+                {t("workQueue.showCompleted", "Show completed")}
+              </Label>
+              <Switch
+                id="show-completed"
+                checked={showCompleted}
+                onCheckedChange={setShowCompleted}
+              />
             </div>
+          </div>
+        ) : null}
+      </OperatorPanel>
+
+      {sortedOperations.length === 0 ? (
+        <OperatorEmptyState
+          icon={PackageSearch}
+          title={t("workQueue.noOperations", "No operations match this view")}
+          description={t(
+            "workQueue.noOperationsDescription",
+            "Adjust the cell, material, or date filters to widen the queue.",
           )}
-
-          {/* Cell Visibility Toggles */}
-          <div className="flex flex-wrap gap-2">
-            <span className="text-sm font-medium text-muted-foreground">Cells:</span>
-            {cells.map((cell) => (
-              <Button
-                key={cell.id}
-                variant={hiddenCells.has(cell.id) ? "outline" : "default"}
-                size="sm"
-                onClick={() => toggleCellVisibility(cell.id)}
-                className={`
-                  ${hiddenCells.has(cell.id) ? "bg-transparent" : `bg-${getStageClass(cell.name)}`}
-                  border-${getStageClass(cell.name)}
-                `}
-              >
-                {hiddenCells.has(cell.id) ? (
-                  <EyeOff className="h-3 w-3 mr-1" />
-                ) : (
-                  <Eye className="h-3 w-3 mr-1" />
-                )}
-                {cell.name}
-              </Button>
-            ))}
-          </div>
-        </div>
-
-        {/* Kanban Board */}
-        <div className="overflow-x-auto">
-          <div className="flex gap-4 pb-4" style={{ minWidth: "max-content" }}>
-            {operationsByCell.map(({ cell, operations }) => (
-              <div
-                key={cell.id}
-                className={`flex-shrink-0 ${viewMode === "detailed" ? "w-80" : "w-64"
-                  } bg-card rounded-lg border`}
-              >
-                <div
-                  className={`p-4 border-b border-t-4 border-t-${getStageClass(cell.name)}`}
-                >
-                  <h3 className="font-semibold text-lg">{cell.name}</h3>
-                  <p className="text-sm text-muted-foreground">
-                    {operations.length} operation{operations.length !== 1 ? "s" : ""}
-                  </p>
+        />
+      ) : (
+        <div className="space-y-4">
+          {operationsByCell.map(({ cell, operations: cellOperations }) => (
+            <OperatorPanel key={cell.id} className="space-y-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="flex items-center gap-3">
+                  <span
+                    className="h-3 w-3 rounded-full"
+                    style={{ backgroundColor: cell.color || "currentColor" }}
+                  />
+                  <div>
+                    <h2 className="text-lg font-semibold text-foreground">{cell.name}</h2>
+                    <p className="text-sm text-muted-foreground">
+                      {cellOperations.length}{" "}
+                      {cellOperations.length === 1
+                        ? t("workQueue.operation", "operation")
+                        : t("workQueue.operations", "operations")}
+                    </p>
+                  </div>
                 </div>
-                <div className="p-4 space-y-3 max-h-[calc(100vh-16rem)] overflow-y-auto">
-                  {operations.length === 0 ? (
-                    <div className="text-center text-muted-foreground py-8">
-                      No operations
-                    </div>
-                  ) : (
-                    operations.map((operation) => {
-                      const assignment = assignmentsByPartId.get(operation.part.id);
-                      return (
-                        <OperationCard
-                          key={operation.id}
-                          operation={operation}
-                          onUpdate={loadData}
-                          compact={viewMode === "compact"}
-                          assignedToMe={!!assignment}
-                          assignedByName={assignment?.assigned_by_name}
-                        />
-                      );
-                    })
-                  )}
-                </div>
+                <OperatorStatusChip
+                  tone="neutral"
+                  label={`${cellOperations.filter((operation) => operation.status === "in_progress").length} ${t("workQueue.inProgress", "in progress")}`}
+                />
               </div>
-            ))}
-          </div>
+
+              {cellOperations.length === 0 ? (
+                <div className="rounded-2xl border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+                  {t("workQueue.noOperationsInCell", "No operations in this cell for the current filters.")}
+                </div>
+              ) : (
+                <div className="grid gap-3 lg:grid-cols-2 2xl:grid-cols-3">
+                  {cellOperations.map((operation) => {
+                    const assignment = assignmentsByPartId.get(operation.part.id);
+                    return (
+                      <OperationCard
+                        key={operation.id}
+                        operation={operation}
+                        onUpdate={() => void loadData()}
+                        assignedToMe={Boolean(assignment)}
+                        assignedByName={assignment?.assigned_by_name}
+                      />
+                    );
+                  })}
+                </div>
+              )}
+            </OperatorPanel>
+          ))}
         </div>
-      </div>
-    </>
+      )}
+    </div>
   );
 }

--- a/src/pages/operator/WorkQueue.tsx
+++ b/src/pages/operator/WorkQueue.tsx
@@ -201,19 +201,24 @@ export default function WorkQueue() {
 
     let matchesDueDate = true;
     if (dueDateFilter !== "all") {
-      const dueDate = new Date(
-        operation.part.job.due_date_override || operation.part.job.due_date,
-      );
-      const today = startOfToday();
-      const endToday = endOfToday();
-      const weekFromNow = addDays(today, 7);
+      const dueDateValue =
+        operation.part.job.due_date_override || operation.part.job.due_date;
+      const dueDate = dueDateValue ? new Date(dueDateValue) : null;
+      const hasValidDueDate =
+        dueDate !== null && Number.isFinite(dueDate.getTime());
 
-      if (dueDateFilter === "overdue") {
-        matchesDueDate = isBefore(dueDate, today);
-      } else if (dueDateFilter === "today") {
-        matchesDueDate = isAfter(dueDate, today) && isBefore(dueDate, endToday);
-      } else if (dueDateFilter === "this_week") {
-        matchesDueDate = isAfter(dueDate, today) && isBefore(dueDate, weekFromNow);
+      if (hasValidDueDate) {
+        const today = startOfToday();
+        const endToday = endOfToday();
+        const weekFromNow = addDays(today, 7);
+
+        if (dueDateFilter === "overdue") {
+          matchesDueDate = isBefore(dueDate, today);
+        } else if (dueDateFilter === "today") {
+          matchesDueDate = isAfter(dueDate, today) && isBefore(dueDate, endToday);
+        } else if (dueDateFilter === "this_week") {
+          matchesDueDate = isAfter(dueDate, today) && isBefore(dueDate, weekFromNow);
+        }
       }
     }
 
@@ -233,9 +238,21 @@ export default function WorkQueue() {
       return a.sequence - b.sequence;
     }
     if (sortBy === "due_date") {
-      const dateA = new Date(a.part.job.due_date_override || a.part.job.due_date);
-      const dateB = new Date(b.part.job.due_date_override || b.part.job.due_date);
-      return dateA.getTime() - dateB.getTime();
+      const getDueTime = (operation: OperationWithDetails) => {
+        const dueDateValue =
+          operation.part.job.due_date_override || operation.part.job.due_date;
+
+        if (!dueDateValue) {
+          return Number.MAX_SAFE_INTEGER;
+        }
+
+        const dueDate = new Date(dueDateValue);
+        return Number.isFinite(dueDate.getTime())
+          ? dueDate.getTime()
+          : Number.MAX_SAFE_INTEGER;
+      };
+
+      return getDueTime(a) - getDueTime(b);
     }
     if (sortBy === "estimated_time") {
       return (a.estimated_time || 0) - (b.estimated_time || 0);

--- a/website/src/content/docs/engineering/design-system-reference.md
+++ b/website/src/content/docs/engineering/design-system-reference.md
@@ -5,7 +5,7 @@ description: "Detailed design system reference for contributors extending the Er
 
 # Eryxon Flow Design System
 
-**Modern design system for manufacturing execution with dark/light/auto theme support**
+**Practical design system for operator-facing MES and manufacturing coordination**
 
 ---
 
@@ -27,15 +27,15 @@ description: "Detailed design system reference for contributors extending the Er
 
 ## Overview
 
-The Eryxon Flow design system is a **modern, multi-theme** UI framework built for manufacturing professionals. It supports **dark**, **light**, and **auto** (system preference) modes.
+The Eryxon Flow design system is a **multi-theme application framework** for small and mid-sized manufacturing teams. It is designed for people working with production data: operators on shared shop-floor tablets, leads checking live progress, and admins managing jobs, parts, routing, issues, and capacity.
 
 ### Core Features
 
-- **Multi-Theme Support**: Dark, light, and auto modes with seamless switching
-- **Glass Morphism Surfaces**: Blur + saturate cards with translucent borders (adapts to theme)
-- **Accent Palette**: Icon tints and pills in blue, green, yellow, and red
-- **System Typography**: Inter blended with the OS stack for crisp UI copy
-- **Touch-Optimized Layouts**: 44px+ targets for shop-floor tablets
+- **Multi-Theme Support**: Dark, light, and auto modes with stable contrast and clear status semantics
+- **Operator-First Layouts**: Shared patterns for packet selection, routing review, quantity reporting, issue reporting, and activity history
+- **Consistent Status Language**: Reusable badges, summary cards, and headers for jobs, parts, operations, and issues
+- **Touch-Optimized Controls**: 44-48px+ targets for shared terminals and tablets
+- **Layered Surface Strategy**: Operator workspaces stay restrained; admin and login surfaces can use Antigravity glass treatment where it improves orientation and perceived polish
 - **shadcn/ui Components**: Every primitive comes from shadcn/ui with theme-aware styling
 
 ### Technology Stack
@@ -89,46 +89,53 @@ All CSS tokens automatically adapt based on the root class. Use design tokens (n
 
 ## Design Philosophy
 
-### "The Simple MES You Love to Use"
+### "Clear Work, Clear Next Action"
 
-Our tagline drives every design decision and anchors the Antigravity styling pass:
+The product is not an HMI. It is a human-first MES workspace for people making decisions and recording production reality. That means the UI must prioritize:
 
-1. **Simple**: A single glass card centered on an ambient stage keeps the focus on the task.
-2. **Beautiful**: Animated gradients, neon pills, and microcopy echo the Antigravity Browser Control preview.
-3. **Functional**: Touch-optimized layouts (44px+ targets) remain practical for shop-floor tablets.
-4. **Professional**: Enterprise-grade typography, accessibility, and predictable motion keep trust high.
+1. **Immediate orientation**: Every page should answer where the user is, what they are looking at, and what status it is in.
+2. **Low-friction execution**: Core actions such as start, pause, complete, report quantity, and report issue must be obvious and reachable on tablets.
+3. **Consistent meaning**: Active, pending, blocked, completed, approved, and rejected should look the same everywhere in the app.
+4. **Production-context hierarchy**: Job number, part number, operation, cell, due date, and packet/document availability are higher priority than decorative treatment.
+5. **Durable readability**: Screens should hold up in bright shops, low-light offices, and long work sessions without depending on motion or gradients for meaning.
 
 ### Visual Aesthetic
 
-- **Ambient Field + Depth** — Backgrounds use radial gradients; floating orbs add parallax in dark mode.
-- **Glass Cards** — Hero surfaces use `backdrop-filter: blur(16px) saturate(180%)` with translucent borders.
-- **Layered Messaging** — Icon container, uppercase welcome text, gradient hero, preview pill, and divider.
-- **Narrative Sections** — Informational capsule, workflow callout, and use-case grid structure content.
-- **Status Icon Tints** — Blue, green, yellow, and red strokes for semantic meaning.
+- **Neutral Base, Semantic Accents** — Most surfaces stay quiet; color is reserved for states and priorities.
+- **Rounded Industrial SaaS Surfaces** — Cards and panels are modern, but not ornamental.
+- **Structured Header Rhythm** — Eyebrow, page title, supporting description, status chips, then actions.
+- **Packet-Centered Detail Views** — The current job packet or record stays visually dominant, with secondary metadata grouped below it.
+- **Action Rails and Summary Grids** — Pages expose the current slice of work with summary cards and obvious next-step actions.
+
+### Surface Split
+
+- **Operator pages**: Prefer neutral panels, strong borders, compact metadata, and obvious action bars.
+- **Admin pages**: Antigravity-style glass cards, gradient headings, and richer depth cues are acceptable because the work is more exploratory and less time-critical.
+- **Auth/login flows**: Keep the more atmospheric presentation via the shared `AuthShell` pattern; it improves branding and first-run orientation without competing with production data.
 
 ### Theme-Aware Design
 
-Both themes are optimized for manufacturing environments:
+Both themes are optimized for manufacturing use:
 
-**Dark Mode** (default for low-light facilities):
-- Deep backgrounds reduce glare on shop floor
-- Radial gradients add depth without distraction
-- Glass surfaces with blur/saturation effects
+**Dark Mode**:
+- Useful on the floor and in lower-light work areas
+- Keeps the background quiet and reduces visual fatigue
+- Uses restrained contrast so status colors can carry attention
 
-**Light Mode** (for well-lit offices):
-- Clean white backgrounds with subtle gradients
-- Improved WCAG AA contrast ratios
-- Glass surfaces adapt with appropriate opacity
+**Light Mode**:
+- Better for offices, engineering desks, and customer-facing review
+- Uses stronger borders and darker neutrals to preserve hierarchy
+- Avoids washed-out cards and low-contrast metadata
 
 ### Key Principles
 
 - **shadcn-first**: If a primitive exists in shadcn/ui, import it via the generator and style it; no bespoke HTML copies.
-- **Token-First Values**: Gradients, pills, and icons reference shared CSS variables (no hex literals).
-- **Layered Glass Depth**: Always stack content over the animated background with a glass card or capsule.
-- **Smooth Animations**: Background orbs use 20s float cycles; cards fade in with `fadeInUp`.
-- **Compact Roundings**: Use 4px, 6px, 8px, and 12px radii for a tighter, more data-dense feel.
-- **Compact Spacing**: Reduced padding and gaps (0.5rem, 0.75rem, 1rem) to maximize data visibility.
-- **Touch-Optimized Rhythm**: Maintain 44px minimum touch targets while reducing visual padding.
+- **Token-First Values**: Colors, borders, and semantic states use shared variables and reusable wrappers.
+- **Meaning Before Decoration**: Never rely on gradients, blur, or animation to communicate state.
+- **Shared Patterns First**: Prefer `AdminPageHeader`, `PageStatsRow`, `OperatorStation`, `AuthShell`, and `StatusBadge` over page-local inventions.
+- **Compact, Readable Density**: Use spacing intentionally so queue views and data tables stay scan-friendly.
+- **Touch-Optimized Rhythm**: Maintain 44px minimum touch targets and prefer 48px for primary actions on operator screens.
+- **Redundant State Encoding**: Use label + icon + color where status is important; color alone is not enough.
 
 ---
 
@@ -136,45 +143,39 @@ Both themes are optimized for manufacturing environments:
 
 ### Design Goals
 
-Core design goals with improved light mode contrast and compact admin layouts:
+1. **Tablet-first for operators**: Shared terminals and tablets need obvious actions, large targets, and stable layouts
+2. **Desktop-first for planners/admins**: Dense data views should still feel ordered and readable
+3. **Single-language status model**: The same concepts should survive across mobile, tablet, and desktop layouts
+4. **Data density with hierarchy**: More rows on screen is useful only if priority remains clear
+5. **Reduced surprise**: Panels may collapse on smaller screens, but primary actions and current context should stay easy to find
 
-1. **Tablet-First for Operators**: Operators primarily use tablets on the shop floor
-2. **PC-First for Admin**: Admin users work on desktop with multi-column layouts
-3. **Mobile Support**: Essential features accessible on mobile devices
-4. **Data Density**: Maximize visible data without sacrificing readability
-5. **Light Mode Contrast**: Improved WCAG AA compliance with darker grays and better border visibility
+### Shared Page Layout Standards
 
-### Admin Page Layout Standards
-
-Admin pages follow a consistent compact layout pattern:
+Admin and operator pages should follow the same high-level rhythm, with different density and action emphasis depending on role:
 
 ```tsx
 <div className="p-4 space-y-4">
-  {/* Header: 2xl title, sm description */}
-  <div>
-    <div className="flex justify-between items-center mb-1">
-      <h1 className="text-2xl font-bold bg-gradient-to-r ...">Title</h1>
-      <Button className="cta-button">Action</Button>
-    </div>
-    <p className="text-muted-foreground text-sm">Description</p>
-  </div>
+  <AdminPageHeader
+    title="Title"
+    description="What the page is for and what the user can do here."
+    action={{ label: "Primary action", onClick: () => {} }}
+  />
 
-  <hr className="title-divider" />
+  <PageStatsRow stats={stats} />
 
-  {/* Content in glass-card with p-4 */}
-  <div className="glass-card p-4">
+  <div className="rounded-2xl border border-border/80 bg-card/95 p-4 shadow-sm">
     <DataTable ... />
   </div>
 </div>
 ```
 
 Key spacing values:
-- **Page padding**: `p-4` (16px)
-- **Section gap**: `space-y-4` (16px)
-- **Card padding**: `p-4` (16px)
-- **Header margin**: `mb-1` (4px)
-- **Title size**: `text-2xl` (24px)
-- **Description size**: `text-sm` (14px)
+- **Page padding**: `p-4` to `p-6`
+- **Section gap**: `space-y-4`
+- **Panel padding**: `p-4` or `p-5`
+- **Title size**: `text-2xl`
+- **Description size**: `text-sm`
+- **Primary action height**: `min-h-11`
 
 ### Breakpoints
 

--- a/website/src/content/docs/engineering/design-system-reference.md
+++ b/website/src/content/docs/engineering/design-system-reference.md
@@ -113,6 +113,28 @@ The product is not an HMI. It is a human-first MES workspace for people making d
 - **Admin pages**: Antigravity-style glass cards, gradient headings, and richer depth cues are acceptable because the work is more exploratory and less time-critical.
 - **Auth/login flows**: Keep the more atmospheric presentation via the shared `AuthShell` pattern; it improves branding and first-run orientation without competing with production data.
 
+#### Shared Primitives vs Presentation
+
+- Shared primitives such as `AdminPageHeader`, `PageStatsRow`, `StatusBadge`, `OperatorStation`, and `AuthShell` are reusable across the app.
+- Antigravity presentation layers such as `.glass-card`, `.onboarding-card`, `.cta-button`, and the animated background are **not** shared defaults; use them only on admin or auth surfaces.
+- Operator pages should prefer neutral containers like `rounded-2xl border border-border/80 bg-card/95 shadow-sm` with compact metadata and fixed action bars.
+
+Operator example:
+
+```tsx
+<OperatorPanel className="space-y-4">
+  <OperatorPageHeader
+    eyebrow="Work Queue"
+    title="Laser cell packets"
+    description="Scan active work, due dates, and current operator context."
+  />
+
+  <div className="rounded-2xl border border-border/80 bg-card/95 p-4 shadow-sm">
+    <DataTable ... />
+  </div>
+</OperatorPanel>
+```
+
 ### Theme-Aware Design
 
 Both themes are optimized for manufacturing use:
@@ -425,9 +447,9 @@ Every interactive element ships from `shadcn/ui`. Never hand-roll components whe
    - Update `components.json` with our namespace (`@/components/ui`).
    - Map shadcn tokens to our CSS variables in `src/styles/design-system.css`.
 
-4. **Wrap with Glass**
-   - For elevated surfaces (card, dialog, sheet) use `.glass-card` or `.onboarding-card`.
-   - Buttons, badges, and inputs adopt Antigravity gradients through Tailwind classes (e.g., `className="cta-button"`).
+4. **Choose the Surface Language**
+   - Operator/shared production screens: start with neutral surfaces such as `bg-card`, `border border-border/80`, and `shadow-sm`.
+   - Admin/auth screens: use `.glass-card`, `.onboarding-card`, and Antigravity button treatments only when that visual depth helps orientation.
 
 5. **Keep Upgrades Centralized**
    - Only edit the components inside `components/ui/`.
@@ -482,9 +504,9 @@ module.exports = {
 - Use these Tailwind tokens inside shadcn components (`buttonVariants`, `badgeVariants`, etc.).
 - Keep variant logic inside the generated component files so we can reuse them across the app.
 
-### Antigravity Layout Primer
+### Antigravity Layout Primer (Admin/Auth Only)
 
-Use the same skeleton from the Antigravity onboarding preview whenever you build full-screen flows.
+Use the same skeleton from the Antigravity onboarding preview whenever you build full-screen admin or auth flows. Do not apply this hero treatment to operator execution screens.
 
 ```tsx
 <>
@@ -1157,7 +1179,7 @@ import { Input } from '@/components/ui/input';
 
 ### Dialogs & Sheets (shadcn/ui)
 
-Use shadcn's `Dialog` and `Sheet` primitives, then add glassmorphism to `DialogContent`/`SheetContent`.
+Use shadcn's `Dialog` and `Sheet` primitives first. Add glassmorphism to `DialogContent`/`SheetContent` only on admin or auth surfaces; operator dialogs should stay neutral and high-contrast.
 
 ```tsx
 import {
@@ -1188,7 +1210,8 @@ export function GlassDialog() {
 }
 ```
 
-- Always pass `className="glass-card"` (or `.onboarding-card` for larger sheets) into the generated shadcn component.
+- For admin/auth dialogs, pass `className="glass-card"` (or `.onboarding-card` for larger sheets) into the generated shadcn component.
+- For operator dialogs, prefer `className="border-border/80 bg-popover"` with minimal decorative treatment.
 - Use shadcn `Form` components for validation, layering `informational-text` capsules or workflow callouts where appropriate.
 
 ### Title Divider
@@ -1371,7 +1394,11 @@ import { PageStatsRow } from "@/components/admin/PageStatsRow";
    ```
    Use generated components everywhere; extend them with Antigravity classes rather than rewriting HTML.
 
-2. **Compose the Antigravity Stack**
+2. **Match the Surface Role**
+   - Operator surfaces: neutral panels, compact metadata, explicit status chips, and obvious action rails.
+   - Admin/auth surfaces: Antigravity layers are acceptable where the work benefits from orientation and brand expression.
+
+3. **Compose the Antigravity Stack (Admin/Auth Only)**
    ```tsx
    <>
      <AnimatedBackground variant="antigravity" />
@@ -1381,13 +1408,13 @@ import { PageStatsRow } from "@/components/admin/PageStatsRow";
    </>
    ```
 
-3. **Use Tokens Everywhere**
+4. **Use Tokens Everywhere**
    ```jsx
    <div className="bg-[hsl(var(--surface-card))] text-foreground rounded-2xl">
    ```
    No hex literals—reference `--surface-*`, `--brand-*`, and status tokens.
 
-4. **Keep the Hero Stack Intact**
+5. **Keep the Hero Stack Intact (Admin/Auth Only)**
    ```jsx
    <div className="icon-container" />
    <p className="welcome-text">Welcome to</p>
@@ -1397,14 +1424,13 @@ import { PageStatsRow } from "@/components/admin/PageStatsRow";
    </div>
    ```
 
-5. **Tell the Narrative**
+6. **Tell the Narrative (Admin/Auth Only)**
    - Informational capsule → workflow callout → use-case grid mirrors the Antigravity story.
    - Add tinted Lucide icons so each card reads instantly.
 
-6. **Leverage Micro-Interactions**
-   - Copy pill flips to `.copied`.
-   - CTA arrows nudge on hover.
-   - Cards fade in with `fadeInUp`.
+7. **Leverage Micro-Interactions Selectively**
+   - On admin/auth pages, copy pills, CTA arrows, and staggered reveals are appropriate.
+   - On operator pages, motion should support state change, not decoration.
 
 ### ❌ Don't
 
@@ -1412,23 +1438,23 @@ import { PageStatsRow } from "@/components/admin/PageStatsRow";
    - Never import another component library for buttons, cards, inputs, etc.
    - If you need a component, run `npx shadcn@latest add <component>` and style it.
 
-2. **No Flat Backgrounds**
+2. **Don't Put Operator Work on Decorative Backgrounds**
    ```css
-   body { background: #111927; } // Do this
-   body { background: #0a0a0a; } // Not acceptable
+   .operator-shell { background: hsl(var(--background)); } // Correct
+   .operator-shell { background: radial-gradient(...); } // Not acceptable
    ```
 
-3. **No Opaque Cards**
-   Glass cards must use blur + saturation. Avoid `bg-gray-900` or solid fills.
+3. **Don't Treat Glass as the Default**
+   Glass cards belong to admin/auth flows. Operator screens should default to solid, readable containers.
 
 4. **No Arbitrary Tailwind Values**
    Stick to `p-4`, `gap-3`, etc. Do not introduce `p-[23px]`.
 
-5. **No Untinted Icons**
-   Assign `.icon-blue`/`.icon-green` classes so icons match the pack.
+5. **No Unscoped Icon Treatment**
+   Use decorative icon tinting on admin/auth surfaces only. Operator icons should stay semantic and legible.
 
-6. **No Static Entrances**
-   Cards and pills should animate (`fadeInUp`, float, copy success) exactly like the reference.
+6. **No Decorative Motion on Execution Screens**
+   Operator cards, dialogs, and action bars should feel stable; reserve staged entrances for admin/auth storytelling surfaces.
 
 ### Accessibility
 
@@ -1551,12 +1577,12 @@ Standard pattern for all admin pages to create visual hierarchy and brand consis
 </div>
 ```
 
-### Glass Data Tables
+### Data Table Surface Treatment
 
-Wrap data tables in glass cards for depth and visual appeal.
+Operator data tables should use neutral containers. Admin and auth-adjacent tables may use glass cards when the surrounding page already uses Antigravity treatment.
 
 ```tsx
-<div className="glass-card p-6">
+<div className="rounded-2xl border border-border/80 bg-card/95 p-4 shadow-sm">
   <DataTable
     columns={columns}
     data={jobs || []}
@@ -1568,9 +1594,9 @@ Wrap data tables in glass cards for depth and visual appeal.
 </div>
 ```
 
-### Modal Dialogs with Glass Effect
+### Modal Dialog Treatment
 
-All dialogs should use glass morphism for consistency.
+Use glass dialogs only on admin/auth surfaces. Operator dialogs should favor quiet backgrounds, clear borders, and predictable spacing.
 
 ```tsx
 <Dialog open={isOpen} onOpenChange={setIsOpen}>


### PR DESCRIPTION
## Why
- Reorients the shop-floor experience around human operator MES workflows for SMB metalworking instead of machine/HMI-style presentation.
- Keeps Antigravity as the intentional visual language for admin and auth surfaces, where exploration, orientation, and brand expression matter more than execution speed.
- Makes status language, page rhythm, and action hierarchy more consistent across the user-facing application.

## How
- Added shared operator workspace primitives and reworked the operator queue, detail, activity, and issues views around packet-centric flow, touch-sized actions, and active-operator context on shared stations.
- Standardized admin headers, stats rows, and status badges so jobs, parts, operations, and issues use the same visual/state model.
- Fixed the admin issue queue so it no longer silently collapses to pending-only data and updated the review dialog to use the shared severity/status components.
- Added a shared `AuthShell` and moved the main auth/invitation flows onto it so Antigravity styling stays consistent for login flows without bleeding into production-facing operator screens.
- Updated the design-system reference to document the operator/admin/auth surface split explicitly.

## Testing
- `npx eslint src/components/auth/AuthShell.tsx src/components/auth/AuthShell.test.tsx src/pages/auth/Auth.tsx src/pages/auth/ForgotPassword.tsx src/pages/auth/ResetPassword.tsx src/pages/auth/AcceptInvitation.tsx src/pages/admin/Jobs.tsx src/pages/admin/Parts.tsx src/pages/admin/IssueQueue.tsx src/components/admin/AdminPageHeader.tsx src/components/admin/PageStatsRow.tsx src/components/ui/status-badge.tsx src/pages/operator/OperatorView.tsx`
- `npx vitest run src/components/auth/AuthShell.test.tsx src/components/admin/AdminPageHeader.test.tsx src/components/admin/PageStatsRow.test.tsx src/components/ui/status-badge.test.tsx src/pages/operator/OperatorView.test.tsx`
- `npm run build`

## Known Follow-up / Existing Failures
- `npm run test:run` still has pre-existing failures in `src/lib/webhooks.test.ts` and `src/lib/event-dispatch.test.ts`, driven by webhook/event-dispatch expectations and Supabase config/mock setup rather than this UI work.
- `npm run test:api:e2e` was not run because `SUPABASE_URL` and `API_KEY` are not configured in this workspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New authentication shell and header components for a consistent onboarding layout
  * Operator workspace component library for status chips, stat cards, panels, and empty states

* **Improvements**
  * Redesigned operator and admin layouts, job/queue views, and detail panels for clearer workflow and responsiveness
  * Expanded semantic status/severity badges and updated visual styling
  * Increased password minimum length on invitation acceptance

* **Documentation**
  * Updated design system reference with operator-first layout and spacing guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->