### PR TITLE
fix: resolve React error #185, CSP blocks, and PDF worker

### DIFF
--- a/src/components/PDFViewer.tsx
+++ b/src/components/PDFViewer.tsx
@@ -17,8 +17,8 @@ import {
 import { cn } from '@/lib/utils';
 import { logger } from '@/lib/logger';
 
-// Configure PDF.js worker from CDN
-pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`;
+// Configure PDF.js worker from CDN (jsdelivr is allowed by our CSP)
+pdfjs.GlobalWorkerOptions.workerSrc = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`;
 
 interface PDFViewerProps {
   url: string;

--- a/src/components/operator/OperationCard.tsx
+++ b/src/components/operator/OperationCard.tsx
@@ -58,13 +58,14 @@ export default function OperationCard({
     profile?.tenant_id,
   );
 
-  const dueDate =
+  const rawDueDate =
     operation.part.job.due_date_override || operation.part.job.due_date;
+  const dueDate = typeof rawDueDate === "string" ? rawDueDate : null;
   const dueDateObj = dueDate ? new Date(dueDate) : null;
   const dueUrgency = getDueUrgency(dueDate);
-  const plannedStartObj = operation.planned_start
-    ? new Date(operation.planned_start)
-    : null;
+  const rawPlannedStart = operation.planned_start;
+  const plannedStartObj =
+    typeof rawPlannedStart === "string" ? new Date(rawPlannedStart) : null;
   const hasPlannedStart =
     plannedStartObj !== null && Number.isFinite(plannedStartObj.getTime());
   const estimatedHours = (operation.estimated_time || 0) / 60;
@@ -116,7 +117,7 @@ export default function OperationCard({
               <span className="truncate font-mono text-[11px] text-muted-foreground">
                 {operation.part.job.job_number}
               </span>
-              {hasPlannedStart ? (
+              {hasPlannedStart && plannedStartObj ? (
                 <span className="shrink-0 text-[9px] text-muted-foreground/70">
                   ▶ {format(plannedStartObj, "dd MMM")}
                 </span>
@@ -151,16 +152,16 @@ export default function OperationCard({
 
           {/* Row 2: Operation name (primary info) */}
           <div className="mt-0.5 truncate text-sm font-semibold text-foreground">
-            {operation.operation_name}
+            {String(operation.operation_name ?? "")}
           </div>
 
           {/* Row 3: Part number + material */}
           <div className="mt-0.5 flex items-center gap-1.5 text-[11px] text-muted-foreground">
-            <span className="truncate">{operation.part.part_number}</span>
+            <span className="truncate">{String(operation.part.part_number ?? "")}</span>
             {operation.part.material ? (
               <>
                 <span className="text-border">·</span>
-                <span className="truncate">{operation.part.material}</span>
+                <span className="truncate">{String(operation.part.material)}</span>
               </>
             ) : null}
           </div>

--- a/src/components/operator/OperationDetailModal.tsx
+++ b/src/components/operator/OperationDetailModal.tsx
@@ -334,7 +334,7 @@ export default function OperationDetailModal({
               </div>
             </div>
 
-            {operation.part.job.customer && (
+            {typeof operation.part.job.customer === "string" && operation.part.job.customer && (
               <div className="text-xs text-muted-foreground bg-muted/30 rounded-md px-3 py-2">
                 {operation.part.job.customer}
               </div>
@@ -366,7 +366,7 @@ export default function OperationDetailModal({
               </div>
             )}
 
-            {operation.notes && (
+            {typeof operation.notes === "string" && operation.notes && (
               <div className="bg-muted/30 rounded-md p-3">
                 <div className="text-xs text-muted-foreground mb-1">{t("operations.notes")}</div>
                 <div className="text-sm">{operation.notes}</div>

--- a/src/components/terminal/DetailPanel.tsx
+++ b/src/components/terminal/DetailPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { TerminalJob } from "@/types/terminal";
-import { getDueUrgency, dueUrgencyTextClass } from "@/lib/due-date";
+// getDueUrgency/dueUrgencyTextClass available if needed for future due-date display
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -275,10 +275,10 @@ export function DetailPanel({
                       {operation.sequence}.
                     </span>
                     <span className="truncate text-xs font-semibold text-foreground">
-                      {operation.operation_name}
+                      {String(operation.operation_name ?? "")}
                     </span>
                     <span className="text-[10px] text-muted-foreground">
-                      {operation.cell?.name || "?"}
+                      {String(operation.cell?.name || "?")}
                     </span>
                   </div>
                   <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
@@ -366,10 +366,10 @@ export function DetailPanel({
             <Zap className="h-4 w-4 shrink-0 text-destructive" />
           ) : null}
           <h2 className="truncate font-mono text-sm font-semibold text-foreground">
-            {job.jobCode}
+            {String(job.jobCode ?? "")}
           </h2>
           <span className="truncate text-sm text-muted-foreground">
-            {job.description}
+            {String(job.description ?? "")}
           </span>
         </div>
         <Badge
@@ -384,7 +384,7 @@ export function DetailPanel({
       {job.notes ? (
         <div className="shrink-0 border-b border-border px-3 py-1.5">
           <div className="rounded-md bg-muted/20 px-2 py-1 text-xs text-muted-foreground">
-            {job.notes}
+            {String(job.notes)}
           </div>
         </div>
       ) : null}

--- a/src/components/terminal/JobRow.tsx
+++ b/src/components/terminal/JobRow.tsx
@@ -30,9 +30,10 @@ const urgencyLabel: Record<string, string> = {
 
 export function JobRow({ job, isSelected, onClick, variant }: JobRowProps) {
   const { t } = useTranslation();
-  const dueDate = job.dueDate ? new Date(job.dueDate) : null;
+  const rawDueDate = typeof job.dueDate === "string" ? job.dueDate : null;
+  const dueDate = rawDueDate ? new Date(rawDueDate) : null;
   const hasValidDueDate = dueDate !== null && Number.isFinite(dueDate.getTime());
-  const dueUrgency = getDueUrgency(job.dueDate);
+  const dueUrgency = getDueUrgency(rawDueDate);
 
   return (
     <tr
@@ -70,13 +71,13 @@ export function JobRow({ job, isSelected, onClick, variant }: JobRowProps) {
               {job.activeOperatorName?.split(" ")[0] || t("terminal.other")}
             </Badge>
           ) : null}
-          {job.jobCode}
+          {String(job.jobCode ?? "")}
         </div>
       </td>
 
       {/* Part Number */}
       <td className="whitespace-nowrap px-2 py-1.5 text-sm text-foreground">
-        {job.description}
+        {String(job.description ?? "")}
       </td>
 
       {/* Operation */}
@@ -100,13 +101,13 @@ export function JobRow({ job, isSelected, onClick, variant }: JobRowProps) {
             color: job.cellColor || "inherit",
           }}
         >
-          {job.cellName || "-"}
+          {String(job.cellName || "-")}
         </span>
       </td>
 
       {/* Material */}
       <td className="whitespace-nowrap px-2 py-1.5 text-sm text-foreground">
-        {job.material || "-"}
+        {String(job.material || "-")}
       </td>
 
       {/* Quantity */}
@@ -121,7 +122,7 @@ export function JobRow({ job, isSelected, onClick, variant }: JobRowProps) {
 
       {/* Planned Start */}
       <td className="whitespace-nowrap px-2 py-1.5 text-sm text-muted-foreground">
-        {job.plannedStart
+        {typeof job.plannedStart === "string"
           ? new Date(job.plannedStart).toLocaleDateString("nl-NL", {
               day: "2-digit",
               month: "2-digit",

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -165,10 +165,22 @@ export async function fetchOperationsWithDetails(tenantId: string): Promise<Oper
     throw entriesError;
   }
 
-  return operations.map((operation) => ({
-    ...operation,
-    active_time_entry: activeEntries?.find((entry) => entry.operation_id === operation.id),
-  }));
+  return operations.map((operation) => {
+    const entry = activeEntries?.find((e) => e.operation_id === operation.id);
+    // Ensure the nested operator join is an object with full_name, not an array.
+    // PostgREST may return arrays for ambiguous FK relationships.
+    const safeEntry = entry
+      ? {
+          id: entry.id,
+          operator_id: entry.operator_id,
+          start_time: entry.start_time,
+          operator: Array.isArray(entry.operator)
+            ? (entry.operator[0] as { full_name: string })
+            : (entry.operator as { full_name: string }),
+        }
+      : undefined;
+    return { ...operation, active_time_entry: safeEntry };
+  });
 }
 
 export async function startTimeTracking(

--- a/src/lib/due-date.ts
+++ b/src/lib/due-date.ts
@@ -13,7 +13,7 @@ export type DueUrgency = "overdue" | "today" | "soon" | "normal" | "none";
 export function getDueUrgency(
   dateValue: string | null | undefined,
 ): DueUrgency {
-  if (!dateValue) return "none";
+  if (!dateValue || typeof dateValue !== "string") return "none";
   const date = new Date(dateValue);
   if (!Number.isFinite(date.getTime())) return "none";
 

--- a/src/pages/operator/OperatorView.tsx
+++ b/src/pages/operator/OperatorView.tsx
@@ -205,36 +205,43 @@ export default function OperatorView() {
       const actual = op.actual_time || 0;
       const remaining = Math.max(0, estimated - actual);
 
+      // Defensively coerce database values to expected primitives.
+      // Supabase SELECT * can include JSON/unknown columns that would
+      // crash React if accidentally rendered as JSX children (error #185).
       return {
         id: op.id,
         operationId: op.id,
         partId: op.part.id,
         jobId: op.part.job.id,
-        jobCode: op.part.job.job_number,
-        description: op.part.part_number,
-        material: op.part.material,
-        quantity: op.part.quantity,
-        currentOp: op.operation_name,
+        jobCode: String(op.part.job.job_number ?? ""),
+        description: String(op.part.part_number ?? ""),
+        material: typeof op.part.material === "string" ? op.part.material : "",
+        quantity: Number(op.part.quantity) || 0,
+        currentOp: String(op.operation_name ?? ""),
         totalOps: 0,
         hours: Number(remaining.toFixed(1)),
-        dueDate: op.part.job.due_date || new Date().toISOString(),
+        dueDate: typeof op.part.job.due_date === "string"
+          ? op.part.job.due_date
+          : new Date().toISOString(),
         status,
         hasPdf,
         hasModel,
-        filePaths: op.part.file_paths || [],
+        filePaths: Array.isArray(op.part.file_paths) ? op.part.file_paths : [],
         activeTimeEntryId: op.active_time_entry?.id,
         activeOperatorId: op.active_time_entry?.operator_id,
-        activeOperatorName: op.active_time_entry?.operator?.full_name,
+        activeOperatorName: typeof op.active_time_entry?.operator?.full_name === "string"
+          ? op.active_time_entry.operator.full_name
+          : undefined,
         isCurrentUserClocked: op.active_time_entry?.operator_id === operatorId,
-        notes: op.notes,
-        cellName: op.cell.name,
-        cellColor: op.cell.color || "#3b82f6",
+        notes: typeof op.notes === "string" ? op.notes : null,
+        cellName: String(op.cell.name ?? ""),
+        cellColor: typeof op.cell.color === "string" ? op.cell.color : "#3b82f6",
         cellId: op.cell_id,
         currentSequence: op.sequence,
-        drawingNo: op.part.drawing_no,
-        cncProgramName: op.part.cnc_program_name,
-        isBulletCard: op.part.is_bullet_card,
-        plannedStart: op.planned_start,
+        drawingNo: typeof op.part.drawing_no === "string" ? op.part.drawing_no : null,
+        cncProgramName: typeof op.part.cnc_program_name === "string" ? op.part.cnc_program_name : null,
+        isBulletCard: Boolean(op.part.is_bullet_card),
+        plannedStart: typeof op.planned_start === "string" ? op.planned_start : null,
       };
     },
     [operatorId],

--- a/vercel.json
+++ b/vercel.json
@@ -27,7 +27,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.supabase.co https://challenges.cloudflare.com; connect-src 'self' blob: https://*.supabase.co wss://*.supabase.co https://challenges.cloudflare.com https://cdn.jsdelivr.net; font-src 'self' data:; frame-src 'self' https://challenges.cloudflare.com; object-src 'none'; base-uri 'self';"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https://*.supabase.co https://challenges.cloudflare.com; connect-src 'self' blob: https://*.supabase.co wss://*.supabase.co https://challenges.cloudflare.com https://cdn.jsdelivr.net; font-src 'self' data: https://fonts.gstatic.com; frame-src 'self' https://challenges.cloudflare.com; object-src 'none'; base-uri 'self';"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- **React error #185** — Supabase `SELECT *` returned JSON/unknown columns that got rendered as React children. Added defensive `String()` / `typeof` guards at the DB→React boundary across 7 component files.
- **CSP blocking Google Fonts** — Added `fonts.googleapis.com` to `style-src` and `fonts.gstatic.com` to `font-src` in `vercel.json`.
- **PDF worker failing** — Switched `pdfjs-dist` worker URL from `unpkg.com` (blocked by CSP) to `cdn.jsdelivr.net` (already allowed).

## Test plan
- [ ] Verify operator view loads without React error #185
- [ ] Verify terminal view loads without crashes
- [ ] Verify batch create page (`/admin/batches/new`) renders correctly
- [ ] Verify PDF viewer loads documents without CSP errors
- [ ] Verify Google Fonts stylesheet loads (no CSP block in console)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved data validation to prevent display issues with missing or malformed data
  * Enhanced null/undefined value handling throughout the application for more stable display
  * Fixed PDF viewer script loading for better reliability

* **Style**
  * Added support for Google Fonts to enhance typography across the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->