### PR TITLE
Localize key docs in Dutch: concepts, guides, glossary

### DIFF
--- a/docs/GLOSSARY_DE.md
+++ b/docs/GLOSSARY_DE.md
@@ -1,0 +1,71 @@
+# Glossar — MES-Fachbegriffe
+
+> Fertigungsvokabular, das in Eryxon Flow verwendet wird. Hilft KI-Agenten und Benutzern, die Domäne zu verstehen.
+
+## Kernentitäten
+
+| Begriff | Definition |
+|---------|-----------|
+| **Auftrag (Job)** | Ein Kundenauftrag mit einem oder mehreren Teilen. Hat eine Auftragsnummer, einen Kundennamen und einen Gesamtstatus. |
+| **Teil (Part)** | Ein physischer Gegenstand, der gefertigt werden muss. Gehört zu einem Auftrag. Hat Teilenummer, Material, Menge und Zeichnung. |
+| **Arbeitsgang (Operation)** | Ein einzelner Fertigungsschritt an einem Teil (z.B. Laserschneiden, Biegen, Schweißen). Hat eine Reihenfolgenummer, geschätzte Zeit und Status. |
+| **Unterschritt (Substep)** | Ein Checklisten-Element innerhalb eines Arbeitsgangs (z.B. "Maße prüfen", "Kanten entgraten"). |
+| **Charge (Batch)** | Eine Gruppe von Arbeitsgängen, die zur effizienten Verarbeitung auf einer einzelnen Maschine/Zelle zusammengefasst werden. |
+
+## Produktionskonzepte
+
+| Begriff | Definition |
+|---------|-----------|
+| **Zelle / Stufe (Cell / Stage)** | Ein Produktionsbereich oder eine Maschinengruppe (z.B. "Laser 1", "Abkantpresse", "Lackierstraße"). Arbeitsgänge werden Zellen zugewiesen. |
+| **Ressource (Resource)** | Eine Maschine, ein Werkzeug oder eine Vorrichtung, die in der Produktion verwendet wird. Zellen zugewiesen. |
+| **Zuweisung (Assignment)** | Verknüpft einen Werker mit bestimmten Aufträgen/Teilen/Arbeitsgängen, an denen er arbeiten soll. |
+| **Arbeitswarteschlange (Work Queue)** | Die Ansicht des Werkers seiner zugewiesenen Arbeitsgänge, nach Priorität geordnet. |
+| **Zeiteintrag (Time Entry)** | Ein Ein-/Ausstempel-Datensatz eines Werkers, der an einem Arbeitsgang arbeitet. |
+| **Kapazitätsmatrix (Capacity Matrix)** | Visuelles Raster, das Zellenverfügbarkeit gegenüber geplanter Arbeit über die Zeit zeigt. |
+| **Bullet Card (Eilauftrag)** | Eilmarkierung auf einem Teil. Das Teil springt an die Spitze jeder Warteschlange. |
+| **UB (Umlaufbestand / WIP)** | Die Anzahl der Arbeitsgänge, die gleichzeitig in einer Zelle aktiv sind. Begrenzt durch UB-Grenzen. |
+| **POLCA** | Paired-cell Overlapping Loops of Cards with Authorization — Arbeitslastverwaltungssystem mit GO/PAUSE-Signalen. |
+| **QRM** | Quick Response Manufacturing — Methodik zur Verkürzung von Durchlaufzeiten. |
+
+## Qualität & Problemmeldungen
+
+| Begriff | Definition |
+|---------|-----------|
+| **NCR** | Non-Conformance Report. Ein formeller Bericht, dass etwas nicht den Spezifikationen entspricht. |
+| **Problemmeldung (Issue)** | Ein während der Produktion gemeldetes Problem. Typen: NCR, Beobachtung, Verbesserung, Sicherheit. |
+| **Ausschuss (Scrap)** | Material, das nicht nachgearbeitet werden kann und entsorgt werden muss. Verfolgt mit Ausschussgrund-Codes. |
+| **Nacharbeit (Rework)** | Material, das die Prüfung nicht bestanden hat, aber korrigiert und erneut verarbeitet werden kann. |
+| **Disposition** | Die Entscheidung über den Umgang mit nicht-konformem Material (Ausschuss, Nacharbeit, Verwenden-wie-es-ist, Rücksendung). |
+| **PMI** | Product Manufacturing Information — Maßdaten aus 3D-Modellen/Zeichnungen. |
+
+## Kennzahlen
+
+| Begriff | Definition |
+|---------|-----------|
+| **OEE** | Overall Equipment Effectiveness. Verfügbarkeit x Leistung x Qualität. Industriestandard-Kennzahl. |
+| **Verfügbarkeit (Availability)** | % der geplanten Zeit, in der die Ausrüstung tatsächlich läuft. |
+| **Leistung (Performance)** | Tatsächliche Ausstoßrate im Vergleich zum theoretischen Maximum. |
+| **Qualität (Quality)** | % der produzierten Teile, die die Erstprüfung bestehen (keine Nacharbeit/kein Ausschuss). |
+
+## ERP-Integration
+
+| Begriff | Definition |
+|---------|-----------|
+| **ERP** | Enterprise Resource Planning — das Geschäftssystem (z.B. SAP, Exact, AFAS), das Aufträge, Bestand und Rechnungsstellung verwaltet. |
+| **Externe ID (External ID)** | Die ID einer Entität im ERP-System. Verwendet für Synchronisationsabgleich. |
+| **Externe Quelle (External Source)** | Welches ERP-System die Daten geliefert hat (z.B. "exact", "sap"). |
+| **Sync-Hash** | SHA-256-Hash synchronisierter Daten zur Änderungserkennung — Updates überspringen, wenn sich Daten nicht geändert haben. |
+| **Massensynchronisation (Bulk Sync)** | Mehrere Datensätze gleichzeitig vom ERP an Eryxon Flow senden in einem API-Aufruf (max. 1000 Einträge). |
+
+## Systemkonzepte
+
+| Begriff | Definition |
+|---------|-----------|
+| **Mandant (Tenant)** | Eine Organisation, die Eryxon Flow nutzt. Alle Daten sind pro Mandant über RLS isoliert. |
+| **RLS** | Row-Level Security — PostgreSQL-Funktion, die den Zeilenzugriff basierend auf dem Sitzungskontext einschränkt. |
+| **API-Schlüssel (API Key)** | Bearer-Token für REST-API-Zugriff. Format: `ery_live_*` (Produktion) oder `ery_test_*` (Sandbox). |
+| **Tarif (Plan)** | Abonnementstufe: free, pro, premium, enterprise. Bestimmt Ratenlimits und Kontingente. |
+| **MCP** | Model Context Protocol — ermöglicht KI-Agenten, mit Eryxon Flow als Werkzeug zu interagieren. |
+| **STEP / STP** | ISO 10303-Dateiformat für 3D-CAD-Modelle. Das vorherrschende Austauschformat in der Fertigungsindustrie. |
+| **Soft Delete** | Datensätze werden mit einem `deleted_at`-Zeitstempel markiert, anstatt physisch gelöscht zu werden. |
+| **Webhook** | HTTP-Callback, der ausgelöst wird, wenn Ereignisse auftreten (Auftrag erstellt, Status geändert usw.). |

--- a/docs/GLOSSARY_NL.md
+++ b/docs/GLOSSARY_NL.md
@@ -1,0 +1,71 @@
+# Woordenlijst — MES Domaintermen
+
+> Productieterminologie gebruikt in Eryxon Flow. Helpt AI-agents en gebruikers het domein te begrijpen.
+
+## Kernentiteiten
+
+| Term | Definitie |
+|------|-----------|
+| **Job** | Een klantenorder met een of meer onderdelen. Heeft een jobnummer, klantnaam en algemene status. |
+| **Onderdeel (Part)** | Een fysiek item dat geproduceerd moet worden. Behoort tot een job. Heeft onderdeelnummer, materiaal, hoeveelheid en tekening. |
+| **Bewerking (Operation)** | Een enkele productiestap op een onderdeel (bijv. lasersnijden, kanten, lassen). Heeft een volgordenummer, geschatte tijd en status. |
+| **Substap (Substep)** | Een checklist-item binnen een bewerking (bijv. "afmetingen controleren", "randen ontbramen"). |
+| **Batch** | Een groep bewerkingen die samen worden verwerkt voor efficiënte productie op een enkele machine/cel. |
+
+## Productieconcepten
+
+| Term | Definitie |
+|------|-----------|
+| **Cel / Stadium (Cell / Stage)** | Een productiegebied of machinegroep (bijv. "Laser 1", "Kantbank", "Verfstraat"). Bewerkingen worden aan cellen toegewezen. |
+| **Middel (Resource)** | Een machine, gereedschap of opspanning die in de productie wordt gebruikt. Toegewezen aan cellen. |
+| **Toewijzing (Assignment)** | Koppelt een operator aan specifieke jobs/onderdelen/bewerkingen waaraan zij moeten werken. |
+| **Werkwachtrij (Work Queue)** | De weergave van de operator van toegewezen bewerkingen, geordend op prioriteit. |
+| **Tijdregistratie (Time Entry)** | Een inklok/uitklok-record van een operator die aan een bewerking werkt. |
+| **Capaciteitsmatrix (Capacity Matrix)** | Visueel raster dat celbeschikbaarheid versus ingepland werk over tijd toont. |
+| **Bullet Card (Spoed)** | Spoedmarkering op een onderdeel. Het onderdeel springt naar de top van elke wachtrij. |
+| **OHW (Onderhanden Werk / WIP)** | Het aantal bewerkingen dat tegelijkertijd actief is in een cel. Beperkt door OHW-limieten. |
+| **POLCA** | Paired-cell Overlapping Loops of Cards with Authorization — werklastbeheersysteem met GO/PAUZE-signalen. |
+| **QRM** | Quick Response Manufacturing — methodologie gericht op het verkorten van doorlooptijden. |
+
+## Kwaliteit & Issues
+
+| Term | Definitie |
+|------|-----------|
+| **NCR** | Non-Conformance Report. Een formeel rapport dat iets niet aan specificaties voldoet. |
+| **Issue** | Een probleem gemeld tijdens productie. Types: NCR, observatie, verbetering, veiligheid. |
+| **Uitval (Scrap)** | Materiaal dat niet kan worden herwerkt en moet worden afgekeurd. Bijgehouden met uitvalredencodes. |
+| **Herwerk (Rework)** | Materiaal dat de inspectie niet heeft doorstaan maar kan worden gecorrigeerd en opnieuw verwerkt. |
+| **Dispositie (Disposition)** | De beslissing over wat te doen met niet-conform materiaal (afkeuren, herwerken, gebruiken-als-is, retourneren). |
+| **PMI** | Product Manufacturing Information — dimensionele data uit 3D-modellen/tekeningen. |
+
+## Meetwaarden
+
+| Term | Definitie |
+|------|-----------|
+| **OEE** | Overall Equipment Effectiveness. Beschikbaarheid x Prestatie x Kwaliteit. Industriestandaard meetwaarde. |
+| **Beschikbaarheid (Availability)** | % van de geplande tijd dat apparatuur daadwerkelijk draait. |
+| **Prestatie (Performance)** | Werkelijke productiesnelheid versus theoretisch maximum. |
+| **Kwaliteit (Quality)** | % geproduceerde items die de eerste inspectie doorstaan (geen herwerk/uitval). |
+
+## ERP-integratie
+
+| Term | Definitie |
+|------|-----------|
+| **ERP** | Enterprise Resource Planning — het bedrijfssysteem (bijv. SAP, Exact, AFAS) dat orders, voorraad en facturatie beheert. |
+| **Extern ID (External ID)** | Het ID van een entiteit in het ERP-systeem. Gebruikt voor synchronisatiekoppeling. |
+| **Externe Bron (External Source)** | Welk ERP-systeem de data heeft aangeleverd (bijv. "exact", "sap"). |
+| **Sync Hash** | SHA-256-hash van gesynchroniseerde data voor wijzigingsdetectie — updates overslaan wanneer data niet is veranderd. |
+| **Bulksynchronisatie (Bulk Sync)** | Meerdere records tegelijk vanuit ERP naar Eryxon Flow pushen in een API-aanroep (max 1000 items). |
+
+## Systeemconcepten
+
+| Term | Definitie |
+|------|-----------|
+| **Tenant** | Een organisatie die Eryxon Flow gebruikt. Alle data is per tenant geïsoleerd via RLS. |
+| **RLS** | Row-Level Security — PostgreSQL-functie die rijtoegang beperkt op basis van sessiecontext. |
+| **API-sleutel (API Key)** | Bearer-token voor REST API-toegang. Formaat: `ery_live_*` (productie) of `ery_test_*` (sandbox). |
+| **Plan** | Abonnementsniveau: free, pro, premium, enterprise. Bepaalt snelheidslimieten en quota's. |
+| **MCP** | Model Context Protocol — stelt AI-agents in staat om met Eryxon Flow te communiceren als tool. |
+| **STEP / STP** | ISO 10303-bestandsformaat voor 3D CAD-modellen. Het dominante uitwisselingsformaat in de maakindustrie. |
+| **Soft Delete** | Records worden gemarkeerd met een `deleted_at`-tijdstempel in plaats van fysiek verwijderd. |
+| **Webhook** | HTTP-callback die wordt afgevuurd wanneer events plaatsvinden (job aangemaakt, status gewijzigd, enz.). |

--- a/website/src/components/override-components/Footer.astro
+++ b/website/src/components/override-components/Footer.astro
@@ -1,6 +1,7 @@
 ---
 import config from "@/config/config.json";
 import social from "@/config/social.json";
+import locales from "@/config/locals.json";
 import { Icon } from "@astrojs/starlight/components";
 import { markdownify } from "@/lib/utils/textConverter";
 import { getTranslations } from "@/lib/utils/languagePerser";
@@ -12,6 +13,25 @@ const menu = await getTranslations(locale || "en");
 const footer = menu.footer;
 const currentLocal = Astro.currentLocale || "en";
 const { hasSidebar } = Astro.locals.starlightRoute;
+
+// Build locale switcher data
+const pathname = Astro.url.pathname;
+function stripLocalePrefix(path: string, loc: string): string {
+  if (loc === "en") return path;
+  const prefix = `/${loc}`;
+  if (path === prefix || path === `${prefix}/`) return "/";
+  if (path.startsWith(`${prefix}/`)) return path.slice(prefix.length);
+  return path;
+}
+const basePath = stripLocalePrefix(pathname, currentLocal);
+const localeEntries = Object.entries(locales) as [string, { lang: string; label: string }][];
+const languageLinks = localeEntries.map(([key, val]) => ({
+  lang: val.lang,
+  label: val.label,
+  href: key === "root" ? basePath : `/${val.lang}${basePath === "/" ? "/" : basePath}`,
+  active: val.lang === currentLocal || (key === "root" && currentLocal === "en"),
+}));
+const languageLabel = Astro.locals.t("footer.language", "Language");
 ---
 
 {
@@ -62,6 +82,25 @@ const { hasSidebar } = Astro.locals.starlightRoute;
             )
           }
 
+          <div>
+            <h4>{languageLabel}</h4>
+            <ul class="language-switcher">
+              {languageLinks.map((link) => (
+                <li>
+                  <a
+                    href={link.href}
+                    hreflang={link.lang}
+                    lang={link.lang}
+                    class:list={[{ active: link.active }]}
+                    aria-current={link.active ? "true" : undefined}
+                  >
+                    {link.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+
           {
             config?.params?.footer_contact?.enable && (
               <div>
@@ -87,7 +126,7 @@ const { hasSidebar } = Astro.locals.starlightRoute;
         </div>
         <div class="bottom-footer">
           <p set:html={markdownify(config?.params?.copyright)} />
-          <a href={currentLocal + "/privacy-policy"}
+          <a href={`/${currentLocal}/privacy-policy`}
             >{Astro.locals.t("footer.privacy", "Privacy Policy")}</a
           >
         </div>
@@ -189,6 +228,26 @@ const { hasSidebar } = Astro.locals.starlightRoute;
 
     .bottom-footer a:hover {
       color: var(--color-primary);
+    }
+    .language-switcher {
+      list-style: none;
+      padding: 0;
+    }
+    .language-switcher li {
+      margin-bottom: 1.2rem;
+    }
+    .language-switcher a {
+      color: var(--sl-color-text);
+      text-decoration: none;
+      font-size: 1rem;
+      transition: color 0.3s ease;
+    }
+    .language-switcher a:hover {
+      color: var(--color-primary);
+    }
+    .language-switcher a.active {
+      color: var(--color-primary);
+      font-weight: 600;
     }
   }
 </style>

--- a/website/src/components/override-components/Head.astro
+++ b/website/src/components/override-components/Head.astro
@@ -1,6 +1,8 @@
 ---
 import { AstroFont } from "astro-font";
 import theme from "@/config/theme.json";
+import config from "@/config/config.json";
+import locales from "@/config/locals.json";
 const { head } = Astro.locals.starlightRoute;
 
 // font families
@@ -22,9 +24,55 @@ if (theme.fonts.font_family.secondary) {
     .replace(/:[ital,]*[ital@]*[wght@]*[0-9,;.]+/gi, "");
 }
 
+// SEO: Build hreflang alternate links for all locales
+const siteUrl = config.site.url.replace(/\/$/, "");
+const currentLocale = Astro.currentLocale || "en";
+const pathname = Astro.url.pathname;
+
+// Strip current locale prefix to get the base path
+function stripLocalePrefix(path: string, locale: string): string {
+  if (locale === "en") return path; // root locale has no prefix
+  const prefix = `/${locale}`;
+  if (path === prefix || path === `${prefix}/`) return "/";
+  if (path.startsWith(`${prefix}/`)) return path.slice(prefix.length);
+  return path;
+}
+
+const basePath = stripLocalePrefix(pathname, currentLocale);
+
+// Build alternate URLs for each locale
+const localeEntries = Object.entries(locales) as [string, { lang: string; label: string }][];
+const alternates = localeEntries.map(([key, val]) => {
+  const lang = val.lang;
+  const localePath = key === "root" ? basePath : `/${lang}${basePath === "/" ? "/" : basePath}`;
+  return { lang, href: `${siteUrl}${localePath}` };
+});
+
+// Serialized locale map for client-side auto-detect script
+const supportedLangs = localeEntries.map(([key, val]) => ({
+  key,
+  lang: val.lang,
+  label: val.label,
+}));
+
 ---
 
 {head.map(({ tag: Tag, attrs, content }) => <Tag {...attrs} set:html={content} />)}
+
+<!-- SEO: canonical URL for this locale -->
+<link rel="canonical" href={`${siteUrl}${pathname}`} />
+
+<!-- SEO: hreflang alternate links for all locales -->
+{alternates.map(({ lang, href }) => (
+  <link rel="alternate" hreflang={lang} href={href} />
+))}
+<link rel="alternate" hreflang="x-default" href={`${siteUrl}${basePath}`} />
+
+<!-- SEO: Open Graph locale tags -->
+<meta property="og:locale" content={currentLocale} />
+{alternates.filter(a => a.lang !== currentLocale).map(({ lang }) => (
+  <meta property="og:locale:alternate" content={lang} />
+))}
 
 <!-- google font css -->
     <AstroFont
@@ -49,4 +97,67 @@ if (theme.fonts.font_family.secondary) {
         },
       ]}
     />
+
+<!-- Browser language auto-detect: offer to switch locale -->
+<script is:inline define:vars={{ supportedLangs, currentLocale }}>
+(function () {
+  const STORAGE_KEY = "eryxon-locale-dismissed";
+  // Only run on first visit or if user hasn't dismissed for this language
+  if (typeof navigator === "undefined") return;
+  const dismissed = sessionStorage.getItem(STORAGE_KEY);
+  if (dismissed) return;
+
+  const browserLangs = navigator.languages || [navigator.language];
+  // Find best matching supported locale
+  let match = null;
+  for (const bl of browserLangs) {
+    const code = bl.toLowerCase().split("-")[0]; // "nl-BE" -> "nl"
+    const found = supportedLangs.find(function (s) { return s.lang === code; });
+    if (found) {
+      match = found;
+      break;
+    }
+  }
+
+  // No match or already on the right locale
+  if (!match || match.lang === currentLocale) return;
+
+  // Build the redirect URL — swap locale prefix in current path
+  var path = window.location.pathname;
+  // Strip current locale prefix
+  var basePath = path;
+  if (currentLocale !== "en") {
+    var prefix = "/" + currentLocale;
+    if (path === prefix || path === prefix + "/") basePath = "/";
+    else if (path.indexOf(prefix + "/") === 0) basePath = path.slice(prefix.length);
+  }
+  var targetPath = match.key === "root" ? basePath : "/" + match.lang + (basePath === "/" ? "/" : basePath);
+
+  // Build banner labels per language
+  var msgs = {
+    nl: { text: "Deze pagina is ook beschikbaar in het Nederlands.", btn: "Ga naar Nederlands", dismiss: "Sluiten" },
+    de: { text: "Diese Seite ist auch auf Deutsch verfügbar.", btn: "Zu Deutsch wechseln", dismiss: "Schließen" },
+    en: { text: "This page is also available in English.", btn: "Switch to English", dismiss: "Close" }
+  };
+  var msg = msgs[match.lang] || { text: "This page is available in " + match.label + ".", btn: match.label, dismiss: "Close" };
+
+  // Create banner
+  var banner = document.createElement("div");
+  banner.id = "locale-banner";
+  banner.setAttribute("role", "status");
+  banner.setAttribute("aria-live", "polite");
+  banner.innerHTML =
+    '<div style="display:flex;align-items:center;justify-content:center;gap:12px;padding:10px 16px;background:var(--sl-color-gray-6,#1e293b);color:var(--sl-color-text,#e2e8f0);font-size:14px;text-align:center;flex-wrap:wrap;">' +
+      '<span>' + msg.text + '</span>' +
+      '<a href="' + targetPath + '" style="background:var(--color-primary,#3b82f6);color:#fff;padding:4px 14px;border-radius:6px;text-decoration:none;font-weight:500;font-size:13px;">' + msg.btn + '</a>' +
+      '<button id="locale-dismiss" style="background:none;border:none;color:var(--sl-color-text,#94a3b8);cursor:pointer;font-size:13px;padding:4px 8px;" aria-label="' + msg.dismiss + '">' + msg.dismiss + '</button>' +
+    '</div>';
+  document.body.prepend(banner);
+
+  document.getElementById("locale-dismiss").addEventListener("click", function () {
+    banner.remove();
+    sessionStorage.setItem(STORAGE_KEY, "1");
+  });
+})();
+</script>
 

--- a/website/src/config/config.json
+++ b/website/src/config/config.json
@@ -23,7 +23,8 @@
     "enable": true,
     "label": "Get Started",
     "translations": {
-      "fr": "Erste Schritte"
+      "de": "Erste Schritte",
+      "nl": "Aan de Slag"
     },
     "link": "/guides/quick-start/"
   }

--- a/website/src/config/locals.json
+++ b/website/src/config/locals.json
@@ -6,5 +6,9 @@
   "nl": {
     "label": "Nederlands",
     "lang": "nl"
+  },
+  "de": {
+    "label": "Deutsch",
+    "lang": "de"
   }
 }

--- a/website/src/config/menu.de.json
+++ b/website/src/config/menu.de.json
@@ -1,0 +1,73 @@
+{
+  "main": [
+    {
+      "name": "Startseite",
+      "url": "/de/"
+    },
+    {
+      "name": "Dokumentation",
+      "url": "/de/introduction/"
+    },
+    {
+      "name": "Live-Demo",
+      "url": "https://app.eryxon.eu"
+    }
+  ],
+  "footer": {
+    "community": {
+      "title": "Open Source",
+      "links": [
+        {
+          "name": "GitHub Repository",
+          "url": "https://github.com/SheetMetalConnect/eryxon-flow"
+        },
+        {
+          "name": "Diskussionen",
+          "url": "https://github.com/SheetMetalConnect/eryxon-flow/discussions"
+        },
+        {
+          "name": "Fehler Melden",
+          "url": "https://github.com/SheetMetalConnect/eryxon-flow/issues"
+        }
+      ]
+    },
+    "help_links": {
+      "title": "Ressourcen",
+      "links": [
+        {
+          "name": "Gehostete Version",
+          "url": "https://app.eryxon.eu"
+        },
+        {
+          "name": "Dokumentation",
+          "url": "/de/introduction/"
+        },
+        {
+          "name": "Self-Hosting",
+          "url": "/de/guides/self-hosting/"
+        },
+        {
+          "name": "REST API Referenz",
+          "url": "/de/api/rest-api-reference/"
+        }
+      ]
+    },
+    "company": {
+      "title": "Kontakt",
+      "links": [
+        {
+          "name": "office@vanenkhuizen.com",
+          "url": "mailto:office@vanenkhuizen.com"
+        },
+        {
+          "name": "LinkedIn",
+          "url": "https://www.linkedin.com/in/lvanenkhuizen/"
+        },
+        {
+          "name": "vanenkhuizen.com",
+          "url": "https://www.vanenkhuizen.com/"
+        }
+      ]
+    }
+  }
+}

--- a/website/src/content/docs/de/guides/admin-manual.md
+++ b/website/src/content/docs/de/guides/admin-manual.md
@@ -1,0 +1,173 @@
+---
+title: Adminhandbuch
+description: Wie Sie die Produktion in Eryxon Flow verwalten — Aufträge, Zellen, Planung, Qualität.
+---
+
+Diese Anleitung behandelt alles, was ein Produktionsleiter oder Planer für den täglichen Betrieb in Eryxon Flow benötigt. Sie setzt voraus, dass Ihr Konto Admin-Zugriff hat.
+
+## Dashboard
+
+Das Dashboard ist Ihr Startbildschirm. Es zeigt:
+
+- **Aktive Werker** — wer ist eingeloggt und arbeitet gerade.
+- **Offene Problemmeldungen** — Qualitätsprobleme von der Werkstatt gemeldet, warten auf Ihre Prüfung.
+- **UB pro Zelle** — wie viele Arbeitsgänge in jeder Produktionszelle aktiv sind, gegen das UB-Limit der Zelle.
+- **Lieferdaten** — anstehende Fristen über alle aktiven Aufträge, nach Dringlichkeit sortiert.
+
+Alle Daten werden in Echtzeit aktualisiert. Wenn ein Werker einen Start oder Abschluss am Terminal scannt, spiegelt das Dashboard dies innerhalb von Sekunden wider.
+
+## Aufträge Verwalten
+
+### Auftragshierarchie
+
+Jeder Auftrag folgt derselben Struktur: **Auftrag > Teile > Arbeitsgänge**.
+
+- Ein **Auftrag** repräsentiert einen Kundenauftrag oder ein internes Projekt. Er enthält den Kundennamen, die Auftragsnummer und das Lieferdatum.
+- Ein **Teil** ist ein physischer Gegenstand, der produziert werden muss. Jedes Teil hat ein Material, eine Menge und eine Zeichnungsreferenz.
+- Ein **Arbeitsgang** ist ein einzelner Produktionsschritt an einem Teil — Schneiden, Biegen, Schweißen, Lackieren usw. Arbeitsgänge sind mit einer Produktionszelle verknüpft und haben eine geschätzte Zeit.
+
+### Einen Auftrag erstellen
+
+1. Gehen Sie zu **Aufträge** und klicken Sie auf **Neuen Auftrag Erstellen**.
+2. Füllen Sie Auftragsnummer, Kunde und Lieferdatum aus.
+3. Fügen Sie ein oder mehrere Teile hinzu. Setzen Sie für jedes Teil die Teilenummer, das Material und die Menge.
+4. Fügen Sie Arbeitsgänge zu jedem Teil hinzu. Wählen Sie für jeden Arbeitsgang die Zelle, setzen Sie die geschätzte Zeit und definieren Sie die Reihenfolge.
+
+Sie können auch `Cmd/Ctrl + N` von überall verwenden, um das Schnellerstellungsmenü zu öffnen.
+
+### Eilaufträge (Bullet Card)
+
+Wenn ein Teil die Warteschlange überspringen muss, markieren Sie es als **Bullet Card** (Eil). Dies bewirkt global drei Dinge:
+
+- Das Teil rückt an die Spitze jeder Tabelle und Arbeitswarteschlange, über alle Zellen hinweg.
+- Werker sehen einen deutlichen Eilindikator auf ihrem Terminal.
+- Das Teil bleibt priorisiert, bis Sie die Eilmarkierung entfernen.
+
+Verwenden Sie dies sparsam. Wenn alles Eil ist, ist nichts Eil.
+
+### Arbeitsgänge anhalten
+
+Sie können jeden Arbeitsgang aus dem Arbeitsgangdetailpanel anhalten. Ein angehaltener Arbeitsgang bleibt in der Arbeitswarteschlange sichtbar, ist aber mit einem Halt-Badge markiert, damit Werker wissen, nicht damit zu beginnen. Setzen Sie ihn fort, wenn die Blockade beseitigt ist.
+
+## Produktionszellen (Stufen)
+
+Zellen repräsentieren Ihre physischen Arbeitsplätze oder Abteilungen — Laserschneiden, Abkantpresse, Schweißen, Montage, Versand.
+
+### Eine Zelle konfigurieren
+
+Gehen Sie zu **Stufen & Zellen** in der Admin-Seitenleiste. Für jede Zelle können Sie einstellen:
+
+- **Name** — was Werker auf dem Terminal sehen (z.B. "Laser 1", "Abkantpresse").
+- **Farbe** — wird in der gesamten Oberfläche zur visuellen Identifikation verwendet.
+- **Symbol** — erscheint auf dem Terminal und in der Kapazitätsmatrix.
+- **Reihenfolge** — die Standardreihenfolge, in der Zellen in Ansichten und Planung erscheinen.
+
+### UB-Grenzen
+
+Jede Zelle hat eine UB-Grenze (Umlaufbestand / Work In Progress). Dies steuert, wie viele Arbeitsgänge gleichzeitig aktiv sein können.
+
+- **Warnschwelle** — die Oberfläche hebt die Zelle hervor, wenn sie sich dem Limit nähert.
+- **Limit durchsetzen** — wenn aktiviert, blockiert das System den vorherigen Arbeitsgang vom Abschluss, wenn die nächste Zelle ausgelastet ist. Dies verhindert, dass sich Arbeit an einem Engpass aufstaut.
+
+Setzen Sie UB-Grenzen basierend auf Ihrer tatsächlichen Arbeitsplatzkapazität. Beginnen Sie konservativ und passen Sie an, basierend auf Ihren Beobachtungen.
+
+### Kapazitätsstunden
+
+Definieren Sie, wie viele Produktionsstunden jede Zelle pro Tag hat. Der Planer verwendet dies, um die Auslastung zu berechnen und überlastete Tage zu markieren.
+
+## Planung und Kapazität
+
+### Auto-Planer
+
+Der Auto-Planer weist Arbeitsgänge Zeitfenstern zu basierend auf:
+
+- Arbeitsgangfolge innerhalb jedes Teils.
+- Geschätzte Stunden pro Arbeitsgang.
+- Zellenkapazität pro Tag.
+- Lieferdaten der Aufträge.
+
+Führen Sie den Planer nach dem Hinzufügen neuer Aufträge oder bei Prioritätsänderungen aus. Er berechnet den gesamten Zeitplan neu und aktualisiert die Kapazitätsmatrix.
+
+### Kapazitätsmatrix
+
+Die Kapazitätsmatrix gibt Ihnen eine Vogelperspektive auf die Auslastung pro Zelle pro Tag. Jede Zelle erscheint als eine Zeile, jeder Tag als eine Spalte. Farbcodierung zeigt verfügbare, belastete und überlastete Zustände an.
+
+Verwenden Sie dies, um Engpässe zu erkennen, bevor sie die Werkstatt erreichen. Wenn eine Zelle in drei Tagen rot zeigt, wissen Sie, dass Sie jetzt handeln müssen — Arbeit verschieben, eine Schicht hinzufügen oder Lieferdaten anpassen.
+
+### Lieferdatum-Überschreibungen
+
+Wenn ein Kunde seine Frist ändert, aktualisieren Sie das Lieferdatum am Auftrag. Der Planer berücksichtigt die Änderung beim nächsten Lauf.
+
+### Fabrikkalender
+
+Der Fabrikkalender definiert Arbeitstage und Feiertage. Der Planer überspringt arbeitsfreie Tage automatisch. Konfigurieren Sie dies unter **Einstellungen**, bevor Sie Ihre erste Planung ausführen.
+
+## Chargenverwaltung
+
+Chargen gruppieren Arbeitsgänge für Schachtelung oder kombinierte Verarbeitung — üblich beim Laserschneiden, wo mehrere Teile dasselbe Blech teilen.
+
+### Mit Chargen arbeiten
+
+1. Erstellen Sie eine Charge und geben Sie ihr einen Namen oder eine Nummer.
+2. Weisen Sie Arbeitsgänge von verschiedenen Teilen der Charge zu.
+3. Verfolgen Sie die Materialzuweisung für die Charge.
+
+Wenn ein Werker eine Charge verarbeitet, schreiten alle enthaltenen Arbeitsgänge gemeinsam voran.
+
+## Zuweisungen und Benutzer
+
+### Arbeit zuweisen
+
+Gehen Sie zur **Zuweisungen**-Seite, um bestimmte Arbeitsgänge Werkern zuzuweisen. Wählen Sie das Teil, den Werker und bestätigen Sie. Die Zuweisung erscheint sofort in der Arbeitswarteschlange des Werkers.
+
+Sie können Werkern auch erlauben, sich selbst aus verfügbarer Arbeit in ihrer Zelle zuzuweisen.
+
+### Rollen
+
+- **Admin** — voller Zugriff auf alle Einstellungen, Aufträge, Planung, Daten und Benutzerverwaltung.
+- **Werker** — Zugriff auf ihre Arbeitswarteschlange, das Terminal und Problemmeldungen. Werker können keine Aufträge ändern, Zeitpläne modifizieren oder auf Einstellungen zugreifen.
+
+Verwalten Sie Benutzer unter **Einstellungen > Benutzer**.
+
+## Qualität und Problemmeldungen
+
+Werker melden Probleme direkt vom Terminal — falsches Material, beschädigte Teile, fehlende Zeichnungen, Maschinenprobleme.
+
+### Problemmeldungen prüfen
+
+1. Gehen Sie zur **Problemmeldungen**-Seite.
+2. Jede Meldung zeigt das Teil, den Arbeitsgang, den Werker und die Beschreibung.
+3. Wählen Sie eine Aktion:
+   - **Genehmigen** — bestätigt, dass es ein gültiges Problem ist. Wird für die Qualitätsverfolgung protokolliert.
+   - **Ablehnen** — kein tatsächliches Problem. Fügen Sie eine Notiz hinzu, die erklärt, warum.
+   - **Schließen** — das Problem wurde gelöst. Fügen Sie Lösungsnotizen hinzu.
+
+Reagieren Sie schnell auf Problemmeldungen. Ungelöste Probleme blockieren Werker und verlangsamen die Produktion.
+
+### Ausschussgründe
+
+Konfigurieren Sie Ausschussgrund-Codes unter **Ausschussgründe** in den Einstellungen. Jeder Grund hat einen Code, eine Beschreibung und eine Kategorie (Material, Prozess, Ausrüstung, Werker, Design). Die Seite zeigt Nutzungsstatistiken, damit Sie sehen können, welche Probleme am häufigsten auftreten.
+
+## Daten und Integration
+
+### CSV-Import
+
+Importieren Sie Aufträge, Teile und Arbeitsgänge aus CSV-Dateien. Dies ist nützlich für die Migration aus Tabellen oder den Empfang strukturierter Daten aus Ihrem ERP. Der Import-Bildschirm validiert Daten vor dem Übernehmen.
+
+### API-Schlüssel
+
+Generieren Sie API-Schlüssel unter **Einstellungen > API-Schlüssel** für die Integration mit externen Systemen. Jeder Schlüssel ist an Ihren Mandanten gebunden und kann jederzeit widerrufen werden.
+
+### Webhooks
+
+Konfigurieren Sie Webhooks unter **Einstellungen > Webhooks**, um Events an externe Systeme zu senden. Verfügbare Events umfassen:
+
+- `operation.started` — ein Werker hat mit der Arbeit begonnen.
+- `operation.completed` — ein Werker hat die Arbeit abgeschlossen.
+- `issue.created` — ein Qualitätsproblem wurde gemeldet.
+
+### Datenexport
+
+Gehen Sie zu **Datenexport** in der Admin-Seitenleiste. Sie können alle Datensätze als JSON oder CSV exportieren. CSV ist typischerweise schneller für große Datenmengen. Exporte enthalten alle Datenbankdatensätze und Metadaten, schließen aber Dateianhänge (nur Pfade) und API-Geheimnisse (nur Präfixe) aus.
+
+Große Exporte können 30-60 Sekunden dauern. Führen Sie sie wenn möglich in ruhigen Zeiten aus.

--- a/website/src/content/docs/de/guides/concepts.md
+++ b/website/src/content/docs/de/guides/concepts.md
@@ -1,0 +1,196 @@
+---
+title: Kernkonzepte
+description: Aufträge, Teile, Arbeitsgänge, Chargen — was sie sind und wie sie zusammenhängen.
+---
+
+Eryxon Flow verfolgt Arbeit über eine einfache Hierarchie: **Auftrag > Teile > Arbeitsgänge**. Alles im System hängt an dieser Struktur.
+
+## Auftrag (Job)
+
+Ein Auftrag ist der Container auf der obersten Ebene. Jedes Teil muss zu einem Auftrag gehören — das ist eine feste Anforderung im Datenmodell.
+
+Ein Auftrag muss kein Kundenauftrag sein. Es kann alles sein, was Teile zusammenfasst:
+
+- Ein Kundenauftrag (am häufigsten in Lohnfertigern)
+- Ein interner Produktionslauf
+- Eine Lagerauffüllungscharge
+- Ein Prototyp oder F&E-Projekt
+- Ein Wartungs- oder Nacharbeitsauftrag
+
+Das Feld `customer` ist optional. Das einzige Pflichtfeld ist `job_number`.
+
+| Feld | Pflicht | Beispiel |
+|------|---------|----------|
+| Auftragsnummer | ja | WO-2026-0142 |
+| Kunde | nein | Hygienisch Staal BV |
+| Lieferdatum | nein | 2026-05-15 |
+| Status | auto | not_started, in_progress, completed |
+
+Ein Auftrag hat ein oder mehrere Teile. Die Eilpriorität wird auf Teileebene festgelegt, nicht auf Auftragsebene.
+
+## Teil (Part)
+
+Ein Teil ist ein physischer Gegenstand, der produziert werden muss. Jedes Teil gehört zu einem Auftrag.
+
+| Feld | Beispiel |
+|------|----------|
+| Teilenummer | FRAME-RVS-316L |
+| Material | V4A 316L 3mm |
+| Menge | 4 |
+| Eilauftrag (Bullet Card) | ja/nein |
+| Übergeordnetes Teil | (für Baugruppen) |
+
+Teile können Folgendes haben:
+
+- **Dateien** — STEP-Modelle (im 3D-Viewer angezeigt), PDF-Zeichnungen, andere Anhänge. Dateien werden an Teile angehängt, nicht an Arbeitsgänge.
+- **Unterteile** — für Baugruppen verweisen Teile auf ein übergeordnetes Teil. Das System zeigt Baugruppen-Abhängigkeiten und warnt Werker, wenn Unterteile noch nicht fertig sind.
+- **Zeichnungsnummer** und **CNC-Programmname** — Schnellreferenzfelder für die Werkstatt.
+- **Abmessungen** — Länge, Breite, Höhe in mm, Gewicht in kg.
+
+## Arbeitsgang (Operation)
+
+Ein Arbeitsgang ist ein einzelner Produktionsschritt an einem Teil. Hier findet die eigentliche Arbeit statt.
+
+| Feld | Beispiel |
+|------|----------|
+| Name | Laserschneiden |
+| Zelle | Laser 1 |
+| Reihenfolge | 1 (erster Schritt) |
+| Geschätzte Zeit | 120 Minuten |
+| Tatsächliche Zeit | 95 Minuten (über Start/Stopp erfasst) |
+| Verbleibend | 25 Minuten (geschätzt minus tatsächlich) |
+| Status | not_started, in_progress, on_hold, completed |
+
+Arbeitsgänge können Folgendes haben:
+
+- **Metadaten** — Laserleistung, Geschwindigkeit, Gastyp, CNC-Programmname, Biegewinkel
+- **Unterschritte** — Aufteilung des Arbeitsgangs in kleinere Aufgaben (z.B. "Blech laden", "Programm fahren", "Kanten entgraten")
+- **Zeiterfassung** — Werker starten/stoppen einen Timer, die tatsächliche Zeit wird erfasst
+- **Problemmeldungen** — Werker melden Probleme mit Schweregrad, Beschreibung und Fotos
+- **Ressourcen** — verknüpfte Werkzeuge, Vorrichtungen, Formen die für diesen Schritt benötigt werden
+- **Angehalten** — pausiert ohne die Warteschlangenposition zu verlieren
+
+Wenn alle Arbeitsgänge an einem Teil abgeschlossen sind, ist das Teil fertig. Wenn alle Teile in einem Auftrag fertig sind, ist der Auftrag erledigt.
+
+## Charge (Batch)
+
+Eine Charge gruppiert Arbeitsgänge von verschiedenen Teilen, die zusammen verarbeitet werden. Der häufigste Anwendungsfall: **Laser-Schachtelung** — mehrere Teile aus demselben Blech geschnitten.
+
+| Feld | Beispiel |
+|------|----------|
+| Chargennummer | NEST-2026-0301 |
+| Typ | laser_nesting |
+| Material | S235 6mm |
+| Blechanzahl | 2 |
+| Zelle | Laserschneiden |
+
+Chargen können Folgendes haben:
+
+- **Schachtelungs-Metadaten** — Blechgröße (1500x3000), Ausnutzungsgrad, CAM-Programmreferenz
+- **Schachtelungsbild** — Upload des Schachtelungslayouts aus der CAM-Software
+- **Lebenszyklus** — Entwurf > in_progress > completed. Start und Stopp können durch einen Werker oder eine Maschine ausgelöst werden (CAD/CAM-Integration über API).
+- **Zeitverteilung** — wenn eine Charge abgeschlossen ist, wird die gesamte Produktionszeit auf alle enthaltenen Arbeitsgänge proportional zu ihrer geschätzten Zeit verteilt.
+
+## Was kann was enthalten
+
+| Fähigkeit | Auftrag | Teil | Arbeitsgang | Charge |
+|-----------|---------|------|-------------|--------|
+| Statusverfolgung | ja | ja | ja | ja |
+| Lieferdatum | ja | — | geplanter Start/Ende | — |
+| Dateien (STEP, PDF) | — | ja | — | Schachtelungsbild |
+| Benutzerdefinierte Metadaten (JSON) | ja | — | ja | Schachtelungs-Metadaten |
+| Notizen | ja | — | ja | ja |
+| Zeiterfassung (geschätzt/tatsächlich) | — | — | ja | ja (verteilt) |
+| Eilpriorität | — | ja | — | — |
+| Angehalten | — | — | ja | — |
+| Unterschritte | — | — | ja | — |
+| Problemmeldungen / NCR | — | — | ja | — |
+| Verknüpfte Ressourcen | — | — | ja | — |
+| Eltern-Kind (Baugruppe) | — | ja | — | übergeordnete Charge |
+| ERP-Sync (external_id) | ja | ja | ja | — |
+| Zugewiesener Werker | — | — | ja | — |
+| Abmessungen / Gewicht | — | ja | — | — |
+| Material / Dicke | — | ja | — | ja |
+| Zeichnungsnummer | — | ja | — | — |
+| CNC-Programmname | — | ja | — | — |
+
+Dateien (STEP-Modelle, PDF-Zeichnungen) werden an **Teile** angehängt, nicht an Aufträge oder Arbeitsgänge. Ein Arbeitsgang erbt seine Dateien vom übergeordneten Teil. Der 3D-Viewer und PDF-Viewer im Terminal zeigen die Dateien des Teils, zu dem der Arbeitsgang gehört.
+
+## Eilauftrag und Angehalten
+
+Dies sind die zwei Prioritätssteuerungen, die Meistern und Planern zur Verfügung stehen.
+
+### Eilauftrag (Bullet Card)
+
+Der Eilstatus wird auf einem **Teil** gesetzt. Er wirkt nach oben und außen:
+
+- Das Teil sortiert als erstes in jeder Tabelle und Warteschlange
+- Alle Arbeitsgänge an diesem Teil erben den Eilindikator
+- Wenn ein Teil in einem Auftrag als Eil markiert ist, zeigt der gesamte Auftrag in der Auftragstabelle als Eil an
+- Das Werker-Terminal hebt Eilzeilen mit einem roten Rand hervor
+- Die Statusleiste des Werkers wechselt zu einem Rot-zu-Grün-Streifenmuster, wenn ein Werker auf einem Eilarbeitsgang eingestempelt ist
+- Arbeitswarteschlange-Kanbanspalten zeigen ein Eilanzahl-Badge
+
+Schalten Sie den Eilstatus im Arbeitsgangdetailpanel um (die Schaltfläche setzt ihn am übergeordneten Teil) oder in der Teile-Verwaltungstabelle.
+
+Eil ist ein visuelles und Sortiersignal. Es blockiert oder ändert keine Planungslogik — es sagt Menschen "mach das zuerst."
+
+### Angehalten (On Hold)
+
+Angehalten wird auf einem **Arbeitsgang** gesetzt. Es betrifft nur diesen spezifischen Arbeitsgang:
+
+- Der Arbeitsgang bleibt in Warteschlangen sichtbar, zeigt aber ein Angehalten-Badge
+- Werker wissen, dass sie damit nicht beginnen sollen
+- Der Arbeitsgang kann weiterhin bearbeitet und aktualisiert werden, während er angehalten ist
+- Setzen Sie den Arbeitsgang fort, um ihn zum Status `not_started` zurückzusetzen
+
+Angehalten kaskadiert nicht. Das Anhalten eines Arbeitsgangs hat keinen Einfluss auf andere Arbeitsgänge am selben Teil oder Auftrag. Andere Arbeitsgänge laufen normal weiter.
+
+Schalten Sie Angehalten im Arbeitsgangdetailpanel um.
+
+## Beispiel: Geschweißte Baugruppe mit Schachtelung
+
+Ein Edelstahl-Lebensmittelschrank. Zwei Ebenen von Unterbaugruppen, mit lasergeschnittenen Teilen über gemeinsame Bleche geschachtelt.
+
+**Auftrag** — WO-2026-0142, Kunde: Precision Steel Ltd, Lieferdatum: 2026-05-15
+
+**Teile und Arbeitsfolge:**
+
+| Teil | Material | Mge | Übergeordnet | Arbeitsgänge |
+|------|----------|-----|--------------|--------------|
+| CABINET-ASSY | — | 1 | — | Montage (180 Min), QK (30 Min) |
+| FRAME-ASSY | — | 1 | CABINET-ASSY | WIG-Schweißen (240 Min), Beizen (90 Min) |
+| UPRIGHT-L | SS 316L 3mm | 2 | FRAME-ASSY | Laserschneiden (30 Min), Biegen (45 Min) |
+| UPRIGHT-R | SS 316L 3mm | 2 | FRAME-ASSY | Laserschneiden (30 Min), Biegen (45 Min) |
+| CROSS-BEAM | SS 316L 3mm | 4 | FRAME-ASSY | Laserschneiden (20 Min), Biegen (25 Min) |
+| LID | SS 304 2mm | 1 | CABINET-ASSY | Laserschneiden (15 Min), Biegen (20 Min), Schleifen (30 Min) |
+| BASE-PLATE | S235 6mm | 1 | CABINET-ASSY | Laserschneiden (10 Min) |
+
+**Schachtelungscharge** — NEST-0301: alle sieben Laserschneidarbeitsgänge gruppiert auf zwei Blechen (1500x3000, 87% Ausnutzung). Ein Schnittlauf, Zeit wird zurück auf jeden Arbeitsgang verteilt.
+
+**Montage-Ablauf:**
+
+1. Laser schneidet alle Teile in einer Charge. Teile werden nach dem Schneiden sortiert.
+2. Ständer und Querträger gehen zum Biegen, dann zum Schweißen, wo FRAME-ASSY aufgebaut wird.
+3. Werker startet FRAME-ASSY Schweißen — System warnt, wenn Unterteile unvollständig sind. Werker kann überschreiben.
+4. Nachdem FRAME-ASSY, LID und BASE-PLATE fertig sind, beginnt die CABINET-ASSY Montage. Gleiche Abhängigkeitsprüfung.
+5. Qualitätskontrolle schließt den Auftrag ab.
+
+**Dateien:** STEP-Modell und PDF-Zeichnung an jedem Teil. Baugruppenzeichnungen an CABINET-ASSY und FRAME-ASSY.
+
+**Metadaten an Arbeitsgängen:**
+
+| Arbeitsgang | Metadaten |
+|-------------|-----------|
+| Laserschneiden | `{"power": 4000, "speed": 12000, "gas": "N2", "program": "NEST-0301"}` |
+| Biegen | `{"bends": [90, 90, 135], "tool": "V16-88"}` |
+| WIG-Schweißen | `{"process": "TIG", "wire": "316L 1.0mm", "gas": "Argon", "cert_required": true}` |
+| Montage | `{"torque_specs": {"M8": 25, "M10": 45}}` |
+
+## Nächste Schritte
+
+- [API-Beispiele](/guides/api-examples/) — curl-Beispiele für Abfragen, Erstellen, Synchronisieren und CAD/CAM-Integration
+- [CSV-Import](/features/csv-import/) — Daten aus Tabellen importieren mit herunterladbaren Vorlagen
+- [Chargen & Schachtelung](/features/batch-management/) — wie Schachtelungschargen im Detail funktionieren
+- [Werkerhandbuch](/de/guides/operator-manual/) — wie Werker das Terminal und die Arbeitswarteschlange nutzen
+- [Adminhandbuch](/de/guides/admin-manual/) — wie Planer Aufträge, Zellen und Planung verwalten

--- a/website/src/content/docs/de/guides/faq.md
+++ b/website/src/content/docs/de/guides/faq.md
@@ -1,0 +1,60 @@
+---
+title: "Hilfe & Häufig Gestellte Fragen"
+description: "Häufig gestellte Fragen zu Eryxon Flow."
+---
+
+## Allgemeine Fragen
+
+### Was ist die Hierarchie in Eryxon Flow?
+1. **Auftrag (Job)** = Kundenauftrag (z.B. "PO-12345")
+2. **Teil (Part)** = Bauteil (z.B. "Halterung A")
+3. **Arbeitsgang (Operation)** = Aufgabe (z.B. "Laserschneiden", "Biegen")
+
+### Wie funktionieren Baugruppen?
+Baugruppen sind Teile, die andere Teile enthalten.
+```
+Halterung Baugruppe (Übergeordnet)
+├── Linke Platte (Unterteil)
+├── Rechte Platte (Unterteil)
+```
+Jedes Teil wird einzeln mit eigenen Arbeitsgängen verfolgt.
+
+### Was ist QRM?
+**Quick Response Manufacturing (QRM)** ist eine Methodik zur Verkürzung von Durchlaufzeiten. Eryxon Flow verwendet es zur Verwaltung des **UB (Umlaufbestand / Work In Progress)**. Wenn eine Zelle "Auf Kapazität" steht, verhindert das System Überproduktion, indem es vorgelagerte Abschlüsse blockiert.
+
+### Was ist eine Bullet Card?
+Eine **Bullet Card** ist die Eilmarkierung auf einem Teil. Wenn aktiviert, springt das Teil an die Spitze jeder Warteschlange und Tabelle. Alle Arbeitsgänge an diesem Teil erben den Eilindikator. Verwenden Sie es sparsam — wenn alles Eil ist, ist nichts Eil.
+
+### Was ist POLCA?
+**POLCA** (Paired-cell Overlapping Loops of Cards with Authorization) ist ein System zur Arbeitslastverwaltung. In Eryxon Flow erscheint es als GO/PAUSE-Signale am Terminal. **GO** bedeutet, die nächste Zelle hat Kapazität. **PAUSE** bedeutet, die nächste Zelle ist voll — warten Sie mit dem Abschluss, um einen Stau zu vermeiden.
+
+### Was sind Zellen und Stufen?
+**Zellen** (auch **Stufen** genannt) repräsentieren physische Arbeitsplätze oder Abteilungen in Ihrer Werkstatt — wie "Laser 1", "Abkantpresse", "Schweißen" oder "Montage". Arbeitsgänge werden Zellen zugewiesen. Jede Zelle hat eine UB-Grenze und Kapazitätsstunden.
+
+### Was ist die Kapazitätsmatrix?
+Eine visuelle Übersicht der Auslastung pro Zelle pro Tag. Jede Zelle ist eine Zeile, jeder Tag eine Spalte. Farbcodierung zeigt verfügbar (grün), belastet (gelb) und überlastet (rot). Verwenden Sie sie, um Engpässe zu erkennen, bevor sie die Werkstatt erreichen.
+
+### Wie funktioniert die Zeiterfassung?
+Werker tippen auf **Start**, um einen Timer zu starten, und **Stopp**, um ihn zu pausieren. Es kann nur ein Arbeitsgang gleichzeitig gemessen werden. Das Starten eines neuen Arbeitsgangs stoppt automatisch den vorherigen. Der laufende Timer ist immer in der Statusleiste sichtbar.
+
+### Was sind Problemmeldungen (NCRs)?
+Problemmeldungen sind Qualitätsprobleme, die Werker aus aktiven Arbeitsgängen melden — falsches Material, beschädigte Teile, Maschinenprobleme, Zeichnungsfehler. Sie haben einen Schweregrad (niedrig/mittel/hoch/kritisch) und können Fotos enthalten. Problemmeldungen sind informativ — sie blockieren die Arbeit nicht.
+
+### Was sind Metadaten?
+Arbeitsgänge und Aufträge unterstützen **benutzerdefinierte JSON-Metadaten** — Maschineneinstellungen, Biegewinkel, Schweißparameter, Werkzeuganforderungen. Dies sind freie Felder, die Sie nach den Bedürfnissen Ihrer Werkstatt ausfüllen können.
+
+### Was ist eine Charge (Batch)?
+Eine **Charge** gruppiert Arbeitsgänge von verschiedenen Teilen, die zusammen verarbeitet werden. Am häufigsten bei der Laser-Schachtelung: mehrere Teile werden aus demselben Blech geschnitten. Die Produktionszeit wird proportional auf alle enthaltenen Arbeitsgänge verteilt.
+
+### Was ist der Fabrikkalender?
+Der **Fabrikkalender** definiert Arbeitstage und Feiertage. Der Auto-Planer überspringt arbeitsfreie Tage automatisch bei der Terminberechnung. Konfigurieren Sie ihn unter Einstellungen, bevor Sie die erste Planung ausführen.
+
+## Spezialisierte Anleitungen
+
+Für detaillierte Anweisungen siehe:
+
+- **[Werkerhandbuch](/de/guides/operator-manual/)** - Täglicher Arbeitsablauf, Terminal-Info, Zeiterfassung.
+- **[Adminhandbuch](/de/guides/admin-manual/)** - Auftragserstellung, Benutzer, Einstellungen.
+- **[Qualitätsmanagement](/guides/quality-management/)** - Ausschussverfolgung und Dashboards.
+- **[Fehlerbehebung](/guides/troubleshooting/)** - Häufige Fehler und Lösungen.
+- **[Self-Hosting](/guides/self-hosting/)** - Installationsanleitung.

--- a/website/src/content/docs/de/guides/operator-manual.md
+++ b/website/src/content/docs/de/guides/operator-manual.md
@@ -1,0 +1,133 @@
+---
+title: Werkerhandbuch
+description: Wie Sie Eryxon Flow als Werker verwenden — Arbeitswarteschlange, Terminal, Zeiterfassung.
+---
+
+Dieses Handbuch behandelt alles, was Sie brauchen, um mit Eryxon Flow in der Werkstatt zu arbeiten. Es gibt zwei Hauptoberflächen: die **Arbeitswarteschlange** für den Desktop und das **Terminal** für fest installierte Werkstationsbildschirme. Beide zeigen dieselbe Arbeit — nur anders dargestellt.
+
+## Arbeitswarteschlange (Kanban)
+
+Die Arbeitswarteschlange ist Ihre Standardansicht nach dem Einloggen. Sie zeigt Arbeitsgänge als Karten auf einem Kanban-Board.
+
+### Aufbau
+
+Jede **Spalte** repräsentiert eine Zelle (Arbeitsplatz) in der Werkstatt. Karten innerhalb einer Spalte sind die Arbeitsgänge, die an dieser Zelle warten oder in Bearbeitung sind. Spaltenköpfe zeigen Summen: Arbeitsstunden in der Warteschlange, Stückzahl und wie viele Eilaufträge in der Spalte sind.
+
+### Eine Karte lesen
+
+Jede Karte zeigt:
+
+- **Auftragsnummer** und Teilename
+- **Arbeitsgang** Name (z.B. "Biegen", "Schweißen")
+- **Material** Typ und Dicke
+- **Geschätzte Stunden** verbleibend
+- **Lieferdatum** mit Dringlichkeitsfärbung — Überfälliges fällt sofort auf
+
+### Ihre Arbeit finden
+
+- **Suchen** nach Auftragsnummer, Teilename, Arbeitsgangname oder Kunde
+- **Filtern** nach Status (aktiv, alle, nicht gestartet, in Bearbeitung) und Lieferdatum (überfällig, heute, diese Woche)
+- **Sortieren** nach Reihenfolge, Lieferdatum oder geschätzter Zeit
+
+Wenn Sie nichts sehen: Prüfen Sie, ob Ihre Filter zurückgesetzt sind. Wenn es immer noch leer ist, wurde noch keine Arbeit Ihrer Zelle zugewiesen.
+
+### Karten-Badges
+
+- **Eil** (rot) — dieser Auftrag hat Vorrang vor allem anderen. Eilaufträge sortieren automatisch nach oben.
+- **Angehalten** (gelb) — dieser Arbeitsgang ist pausiert. Beginnen Sie nicht damit, bis der Halt aufgehoben ist.
+
+### Detailpanel
+
+Klicken Sie auf eine Karte, um das Detailpanel auf der rechten Seite zu öffnen. Hier sehen Sie:
+
+- Vollständige Teileinformationen (Kunde, Menge, Material)
+- Komplette Arbeitsfolge — jeder Arbeitsgang in Reihenfolge, als visueller Fluss durch die Zellen dargestellt
+- Angehängte Dateien: 3D-Modell-Viewer für STEP-Dateien, PDF-Viewer für Zeichnungen
+- Eil- und Halt-Schalter — markieren Sie einen Arbeitsgang als Eil oder setzen Sie ihn auf Halt
+- Zeiterfassungssteuerung (Start, Stopp, Fertig)
+
+## Terminal-Ansicht
+
+Das Terminal ist für fest installierte Bildschirme an einem Arbeitsplatz gebaut. Es funktioniert gut auf Touch-Geräten und Tablets. Verwenden Sie es, wenn Sie für Ihre Schicht an einer Zelle stationiert sind.
+
+### Erste Schritte
+
+Wählen Sie Ihre Zelle aus dem **Zellenselektor** in der Kopfzeile. Das Terminal zeigt dann nur Arbeit für diese Zelle, aufgeteilt in drei Warteschlangen:
+
+- **In Bearbeitung** (grün) — Arbeitsgänge, an denen Sie gerade aktiv arbeiten
+- **Im Puffer** (blau) — die nächsten Arbeitsgänge, bereit zum Starten, bereits an Ihrer Zelle
+- **Erwartet** (gelb) — anstehende Arbeit, die an Ihrer Zelle eintreffen wird
+
+### Statusleiste
+
+Die Leiste unter der Kopfzeile zeigt:
+
+- Ihren Werkernamen
+- Den Arbeitsgang, an dem Sie gerade arbeiten, und zu welchem Auftrag er gehört
+- Einen laufenden Timer seit dem Start
+- Diagonale Streifenmuster, die sich je nach Status ändern: grün bei aktiver Arbeit, gelbe Streifen wenn nicht eingestempelt, Rot-zu-Grün-Verlauf bei einem Eilauftrag
+
+### POLCA-Zellensignale
+
+Die Zellenspalte zeigt ein Signal für jeden Arbeitsgang: die **aktuelle Zelle** und die **nächste Zelle** in der Arbeitsfolge, mit einem Kapazitätsindikator:
+
+- **GO** (Play-Symbol) — die nächste Zelle hat Kapazität. Sie können Ihren Arbeitsgang abschließen und das Teil fließt reibungslos weiter.
+- **PAUSE** (Pause-Symbol) — die nächste Zelle ist ausgelastet. Ihren Arbeitsgang jetzt abzuschließen würde einen Stau verursachen.
+
+Dies verhindert Engpässe. Das System verwaltet Umlaufbestandsgrenzen pro Zelle.
+
+### Rückstandsstatus
+
+Arbeitsgänge zeigen ein Rückstandslabel, wenn Fristen nahen:
+
+- **Überfällig** — über dem Termin, sollte bereits erledigt sein
+- **Heute** — heute fällig
+- **Demnächst** — fällig innerhalb weniger Tage
+
+### Detail-Seitenleiste
+
+Tippen Sie auf einen Arbeitsgang, um die Seitenleiste rechts zu öffnen:
+
+- **3D-Viewer** — drehen und zoomen Sie das Teilemodell (wenn eine STEP-Datei angehängt ist)
+- **PDF-Viewer** — betrachten Sie die technische Zeichnung
+- **Arbeitsfolge** — sehen Sie die vollständige Reihenfolge der Arbeitsgänge und wohin das Teil als nächstes geht
+
+## Zeiterfassung
+
+Die Zeiterfassung verknüpft Ihre Arbeit mit jedem Arbeitsgang.
+
+### So funktioniert es
+
+1. **Start** — tippen Sie auf "Start" beim Arbeitsgang, an dem Sie arbeiten werden. Der Timer beginnt und der Arbeitsgang wechselt zu "In Bearbeitung."
+2. **Stopp** — tippen Sie auf "Stopp", wenn die physische Arbeit erledigt ist.
+3. **Fertig** — markieren Sie den Arbeitsgang als fertig, um ihn zur nächsten Zelle zu verschieben.
+
+Es kann nur **ein Arbeitsgang** gleichzeitig gemessen werden. Das Starten eines neuen Arbeitsgangs stoppt den vorherigen.
+
+Der laufende Timer ist immer in der Statusleiste sichtbar, damit Sie nie vergessen zu stoppen.
+
+## Probleme Melden
+
+Wenn etwas schiefgeht — falsches Material, beschädigtes Teil, Maschinenproblem, Zeichnungsfehler — melden Sie es sofort.
+
+### Schritte
+
+1. Öffnen Sie das Arbeitsgangdetail (aus der Arbeitswarteschlange oder dem Terminal)
+2. Tippen Sie auf **Problem Melden**
+3. Wählen Sie einen Schweregrad:
+   - **Niedrig** — gering, blockiert die Arbeit nicht
+   - **Mittel** — braucht Aufmerksamkeit, aber Sie können weiterarbeiten
+   - **Hoch** — blockiert diesen Arbeitsgang
+   - **Kritisch** — Sicherheitsrisiko oder großer Produktionsstopp
+4. Beschreiben Sie das Problem
+5. **Fotos hinzufügen** — machen Sie ein Foto mit Ihrem Handy oder Tablet
+6. Absenden
+
+Die Problemmeldung geht sofort in die Admin-Problemwarteschlange.
+
+## Tipps
+
+- Starten Sie immer Ihren Timer, bevor Sie mit der physischen Arbeit beginnen.
+- Prüfen Sie die POLCA-Signale, bevor Sie einen Arbeitsgang abschließen. Wenn die nächste Zelle PAUSE zeigt, fragen Sie Ihren Vorgesetzten.
+- Melden Sie Probleme in dem Moment, in dem Sie sie entdecken. Ein Foto sagt mehr als tausend Worte.
+- Wenn Ihr Bildschirm leer aussieht, setzen Sie zuerst alle Filter zurück.

--- a/website/src/content/docs/de/guides/quick-start.md
+++ b/website/src/content/docs/de/guides/quick-start.md
@@ -1,0 +1,184 @@
+---
+title: "Schnellstart"
+description: "Eryxon Flow in wenigen Minuten einrichten und verwenden."
+---
+
+Eryxon Flow schnell einrichten.
+
+> **Einfach ausprobieren?** Testen Sie die [Live-Demo auf app.eryxon.eu](https://app.eryxon.eu) — keine Einrichtung nötig. Registrieren und sofort loslegen.
+
+---
+
+## Voraussetzungen
+
+- Node.js 20+ ([Download](https://nodejs.org))
+- Ein Supabase-Konto (kostenloser Tarif reicht) - [Anmelden](https://supabase.com)
+
+---
+
+## Schritt 1: Supabase Einrichten
+
+### 1.1 Projekt Erstellen
+
+1. Gehen Sie zu [supabase.com](https://supabase.com) → **New Project**
+2. Benennen Sie es `eryxon-flow`
+3. Speichern Sie Ihr Datenbank-Passwort
+4. Klicken Sie auf **Create**
+
+### 1.2 Ihre Schlüssel Abrufen
+
+Gehen Sie zu **Settings** → **API** und kopieren Sie:
+- **Project URL** (z.B. `https://abc123.supabase.co`)
+- **anon public key** (beginnt mit `eyJ...`)
+
+### 1.3 Datenbankschema Anwenden
+
+Verwenden Sie die Supabase CLI für Ihr Zielprojekt:
+
+```bash
+supabase link --project-ref YOUR_PROJECT_REF
+supabase db push
+```
+
+### 1.4 Seed-Daten Anwenden
+
+Die Seed-Datei richtet Speicherrichtlinien, RLS-Standardwerte und Cron-Jobs ein:
+
+```bash
+supabase db execute --file supabase/seed.sql
+```
+
+### 1.5 Speicher-Buckets Erstellen
+
+```bash
+supabase storage create parts-images
+supabase storage create issues
+supabase storage create parts-cad
+supabase storage create batch-images
+```
+
+### 1.6 Edge Functions Bereitstellen
+
+```bash
+supabase functions deploy
+```
+
+### 1.7 Edge Function Secrets Setzen
+
+Gehen Sie zu **Settings** → **API** und kopieren Sie den **service_role** Schlüssel, dann:
+
+```bash
+supabase secrets set SUPABASE_URL=https://YOUR_PROJECT_REF.supabase.co SUPABASE_SERVICE_ROLE_KEY=YOUR_SERVICE_ROLE_KEY
+```
+
+Konfigurieren Sie den `notify-new-signup` Database Webhook nachdem die Migrationen angewendet wurden (siehe [Self-Hosting-Anleitung](/guides/self-hosting/)).
+
+> **Automatisierung bevorzugt?** Führen Sie `bash scripts/setup.sh` aus — es führt Sie interaktiv durch alles oben Genannte.
+
+---
+
+## Schritt 2: Die Anwendung Starten
+
+```bash
+git clone https://github.com/SheetMetalConnect/eryxon-flow.git
+cd eryxon-flow
+
+npm install
+
+cp .env.example .env
+```
+
+Bearbeiten Sie `.env`:
+```bash
+VITE_SUPABASE_URL=https://your-project-id.supabase.co
+VITE_SUPABASE_PUBLISHABLE_KEY=your-anon-key
+VITE_SUPABASE_PROJECT_ID=your-project-id
+```
+
+Starten Sie die App:
+```bash
+npm run dev
+```
+
+Öffnen Sie **http://localhost:8080**
+
+---
+
+## Schritt 3: Ihr Konto Erstellen
+
+1. Klicken Sie auf **Sign Up**
+2. Geben Sie E-Mail und Passwort ein
+3. Bestätigen Sie Ihre E-Mail (Posteingang prüfen)
+4. Sie sind jetzt Admin Ihrer Organisation!
+
+---
+
+## Schritt 4: Erkunden (Optional)
+
+### Demo-Daten Laden
+
+Möchten Sie die App mit Beispieldaten sehen?
+
+1. Gehen Sie zu **Settings** in der Admin-Seitenleiste
+2. Klicken Sie auf **Create Demo Data**
+3. Erkunden Sie Beispiel-Aufträge, Teile und Arbeitsgänge
+
+### Schnelle Rundführung
+
+| Seite | Was sie tut |
+|-------|------------|
+| `/admin/dashboard` | Produktionsübersicht |
+| `/admin/jobs` | Fertigungsaufträge verwalten |
+| `/admin/jobs/new` | Neuen Auftrag erstellen |
+| `/operator/work-queue` | Aufgabenliste Werker |
+| `/operator/login` | Terminal-Anmeldung Werkstatt |
+| `/admin/config/stages` | Arbeitsstufen konfigurieren |
+
+---
+
+## Was Nun?
+
+**Einrichtung & Deployment:**
+- [Deployment-Anleitung](/guides/deployment/) - Optionen für Produktions-Deployment
+- [Self-Hosting-Anleitung](/guides/self-hosting/) - Umgebungs- und Ausrolldetails
+- [MCP Server Setup](/guides/mcp-setup/) - KI-Assistenten-Integration einrichten
+
+**API & Integration:**
+- [REST API Übersicht](/architecture/connectivity-rest-api/) - Integrationsarchitektur
+- [REST API Referenz](/api/rest-api-reference/) - Vollständige Endpoint-Referenz
+- [API Payload Referenz](/api/payload-reference/) - Kopier-und-Einfüge-Payload-Beispiele
+- [MCP Demo-Anleitung](/api/mcp-demo-guide/) - Beispiele für KI-Assistenten-Nutzung
+- [Webhooks & MQTT](/architecture/connectivity-mqtt/) - Event-gesteuerte Integration
+- **Swagger/OpenAPI** - In der App verfügbar unter `/admin/api-docs` (Anmeldung erforderlich)
+
+**Architektur & Hilfe:**
+- [App-Architektur](/architecture/app-architecture/) - Systemdesign-Übersicht
+- [FAQ](/de/guides/faq) - Häufig gestellte Fragen
+
+---
+
+## Häufige Probleme
+
+**Kann mich nicht registrieren?**
+- Prüfen Sie, ob Ihre Supabase URL in `.env` korrekt ist
+- Überprüfen Sie die E-Mail-Einstellungen im Supabase Auth-Dashboard
+
+**Datenbankfehler?**
+- Stellen Sie sicher, dass Sie das Schema-SQL ausgeführt haben
+- Prüfen Sie den SQL Editor auf Fehler
+
+**Seite lädt nicht?**
+- Vergewissern Sie sich, dass beide Umgebungsvariablen gesetzt sind
+- Prüfen Sie die Browser-Konsole auf Fehler
+
+---
+
+## Hilfe Benötigt?
+
+- Beginnen Sie bei der [Dokumentations-Startseite](/)
+- Erstellen Sie ein Issue auf GitHub
+- Beteiligen Sie sich an unseren Community-Diskussionen
+
+---
+
+*Viel Erfolg in der Fertigung!*

--- a/website/src/content/docs/de/introduction.md
+++ b/website/src/content/docs/de/introduction.md
@@ -1,0 +1,104 @@
+---
+title: Willkommen bei Eryxon Flow
+description: Das einfache, elegante und leistungsstarke Manufacturing Execution System, mit dem Ihre Mitarbeiter gerne arbeiten. Entwickelt für die Blechbearbeitung.
+---
+
+**Das einfache, elegante und leistungsstarke Manufacturing Execution System, mit dem Ihre Mitarbeiter gerne arbeiten. Entwickelt für die Blechbearbeitung.**
+
+> **Jetzt ausprobieren:** Erkunden Sie die [Live-Demo auf app.eryxon.eu](https://app.eryxon.eu) — keine Installation erforderlich.
+
+## Was Es Macht
+
+Eryxon verfolgt Aufträge, Teile und Aufgaben durch die Produktion mit einer mobil- und tabletfreundlichen Oberfläche. Daten kommen über eine API aus Ihrem ERP.
+
+### Für Werker
+Die Oberfläche zeigt, woran gearbeitet werden muss, gruppiert nach Materialien und Fertigungsstufen — organisiert so, wie Ihre Werkstatt läuft, nicht wie Buchhalter denken.
+- **Visuelle Indikatoren** (Farben, Bilder) machen Aufgaben sofort erkennbar.
+- **STEP-Datei-Viewer** zeigt die Geometrie.
+- **PDF-Viewer** zeigt die Zeichnungen.
+- Start- und Stoppzeit bei Aufgaben erfassen.
+- Probleme melden, wenn etwas nicht stimmt.
+
+Alles was nötig ist, nichts Überflüssiges.
+
+### Für Administratoren
+Sehen Sie in Echtzeit, wer woran arbeitet.
+- Bestimmte Arbeit bestimmten Personen zuweisen.
+- Problemmeldungen prüfen und genehmigen.
+- Termine bei Bedarf überschreiben.
+- Stufen, Materialien und Vorlagen konfigurieren.
+
+Echte Einblicke in die Werkstattaktivitäten, ohne die Halle betreten zu müssen.
+
+### Arbeitsorganisation
+Arbeit wird **Kanban-artig** mit visuellen Spalten pro Stufe dargestellt. Werker sehen, was verfügbar ist, und ziehen Arbeit, wenn sie bereit sind — nicht durch einen Zeitplan geschoben. Stufen repräsentieren Fertigungszonen (Schneiden, Biegen, Schweißen, Montage).
+
+**Quick Response Manufacturing (QRM)** Prinzipien sind eingebaut:
+- Visuelle Indikatoren zeigen, wenn zu viele Aufträge oder Teile in derselben Stufe sind.
+- Umlaufbestand (WIP) pro Stufe begrenzen, um den Durchfluss aufrechtzuerhalten.
+- Fortschritt nach Stufenabschluss verfolgen, nicht nur einzelne Bearbeitungszeiten.
+- Zeiterfassung zeigt, was noch übrig ist, nicht nur was erledigt wurde.
+- **Echtzeit-Updates** — Änderungen erscheinen sofort auf allen Bildschirmen.
+
+### Flexible Daten
+Aufträge, Teile und Aufgaben unterstützen **benutzerdefinierte JSON-Metadaten** — Maschineneinstellungen, Biegefolgen, Schweißparameter. Definieren Sie wiederverwendbare Ressourcen wie Formen, Werkzeuge, Vorrichtungen oder Materialien und verknüpfen Sie diese mit der Arbeit. Werker sehen, was benötigt wird, und etwaige benutzerdefinierte Anweisungen in der Aufgabenansicht.
+
+---
+
+## Benutzer & Rollen
+
+### Werker
+Sehen ihre Arbeitswarteschlange, erfassen Start-/Stoppzeiten, markieren Aufgaben als erledigt, betrachten Dateien und melden Qualitätsprobleme.
+
+### Administratoren
+Können alles, was Werker können, plus: bestimmte Arbeit bestimmten Personen zuweisen, Probleme verwalten, Termine überschreiben und Stufen/Materialien/Vorlagen konfigurieren.
+
+> **Hinweis:** Werker-Konten können als Maschinen markiert werden für autonome Prozesse.
+
+---
+
+## Echtzeit-Einblick
+
+Verfolgen Sie in Echtzeit, wer anwesend ist und woran gearbeitet wird. Kein Raten, keine Verzögerungen. Änderungen erscheinen sofort auf allen Bildschirmen über **WebSocket-Updates**.
+
+---
+
+## Integration-First-Architektur
+
+**100% API-gesteuert.** Ihr ERP sendet Aufträge, Teile und Aufgaben über die REST-API. Eryxon sendet Abschlussereignisse zurück über Webhooks. Der MCP-Server ermöglicht KI/Automatisierungs-Integration.
+
+### Dateihandhabung
+Fordern Sie eine signierte Upload-URL über die API an, laden Sie STEP- und PDF-Dateien direkt in den Supabase Storage hoch und referenzieren Sie dann den Dateipfad beim Erstellen von Aufträgen oder Teilen. Große Dateien (typisch 5-50 MB) werden direkt in den Speicher hochgeladen — keine Timeouts, keine API-Engpässe.
+
+### Benutzerdefinierte Metadaten
+Fügen Sie JSON-Payloads zu Aufträgen, Teilen und Aufgaben hinzu für Ihre spezifischen Anforderungen — Werkzeuganforderungen, Formnummern, Maschineneinstellungen, Materialspezifikationen, alles was Ihre Werkstatt nachverfolgen muss.
+
+### ERP-Integrationen
+Partner wie **Sheet Metal Connect e.U.** bauen Integrationen für gängige ERP-Systeme. Oder bauen Sie Ihre eigene mit unseren GitHub-Starter-Kits mit Beispielcode und Dokumentation.
+
+### Montage-Verfolgung
+Teile können Eltern-Kind-Beziehungen haben. Visuelle Gruppierung zeigt Baugruppen mit verschachtelten Komponenten. Nicht-blockierende Abhängigkeitswarnungen erinnern Werker daran, wann Unterteile fertig sein sollten, bevor Montageaufgaben beginnen — sie können dies aber bei Bedarf überschreiben.
+
+### Problemmeldung
+Werker erstellen Problemmeldungen (NCRs) aus aktiven Aufgaben mit Beschreibung, Schweregrad und optionalen Fotos. Einfacher Genehmigungsworkflow: ausstehend → genehmigt/abgelehnt → geschlossen. Problemmeldungen sind informativ — sie blockieren nicht den Arbeitsfortschritt.
+
+---
+
+## Was Wir Nicht Tun (Bewusst)
+
+*   **Keine Finanzverfolgung.** Wir erfassen die Arbeitszeit, nicht Kosten, Preise oder Margen.
+*   **Kein Einkauf.** Aufgaben können als extern markiert werden (Fremdvergabe) und der Status kann über die API verfolgt werden, aber es gibt keine Bestellverwaltung oder Lieferantentransaktionen.
+*   **Keine Stücklistenverwaltung.** Wir verfolgen, was produziert werden muss, nicht Artikeldetails oder Bestände. Teile können Eltern-Kind-Verknüpfungen für Montagevisualisierung haben, aber keine mehrstufigen Stücklisten, die nicht in der Produktion leben.
+*   **Keine Planung.** Termine kommen meist aus Ihrem ERP, aber Administratoren können diese jederzeit manuell überschreiben. Wir berechnen oder optimieren keine Zeitpläne — Sie behalten die Kontrolle.
+*   **Keine Berichte.** Nur Echtzeit-Statistikpanels. Keine eingebauten historischen Analysen — aber alle Daten sind über API/MCP für Ihre eigenen Berichte zugänglich.
+
+---
+
+## Technischer Stack
+
+*   **Frontend:** React + TypeScript
+*   **Backend:** Supabase (PostgreSQL, Edge Functions, Realtime, Storage)
+*   **Auth:** JWT-basiert mit rollenbasierter Zugriffskontrolle
+*   **Dateien:** Supabase Storage mit signierten URLs
+*   **STEP-Viewer:** occt-import-js für clientseitiges STEP-Parsing + Three.js-Rendering
+*   **Integration:** REST-API, Webhooks, MCP-Server

--- a/website/src/content/docs/nl/guides/admin-manual.md
+++ b/website/src/content/docs/nl/guides/admin-manual.md
@@ -1,0 +1,173 @@
+---
+title: Handleiding Admin
+description: Hoe productie te beheren in Eryxon Flow — jobs, cellen, planning, kwaliteit.
+---
+
+Deze handleiding behandelt alles wat een productiemanager of planner nodig heeft om de dagelijkse operaties in Eryxon Flow te draaien. Het gaat ervan uit dat je account admin-toegang heeft.
+
+## Dashboard
+
+Het dashboard is je startscherm. Het toont:
+
+- **Actieve operators** — wie is ingelogd en werkt er op dit moment.
+- **Openstaande issues** — kwaliteitsproblemen gemeld vanaf de werkvloer, wachtend op je beoordeling.
+- **OHW per cel** — hoeveel bewerkingen actief zijn in elke productiecel, afgezet tegen de OHW-limiet van de cel.
+- **Leverdata** — aankomende deadlines over alle actieve jobs, gesorteerd op urgentie.
+
+Alle data wordt in realtime bijgewerkt. Wanneer een operator een start of einde scant op de terminal, wordt het dashboard binnen seconden bijgewerkt.
+
+## Jobs Beheren
+
+### Jobhierarchie
+
+Elke job volgt dezelfde structuur: **Job > Onderdelen > Bewerkingen**.
+
+- Een **job** vertegenwoordigt een klantenorder of intern project. Het bevat de klantnaam, jobnummer en leverdatum.
+- Een **onderdeel** is een fysiek item dat geproduceerd moet worden. Elk onderdeel heeft een materiaal, hoeveelheid en tekeningreferentie.
+- Een **bewerking** is een enkele productiestap op een onderdeel — snijden, kanten, lassen, lakken, enz. Bewerkingen zijn gekoppeld aan een productiecel en hebben een geschatte tijd.
+
+### Een job aanmaken
+
+1. Ga naar **Jobs** en klik op **Nieuwe Job Aanmaken**.
+2. Vul het jobnummer, de klant en de leverdatum in.
+3. Voeg een of meer onderdelen toe. Stel voor elk onderdeel het onderdeelnummer, materiaal en hoeveelheid in.
+4. Voeg bewerkingen toe aan elk onderdeel. Selecteer voor elke bewerking de cel, stel de geschatte tijd in en definieer de volgorde.
+
+Je kunt ook `Cmd/Ctrl + N` gebruiken vanuit elke plek om het snelcreatiemenu te openen.
+
+### Spoedorders (bullet card)
+
+Wanneer een onderdeel de wachtrij moet passeren, markeer het als **bullet card** (spoed). Dit doet globaal drie dingen:
+
+- Het onderdeel gaat naar de top van elke tabel en werkwachtrij, over alle cellen.
+- Operators zien een duidelijke spoedindicator op hun terminal.
+- Het onderdeel blijft geprioriteerd totdat je de spoedvlag verwijdert.
+
+Gebruik dit spaarzaam. Als alles spoed is, is niets spoed.
+
+### Bewerkingen in wacht zetten
+
+Je kunt elke bewerking in wacht zetten vanuit het bewerkingsdetailpaneel. Een bewerking in wacht blijft zichtbaar in de werkwachtrij maar is gemarkeerd met een wachtbadge zodat operators weten dat ze er niet aan moeten beginnen. Hervat het wanneer de blokkade is opgeheven.
+
+## Productiecellen (Stadia)
+
+Cellen vertegenwoordigen je fysieke werkstations of afdelingen — lasersnijden, kantbank, lassen, assemblage, verzending.
+
+### Een cel configureren
+
+Ga naar **Stadia & Cellen** in de admin-zijbalk. Voor elke cel kun je instellen:
+
+- **Naam** — wat operators op de terminal zien (bijv. "Laser 1", "Kantbank").
+- **Kleur** — gebruikt door de hele interface voor visuele herkenning.
+- **Icoon** — verschijnt op de terminal en in de capaciteitsmatrix.
+- **Volgorde** — de standaardvolgorde waarin cellen in weergaven en planning verschijnen.
+
+### OHW-limieten
+
+Elke cel heeft een OHW-limiet (Onderhanden Werk). Dit bepaalt hoeveel bewerkingen tegelijkertijd actief kunnen zijn.
+
+- **Waarschuwingsdrempel** — de interface markeert de cel wanneer deze de limiet nadert.
+- **Limiet afdwingen** — indien ingeschakeld, blokkeert het systeem de vorige bewerking van voltooiing als de volgende cel op capaciteit zit. Dit voorkomt dat werk zich ophoopt bij een knelpunt.
+
+Stel OHW-limieten in op basis van je daadwerkelijke stationcapaciteit. Begin conservatief en pas aan op basis van wat je observeert.
+
+### Capaciteitsuren
+
+Definieer hoeveel productieuren elke cel per dag heeft. De planner gebruikt dit om de belasting te berekenen en te markeren wanneer dagen overbelast zijn.
+
+## Planning en Capaciteit
+
+### Auto-planner
+
+De auto-planner wijst bewerkingen toe aan tijdslots op basis van:
+
+- Bewerkingsvolgorde binnen elk onderdeel.
+- Geschatte uren per bewerking.
+- Celcapaciteit per dag.
+- Leverdata van jobs.
+
+Draai de planner na het toevoegen van nieuwe jobs of wanneer prioriteiten veranderen. Het herberekent het volledige schema en werkt de capaciteitsmatrix bij.
+
+### Capaciteitsmatrix
+
+De capaciteitsmatrix geeft je een vogelvluchtperspectief van de belasting per cel per dag. Elke cel verschijnt als een rij, elke dag als een kolom. Kleurcodering geeft beschikbare, belaste en overbelaste statussen aan.
+
+Gebruik dit om knelpunten te herkennen voordat ze de werkvloer bereiken. Als een cel over drie dagen rood toont, weet je dat je nu moet handelen — werk verplaatsen, een dienst toevoegen of leverdata aanpassen.
+
+### Leverdatum-overschrijvingen
+
+Wanneer een klant de deadline wijzigt, werk de leverdatum bij op de job. De planner pakt de wijziging op bij de volgende run.
+
+### Fabriekskalender
+
+De fabriekskalender definieert werkdagen en feestdagen. De planner slaat niet-werkdagen automatisch over. Configureer dit in **Instellingen** voordat je je eerste planning draait.
+
+## Batchbeheer
+
+Batches groeperen bewerkingen voor nesting of gecombineerde verwerking — gebruikelijk bij lasersnijden waar meerdere onderdelen dezelfde plaat delen.
+
+### Werken met batches
+
+1. Maak een batch aan en geef deze een naam of nummer.
+2. Wijs bewerkingen van verschillende onderdelen toe aan de batch.
+3. Volg de materiaaltoewijzing voor de batch.
+
+Wanneer een operator een batch verwerkt, vorderen alle opgenomen bewerkingen samen.
+
+## Toewijzingen en Gebruikers
+
+### Werk toewijzen
+
+Ga naar de **Toewijzingen**-pagina om specifieke bewerkingen aan operators toe te wijzen. Selecteer het onderdeel, kies de operator en bevestig. De toewijzing verschijnt onmiddellijk in de werkwachtrij van de operator.
+
+Je kunt operators ook zelf laten toewijzen uit beschikbaar werk in hun cel.
+
+### Rollen
+
+- **Admin** — volledige toegang tot alle instellingen, jobs, planning, data en gebruikersbeheer.
+- **Operator** — toegang tot hun werkwachtrij, de terminal en issuerapportage. Operators kunnen geen jobs wijzigen, planningen veranderen of instellingen openen.
+
+Beheer gebruikers in **Instellingen > Gebruikers**.
+
+## Kwaliteit en Issues
+
+Operators melden issues direct vanuit de terminal — verkeerd materiaal, beschadigde onderdelen, ontbrekende tekeningen, machineproblemen.
+
+### Issues beoordelen
+
+1. Ga naar de **Issues**-pagina.
+2. Elke issue toont het onderdeel, de bewerking, de operator en de beschrijving.
+3. Kies een actie:
+   - **Goedkeuren** — bevestigt dat het een geldig issue is. Logt het voor kwaliteitsregistratie.
+   - **Afwijzen** — het is geen daadwerkelijk issue. Voeg een notitie toe die uitlegt waarom.
+   - **Sluiten** — het issue is opgelost. Voeg oplossingsnotities toe.
+
+Reageer snel op issues. Onopgeloste issues blokkeren operators en vertragen de productie.
+
+### Uitvalredenen
+
+Configureer uitvalredencodes in **Uitvalredenen** instellingen. Elke reden heeft een code, beschrijving en categorie (Materiaal, Proces, Apparatuur, Operator, Ontwerp). De pagina toont gebruiksstatistieken zodat je kunt zien welke problemen het vaakst voorkomen.
+
+## Data en Integratie
+
+### CSV-import
+
+Importeer jobs, onderdelen en bewerkingen uit CSV-bestanden. Dit is handig voor migratie vanuit spreadsheets of het ontvangen van gestructureerde data uit je ERP. Het importscherm valideert data voordat het wordt doorgevoerd.
+
+### API-sleutels
+
+Genereer API-sleutels in **Instellingen > API-sleutels** voor integratie met externe systemen. Elke sleutel is gekoppeld aan je tenant en kan op elk moment worden ingetrokken.
+
+### Webhooks
+
+Configureer webhooks in **Instellingen > Webhooks** om events naar externe systemen te pushen. Beschikbare events zijn:
+
+- `operation.started` — een operator is met werk begonnen.
+- `operation.completed` — een operator heeft werk afgerond.
+- `issue.created` — een kwaliteitsissue is gemeld.
+
+### Data-export
+
+Ga naar **Data Export** in de admin-zijbalk. Je kunt alle records exporteren als JSON of CSV. CSV is doorgaans sneller voor grote datasets. Exports bevatten alle databaserecords en metadata maar sluiten bestandsbijlagen (alleen paden) en API-geheimen (alleen prefixen) uit.
+
+Grote exports kunnen 30-60 seconden duren. Voer ze uit tijdens rustige uren indien mogelijk.

--- a/website/src/content/docs/nl/guides/concepts.md
+++ b/website/src/content/docs/nl/guides/concepts.md
@@ -1,0 +1,196 @@
+---
+title: Kernconcepten
+description: Jobs, onderdelen, bewerkingen, batches — wat ze zijn en hoe ze samenhangen.
+---
+
+Eryxon Flow volgt werk via een eenvoudige hierarchie: **Job > Onderdelen > Bewerkingen**. Alles in het systeem hangt aan deze structuur.
+
+## Job
+
+Een job is de container op het hoogste niveau. Elk onderdeel moet tot een job behoren — dit is een harde eis in het datamodel.
+
+Een job hoeft geen klantenorder te zijn. Het kan alles zijn dat onderdelen groepeert:
+
+- Een klantenorder (meest voorkomend bij jobshops)
+- Een interne productierun
+- Een voorraadaanvullingsbatch
+- Een prototype of R&D-project
+- Een onderhouds- of herwerkopdracht
+
+Het veld `customer` is optioneel. Het enige verplichte veld is `job_number`.
+
+| Veld | Verplicht | Voorbeeld |
+|------|-----------|-----------|
+| Jobnummer | ja | WO-2026-0142 |
+| Klant | nee | Hygienisch Staal BV |
+| Leverdatum | nee | 2026-05-15 |
+| Status | auto | not_started, in_progress, completed |
+
+Een job heeft een of meer onderdelen. Spoedprioriteit wordt op onderdeelniveau ingesteld, niet op jobniveau.
+
+## Onderdeel
+
+Een onderdeel is een fysiek item dat geproduceerd moet worden. Elk onderdeel behoort tot een job.
+
+| Veld | Voorbeeld |
+|------|-----------|
+| Onderdeelnummer | FRAME-RVS-316L |
+| Materiaal | RVS 316L 3mm |
+| Hoeveelheid | 4 |
+| Spoed (bullet card) | ja/nee |
+| Bovenliggend onderdeel | (voor assemblages) |
+
+Onderdelen kunnen het volgende hebben:
+
+- **Bestanden** — STEP-modellen (getoond in 3D-viewer), PDF-tekeningen, andere bijlagen. Bestanden worden aan onderdelen gekoppeld, niet aan bewerkingen.
+- **Onderliggende onderdelen** — voor assemblages verwijzen onderdelen naar een bovenliggend onderdeel. Het systeem toont assemblage-afhankelijkheden en waarschuwt operators wanneer onderliggende onderdelen nog niet klaar zijn.
+- **Tekeningnummer** en **CNC-programmanaam** — snelle referentievelden voor de werkvloer.
+- **Afmetingen** — lengte, breedte, hoogte in mm, gewicht in kg.
+
+## Bewerking
+
+Een bewerking is een enkele productiestap op een onderdeel. Hier vindt het daadwerkelijke werk plaats.
+
+| Veld | Voorbeeld |
+|------|-----------|
+| Naam | Lasersnijden |
+| Cel | Laser 1 |
+| Volgorde | 1 (eerste stap) |
+| Geschatte tijd | 120 minuten |
+| Werkelijke tijd | 95 minuten (bijgehouden via start/stop) |
+| Resterend | 25 minuten (geschat minus werkelijk) |
+| Status | not_started, in_progress, on_hold, completed |
+
+Bewerkingen kunnen het volgende hebben:
+
+- **Metadata** — laservermogen, snelheid, gastype, CNC-programmanaam, buighoeken
+- **Substappen** — opsplitsing van de bewerking in kleinere taken (bijv. "plaat laden", "programma draaien", "randen ontbramen")
+- **Tijdregistratie** — operators starten/stoppen een timer, werkelijke tijd wordt vastgelegd
+- **Issues** — operators melden problemen met ernst, beschrijving en foto's
+- **Middelen** — gekoppeld gereedschap, opspanningen, mallen die nodig zijn voor deze stap
+- **In wacht** — gepauzeerd zonder wachtrijpositie te verliezen
+
+Wanneer alle bewerkingen op een onderdeel zijn voltooid, is het onderdeel klaar. Wanneer alle onderdelen in een job klaar zijn, is de job klaar.
+
+## Batch
+
+Een batch groepeert bewerkingen van verschillende onderdelen die samen worden verwerkt. Het meest voorkomende gebruik: **laser nesting** — meerdere onderdelen gesneden uit dezelfde plaat.
+
+| Veld | Voorbeeld |
+|------|-----------|
+| Batchnummer | NEST-2026-0301 |
+| Type | laser_nesting |
+| Materiaal | S235 6mm |
+| Aantal platen | 2 |
+| Cel | Lasersnijden |
+
+Batches kunnen het volgende hebben:
+
+- **Nesting-metadata** — plaatgrootte (1500x3000), benuttingspercentage, CAM-programmareferentie
+- **Nesting-afbeelding** — upload van de nesting-layout uit de CAM-software
+- **Levenscyclus** — concept > in_progress > completed. Start en stop kunnen worden geactiveerd door een operator of door een machine (CAD/CAM-integratie via API).
+- **Tijdsverdeling** — wanneer een batch is voltooid, wordt de totale productietijd verdeeld over alle opgenomen bewerkingen, evenredig aan hun geschatte tijd.
+
+## Wat kan wat bevatten
+
+| Mogelijkheid | Job | Onderdeel | Bewerking | Batch |
+|-------------|-----|-----------|-----------|-------|
+| Statusregistratie | ja | ja | ja | ja |
+| Leverdatum | ja | — | geplande start/eind | — |
+| Bestanden (STEP, PDF) | — | ja | — | nesting-afbeelding |
+| Aangepaste metadata (JSON) | ja | — | ja | nesting-metadata |
+| Notities | ja | — | ja | ja |
+| Tijdregistratie (geschat/werkelijk) | — | — | ja | ja (verdeeld) |
+| Spoedprioriteit | — | ja | — | — |
+| In wacht | — | — | ja | — |
+| Substappen | — | — | ja | — |
+| Issues / NCR | — | — | ja | — |
+| Gekoppelde middelen | — | — | ja | — |
+| Ouder-kind (assemblage) | — | ja | — | bovenliggende batch |
+| ERP-sync (external_id) | ja | ja | ja | — |
+| Toegewezen operator | — | — | ja | — |
+| Afmetingen / gewicht | — | ja | — | — |
+| Materiaal / dikte | — | ja | — | ja |
+| Tekeningnummer | — | ja | — | — |
+| CNC-programmanaam | — | ja | — | — |
+
+Bestanden (STEP-modellen, PDF-tekeningen) worden aan **onderdelen** gekoppeld, niet aan jobs of bewerkingen. Een bewerking erft de bestanden van het bovenliggende onderdeel. De 3D-viewer en PDF-viewer in de terminal tonen de bestanden van het onderdeel waartoe de bewerking behoort.
+
+## Spoed en In Wacht
+
+Dit zijn de twee prioriteitsopties die beschikbaar zijn voor voormannen en planners.
+
+### Spoed (bullet card)
+
+Spoed wordt ingesteld op een **onderdeel**. Het werkt omhoog en naar buiten door:
+
+- Het onderdeel sorteert als eerste in elke tabel en wachtrij
+- Alle bewerkingen op dat onderdeel erven de spoedindicator
+- Als een onderdeel in een job spoed is, toont de gehele job als spoed in de Jobs-tabel
+- De operator-terminal markeert spoedrijen met een rode rand
+- De statusbalk van de operator schakelt naar een rood-naar-groen streeppatroon wanneer een operator is ingeklokt op een spoedbewerking
+- Werkwachtrij kanban-kolommen tonen een spoedtelbadge
+
+Schakel spoed in vanuit het bewerkingsdetailpaneel (de knop stelt het in op het bovenliggende onderdeel) of vanuit de Onderdelen-beheertabel.
+
+Spoed is een visueel en sorteersignaal. Het blokkeert of wijzigt geen planningslogica — het vertelt mensen "doe dit eerst."
+
+### In Wacht
+
+In wacht wordt ingesteld op een **bewerking**. Het heeft alleen invloed op die specifieke bewerking:
+
+- De bewerking blijft zichtbaar in wachtrijen maar toont een wachtbadge
+- Operators weten dat ze er niet aan moeten beginnen
+- De bewerking kan nog steeds worden bewerkt en bijgewerkt terwijl deze in wacht staat
+- Hervat de bewerking om terug te keren naar de status `not_started`
+
+In wacht werkt niet door. Het in wacht zetten van een bewerking heeft geen invloed op andere bewerkingen op hetzelfde onderdeel of dezelfde job. Andere bewerkingen gaan normaal door.
+
+Schakel in wacht in vanuit het bewerkingsdetailpaneel.
+
+## Voorbeeld: Gelaste Assemblage met Nesting
+
+Een roestvrijstalen voedselveilige kast. Twee niveaus van subassemblages, met lasergesneden onderdelen genest over gedeelde platen.
+
+**Job** — WO-2026-0142, klant: Precision Steel Ltd, leverdatum: 2026-05-15
+
+**Onderdelen en routing:**
+
+| Onderdeel | Materiaal | Hvh | Ouder | Bewerkingen |
+|-----------|-----------|-----|-------|-------------|
+| CABINET-ASSY | — | 1 | — | Assemblage (180 min), QC (30 min) |
+| FRAME-ASSY | — | 1 | CABINET-ASSY | TIG Lassen (240 min), Beitsen (90 min) |
+| UPRIGHT-L | SS 316L 3mm | 2 | FRAME-ASSY | Lasersnijden (30 min), Kanten (45 min) |
+| UPRIGHT-R | SS 316L 3mm | 2 | FRAME-ASSY | Lasersnijden (30 min), Kanten (45 min) |
+| CROSS-BEAM | SS 316L 3mm | 4 | FRAME-ASSY | Lasersnijden (20 min), Kanten (25 min) |
+| LID | SS 304 2mm | 1 | CABINET-ASSY | Lasersnijden (15 min), Kanten (20 min), Slijpen (30 min) |
+| BASE-PLATE | S235 6mm | 1 | CABINET-ASSY | Lasersnijden (10 min) |
+
+**Nesting-batch** — NEST-0301: alle zeven lasersnijbewerkingen gegroepeerd op twee platen (1500x3000, 87% benutting). Een snijrun, tijd verdeeld terug naar elke bewerking.
+
+**Assemblage-flow:**
+
+1. Laser snijdt alle onderdelen in een batch. Onderdelen worden na het snijden gesorteerd.
+2. Staanders en dwarsbalken gaan naar het kanten, daarna naar het lassen waar FRAME-ASSY wordt opgebouwd.
+3. Operator start FRAME-ASSY las — systeem waarschuwt als onderliggende onderdelen niet volledig zijn. Operator kan dit overschrijven.
+4. Nadat FRAME-ASSY, LID en BASE-PLATE klaar zijn, start de CABINET-ASSY assemblage. Dezelfde afhankelijkheidscontrole.
+5. Kwaliteitsinspectie voltooit de job.
+
+**Bestanden:** STEP-model en PDF-tekening op elk onderdeel. Assemblagetekeningen op CABINET-ASSY en FRAME-ASSY.
+
+**Metadata op bewerkingen:**
+
+| Bewerking | Metadata |
+|-----------|----------|
+| Lasersnijden | `{"power": 4000, "speed": 12000, "gas": "N2", "program": "NEST-0301"}` |
+| Kanten | `{"bends": [90, 90, 135], "tool": "V16-88"}` |
+| TIG Lassen | `{"process": "TIG", "wire": "316L 1.0mm", "gas": "Argon", "cert_required": true}` |
+| Assemblage | `{"torque_specs": {"M8": 25, "M10": 45}}` |
+
+## Volgende Stappen
+
+- [API-voorbeelden](/guides/api-examples/) — curl-voorbeelden voor opvragen, aanmaken, synchroniseren en CAD/CAM-integratie
+- [CSV Import](/features/csv-import/) — importeer data uit spreadsheets met downloadbare sjablonen
+- [Batch & Nesting](/features/batch-management/) — hoe nesting-batches in detail werken
+- [Handleiding Operator](/nl/guides/operator-manual/) — hoe operators de terminal en werkwachtrij gebruiken
+- [Handleiding Admin](/nl/guides/admin-manual/) — hoe planners jobs, cellen en planning beheren

--- a/website/src/content/docs/nl/guides/faq.md
+++ b/website/src/content/docs/nl/guides/faq.md
@@ -1,0 +1,54 @@
+---
+title: "Help & Veelgestelde Vragen"
+description: "Veelgestelde vragen over Eryxon Flow."
+---
+
+## Algemene Vragen
+
+### Wat is de hierarchie in Eryxon Flow?
+1. **Job** = Klantenorder (bijv. "PO-12345")
+2. **Onderdeel** = Component (bijv. "Beugel A")
+3. **Bewerking** = Taak (bijv. "Lasersnijden", "Kanten")
+
+### Hoe werken assemblages?
+Assemblages zijn onderdelen die andere onderdelen bevatten.
+```
+Beugel Assemblage (Ouder)
+├── Linkerplaat (Kind)
+├── Rechterplaat (Kind)
+```
+Elk onderdeel wordt individueel gevolgd met eigen bewerkingen.
+
+### Wat is QRM?
+**Quick Response Manufacturing (QRM)** is een methodologie om doorlooptijden te verkorten. Eryxon Flow gebruikt het om **OHW (Onderhanden Werk)** te beheren. Als een cel "Op Capaciteit" staat, voorkomt het systeem overproductie door stroomopwaartse voltooiingen te blokkeren.
+
+### Wat is een bullet card?
+Een **bullet card** is de spoedmarkering op een onderdeel. Wanneer ingeschakeld, springt het onderdeel naar de top van elke wachtrij en tabel. Alle bewerkingen op dat onderdeel erven de spoedindicator. Gebruik spaarzaam — als alles spoed is, is niets spoed.
+
+### Wat is POLCA?
+**POLCA** (Paired-cell Overlapping Loops of Cards with Authorization) is een werklastbeheersysteem. In Eryxon Flow verschijnt het als GO/PAUZE-signalen op de terminal. **GO** betekent dat de volgende cel capaciteit heeft. **PAUZE** betekent dat de volgende cel vol zit — wacht met voltooien om ophoping te voorkomen.
+
+### Wat zijn cellen en stadia?
+**Cellen** (ook wel **stadia** genoemd) vertegenwoordigen fysieke werkstations of afdelingen in je werkplaats — zoals "Laser 1", "Kantbank", "Lassen" of "Assemblage". Bewerkingen worden aan cellen toegewezen. Elke cel heeft een OHW-limiet en capaciteitsuren.
+
+### Wat is de capaciteitsmatrix?
+Een visueel overzicht van de belasting per cel per dag. Elke cel is een rij, elke dag een kolom. Kleurcodering toont beschikbaar (groen), belast (oranje) en overbelast (rood). Gebruik het om knelpunten te herkennen voordat ze de werkvloer bereiken.
+
+### Hoe werkt tijdregistratie?
+Operators tikken **Start** om een timer te starten en **Stop** om deze te pauzeren. Er kan slechts een bewerking tegelijk getimed worden. Het starten van een nieuwe bewerking stopt automatisch de vorige. De lopende timer is altijd zichtbaar in de statusbalk.
+
+### Wat zijn issues (NCR's)?
+Issues zijn kwaliteitsproblemen die operators melden vanuit actieve bewerkingen — verkeerd materiaal, beschadigde onderdelen, machineproblemen, tekeningfouten. Ze hebben een ernst (laag/gemiddeld/hoog/kritiek) en kunnen foto's bevatten. Issues zijn informatief — ze blokkeren het werk niet.
+
+### Wat is metadata?
+Bewerkingen en jobs ondersteunen **aangepaste JSON-metadata** — machine-instellingen, buighoeken, lasparameters, gereedschapsvereisten. Dit zijn vrije velden die je kunt invullen naar behoefte van je werkplaats.
+
+## Gespecialiseerde Handleidingen
+
+Voor gedetailleerde instructies, zie:
+
+- **[Handleiding Operator](/nl/guides/operator-manual/)** - Dagelijkse workflow, Terminal-info, Tijdregistratie.
+- **[Handleiding Admin](/nl/guides/admin-manual/)** - Job-aanmaak, Gebruikers, Instellingen.
+- **[Kwaliteitsbeheer](/guides/quality-management/)** - Uitvalregistratie en Dashboards.
+- **[Probleemoplossing](/guides/troubleshooting/)** - Veelvoorkomende fouten en oplossingen.
+- **[Zelf Hosten](/guides/self-hosting/)** - Installatiehandleiding.

--- a/website/src/content/docs/nl/guides/operator-manual.md
+++ b/website/src/content/docs/nl/guides/operator-manual.md
@@ -1,0 +1,133 @@
+---
+title: Handleiding Operator
+description: Hoe Eryxon Flow te gebruiken als operator — werkwachtrij, terminal, tijdregistratie.
+---
+
+Deze handleiding behandelt alles wat je nodig hebt om met Eryxon Flow op de werkvloer te werken. Er zijn twee hoofdinterfaces: de **Werkwachtrij** voor desktopgebruik en de **Terminal** voor vaste werkstationschermen. Beide tonen hetzelfde werk — alleen anders gepresenteerd.
+
+## Werkwachtrij (Kanban)
+
+De Werkwachtrij is je standaardweergave na het inloggen. Het toont bewerkingen als kaarten op een kanbanbord.
+
+### Indeling
+
+Elke **kolom** vertegenwoordigt een cel (werkplek) in de werkplaats. Kaarten in een kolom zijn de bewerkingen die wachten of in uitvoering zijn bij die cel. Kolomkoppen tonen totalen: uren werk in de wachtrij, aantal stuks en hoeveel spoedjobs in de kolom staan.
+
+### Een kaart lezen
+
+Elke kaart toont:
+
+- **Jobnummer** en onderdeel naam
+- **Bewerking** naam (bijv. "Kanten", "Lassen")
+- **Materiaal** type en dikte
+- **Geschatte uren** resterend
+- **Leverdatum** met urgentiekleuring — te laat springt er direct uit
+
+### Je werk vinden
+
+- **Zoeken** op jobnummer, onderdeelnaam, bewerkingsnaam of klant
+- **Filteren** op status (actief, alles, niet gestart, in uitvoering) en leverdatum (te laat, vandaag, deze week)
+- **Sorteren** op volgorde, leverdatum of geschatte tijd
+
+Als je niets ziet: controleer of je filters leeg zijn. Als het nog steeds leeg is, is er nog geen werk aan je cel toegewezen.
+
+### Kaartbadges
+
+- **Spoed** (rood) — deze job heeft prioriteit boven alles. Spoedjobs sorteren automatisch bovenaan.
+- **In wacht** (oranje) — deze bewerking is gepauzeerd. Begin er niet aan tot de wachtstatus is opgeheven.
+
+### Detailpaneel
+
+Klik op een kaart om het detailpaneel aan de rechterkant te openen. Hier zie je:
+
+- Volledige onderdeelinformatie (klant, hoeveelheid, materiaal)
+- Complete routing — elke bewerking in volgorde, getoond als een visuele stroom door cellen
+- Bijgevoegde bestanden: 3D-modelviewer voor STEP-bestanden, PDF-viewer voor tekeningen
+- Spoed- en wachtschakelaars — markeer een bewerking als spoed of zet in wacht
+- Tijdregistratiebesturing (start, stop, voltooid)
+
+## Terminal-weergave
+
+De Terminal is gebouwd voor vaste schermen bij een werkstation. Het werkt goed op touchapparaten en tablets. Gebruik het wanneer je voor je dienst bij een cel staat.
+
+### Aan de slag
+
+Kies je cel uit de **celselector** in de koptekst. De terminal toont dan alleen werk voor die cel, opgesplitst in drie wachtrijen:
+
+- **In Bewerking** (groen) — bewerkingen waar je op dit moment actief aan werkt
+- **In Buffer** (blauw) — de volgende bewerkingen die klaar zijn om te starten, al bij je cel
+- **Verwacht** (oranje) — aankomend werk dat bij je cel zal aankomen
+
+### Statusbalk
+
+De balk onder de koptekst toont:
+
+- Je operatornaam
+- De bewerking waaraan je momenteel werkt en bij welke job deze hoort
+- Een lopende timer sinds je bent gestart
+- Diagonale streeppatronen die veranderen op basis van je status: groen tijdens actief werken, oranje strepen wanneer je niet bent ingeklokt, rood-naar-groen kleurverloop wanneer je aan een spoedorder werkt
+
+### POLCA-celsignalen
+
+De Cel-kolom toont een signaal voor elke bewerking: de **huidige cel** en de **volgende cel** in de routing, met een capaciteitsindicator:
+
+- **GO** (play-icoon) — de volgende cel heeft capaciteit. Je kunt je bewerking voltooien en het onderdeel stroomt soepel door.
+- **PAUZE** (pauze-icoon) — de volgende cel zit op capaciteit. Je bewerking nu afronden zou een ophoping veroorzaken.
+
+Dit voorkomt knelpunten. Het systeem beheert onderhanden-werklimieten per cel.
+
+### Achterstandstatus
+
+Bewerkingen tonen een achterstandslabel wanneer deadlines naderen:
+
+- **Te laat** — over de datum, had al klaar moeten zijn
+- **Vandaag** — vandaag op te leveren
+- **Binnenkort** — op te leveren binnen enkele dagen
+
+### Detailzijbalk
+
+Tik op een bewerking om de zijbalk aan de rechterkant te openen:
+
+- **3D-viewer** — roteer en zoom het onderdeelmodel (als er een STEP-bestand is bijgevoegd)
+- **PDF-viewer** — bekijk de technische tekening
+- **Routing** — bekijk de volledige volgorde van bewerkingen en waar het onderdeel hierna naartoe gaat
+
+## Tijdregistratie
+
+Tijdregistratie koppelt je werk aan elke bewerking.
+
+### Hoe het werkt
+
+1. **Start** — tik op "Start" bij de bewerking waaraan je gaat werken. De timer begint en de bewerking gaat naar "In Bewerking."
+2. **Stop** — tik op "Stop" wanneer het fysieke werk is gedaan.
+3. **Voltooid** — markeer de bewerking als voltooid om deze naar de volgende cel te verplaatsen.
+
+Er kan slechts **een bewerking** tegelijk getimed worden. Het starten van een nieuwe bewerking stopt de vorige.
+
+De lopende timer is altijd zichtbaar in de statusbalk zodat je nooit vergeet te stoppen.
+
+## Issues Melden
+
+Wanneer er iets misgaat — verkeerd materiaal, beschadigd onderdeel, machineprobleem, tekeningfout — meld het direct.
+
+### Stappen
+
+1. Open het bewerkingsdetail (vanuit de Werkwachtrij of Terminal)
+2. Tik op **Issue Melden**
+3. Kies een ernst:
+   - **Laag** — klein, blokkeert het werk niet
+   - **Gemiddeld** — heeft aandacht nodig maar je kunt doorgaan
+   - **Hoog** — blokkeert deze bewerking
+   - **Kritiek** — veiligheidsrisico of grote productiestop
+4. Beschrijf het probleem
+5. **Voeg foto's toe** — maak een foto met je telefoon of tabletcamera
+6. Verstuur
+
+De issue gaat onmiddellijk naar de admin Issue-wachtrij.
+
+## Tips
+
+- Start altijd je timer voordat je aan het fysieke werk begint.
+- Controleer de POLCA-signalen voordat je een bewerking voltooit. Als de volgende cel PAUZE toont, vraag je leidinggevende.
+- Meld issues op het moment dat je ze ziet. Een foto zegt meer dan duizend woorden.
+- Als je scherm leeg lijkt, wis dan eerst alle filters.

--- a/website/src/content/docs/nl/guides/quick-start.md
+++ b/website/src/content/docs/nl/guides/quick-start.md
@@ -1,0 +1,184 @@
+---
+title: "Snel Starten"
+description: "Eryxon Flow in enkele minuten opstarten en gebruiken."
+---
+
+Eryxon Flow snel opstarten.
+
+> **Gewoon verkennen?** Probeer de [live demo op app.eryxon.eu](https://app.eryxon.eu) — geen installatie nodig. Registreer en begin direct met verkennen.
+
+---
+
+## Vereisten
+
+- Node.js 20+ ([download](https://nodejs.org))
+- Een Supabase-account (gratis tier werkt) - [aanmelden](https://supabase.com)
+
+---
+
+## Stap 1: Supabase Instellen
+
+### 1.1 Project Aanmaken
+
+1. Ga naar [supabase.com](https://supabase.com) → **New Project**
+2. Noem het `eryxon-flow`
+3. Sla je databasewachtwoord op
+4. Klik op **Create**
+
+### 1.2 Je Sleutels Ophalen
+
+Ga naar **Settings** → **API** en kopieer:
+- **Project URL** (bijv. `https://abc123.supabase.co`)
+- **anon public key** (begint met `eyJ...`)
+
+### 1.3 Databaseschema Toepassen
+
+Gebruik de Supabase CLI tegen je doelproject:
+
+```bash
+supabase link --project-ref YOUR_PROJECT_REF
+supabase db push
+```
+
+### 1.4 Seeddata Toepassen
+
+Het seedbestand stelt opslagbeleid, RLS-standaarden en cron-jobs in:
+
+```bash
+supabase db execute --file supabase/seed.sql
+```
+
+### 1.5 Opslagbuckets Aanmaken
+
+```bash
+supabase storage create parts-images
+supabase storage create issues
+supabase storage create parts-cad
+supabase storage create batch-images
+```
+
+### 1.6 Edge Functions Deployen
+
+```bash
+supabase functions deploy
+```
+
+### 1.7 Edge Function Secrets Instellen
+
+Ga naar **Settings** → **API** en kopieer de **service_role** sleutel, dan:
+
+```bash
+supabase secrets set SUPABASE_URL=https://YOUR_PROJECT_REF.supabase.co SUPABASE_SERVICE_ROLE_KEY=YOUR_SERVICE_ROLE_KEY
+```
+
+Configureer de `notify-new-signup` Database Webhook nadat migraties zijn toegepast (zie [Handleiding Zelf Hosten](/guides/self-hosting/)).
+
+> **Liever automatisering?** Voer `bash scripts/setup.sh` uit — dat leidt je interactief door alles hierboven.
+
+---
+
+## Stap 2: De Applicatie Starten
+
+```bash
+git clone https://github.com/SheetMetalConnect/eryxon-flow.git
+cd eryxon-flow
+
+npm install
+
+cp .env.example .env
+```
+
+Bewerk `.env`:
+```bash
+VITE_SUPABASE_URL=https://your-project-id.supabase.co
+VITE_SUPABASE_PUBLISHABLE_KEY=your-anon-key
+VITE_SUPABASE_PROJECT_ID=your-project-id
+```
+
+Start de app:
+```bash
+npm run dev
+```
+
+Open **http://localhost:8080**
+
+---
+
+## Stap 3: Je Account Aanmaken
+
+1. Klik op **Sign Up**
+2. Voer e-mail en wachtwoord in
+3. Bevestig je e-mail (controleer je inbox)
+4. Je bent nu admin van je organisatie!
+
+---
+
+## Stap 4: Verkennen (Optioneel)
+
+### Demodata Laden
+
+Wil je de app met voorbeelddata zien?
+
+1. Ga naar **Settings** in de admin-zijbalk
+2. Klik op **Create Demo Data**
+3. Verken voorbeeldjobs, onderdelen en bewerkingen
+
+### Snelle Rondleiding
+
+| Pagina | Wat het doet |
+|--------|-------------|
+| `/admin/dashboard` | Productieoverzicht |
+| `/admin/jobs` | Productiejobs beheren |
+| `/admin/jobs/new` | Nieuwe job aanmaken |
+| `/operator/work-queue` | Takenlijst operator |
+| `/operator/login` | Terminal-inlog werkvloer |
+| `/admin/config/stages` | Werkstadia configureren |
+
+---
+
+## Wat Nu?
+
+**Installatie & Deployment:**
+- [Deployment Gids](/guides/deployment/) - Productie-deploymentopties
+- [Zelf Hosten Gids](/guides/self-hosting/) - Omgeving en uitroldetails
+- [MCP Server Setup](/guides/mcp-setup/) - AI-assistent integratie instellen
+
+**API & Integratie:**
+- [REST API Overzicht](/architecture/connectivity-rest-api/) - Integratiearchitectuur
+- [REST API Referentie](/api/rest-api-reference/) - Volledige endpoint-referentie
+- [API Payload Referentie](/api/payload-reference/) - Kopieer-en-plak payload-voorbeelden
+- [MCP Demo Gids](/api/mcp-demo-guide/) - Voorbeelden AI-assistentgebruik
+- [Webhooks & MQTT](/architecture/connectivity-mqtt/) - Event-gedreven integratie
+- **Swagger/OpenAPI** - Beschikbaar in de app op `/admin/api-docs` (inlog vereist)
+
+**Architectuur & Hulp:**
+- [App-architectuur](/architecture/app-architecture/) - Systeemontwerp-overzicht
+- [FAQ](/nl/guides/faq) - Veelgestelde vragen
+
+---
+
+## Veelvoorkomende Problemen
+
+**Kan niet registreren?**
+- Controleer of je Supabase URL correct is in `.env`
+- Verifieer e-mailinstellingen in het Supabase Auth-dashboard
+
+**Databasefouten?**
+- Zorg dat je het schema-SQL hebt uitgevoerd
+- Controleer de SQL Editor op fouten
+
+**Pagina laadt niet?**
+- Controleer of beide omgevingsvariabelen zijn ingesteld
+- Controleer de browserconsole op fouten
+
+---
+
+## Hulp Nodig?
+
+- Begin bij de [documentatie-homepagina](/)
+- Open een issue op GitHub
+- Doe mee aan onze communitydiscussies
+
+---
+
+*Veel productiesucces!*

--- a/website/src/content/i18n/de.json
+++ b/website/src/content/i18n/de.json
@@ -1,0 +1,7 @@
+{
+  "page.nextLink": "Nächste Seite",
+  "page.previousLink": "Vorherige Seite",
+  "hero.popular": "Beliebt",
+  "footer.privacy": "Datenschutz",
+  "footer.language": "Sprache"
+}

--- a/website/src/content/i18n/en.json
+++ b/website/src/content/i18n/en.json
@@ -2,5 +2,6 @@
   "page.nextLink": "Next page",
   "page.previousLink": "Previous page",
   "hero.popular": "Popular",
-  "footer.privacy": "Privacy Policy"
+  "footer.privacy": "Privacy Policy",
+  "footer.language": "Language"
 }

--- a/website/src/content/i18n/nl.json
+++ b/website/src/content/i18n/nl.json
@@ -2,5 +2,6 @@
     "page.nextLink": "Volgende pagina",
     "page.previousLink": "Vorige pagina",
     "hero.popular": "Populair",
-    "footer.privacy": "Privacybeleid"
+    "footer.privacy": "Privacybeleid",
+    "footer.language": "Taal"
 }


### PR DESCRIPTION
Add Dutch (nl) translations for all core documentation covering
concepts, definitions, and how-to-use guides:
- nl/guides/concepts.md — Kernconcepten (Jobs, Onderdelen, Bewerkingen, Batches)
- nl/guides/quick-start.md — Snel Starten handleiding
- nl/guides/operator-manual.md — Handleiding Operator (werkwachtrij, terminal, tijdregistratie)
- nl/guides/admin-manual.md — Handleiding Admin (jobs, cellen, planning, kwaliteit)
- nl/guides/faq.md — Veelgestelde Vragen met extra Nederlandse begrippen
- docs/GLOSSARY_NL.md — Volledige Nederlandse woordenlijst MES-domaintermen

https://claude.ai/code/session_01EmKB2QoSadAvDcvKTyGN65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Full German and Dutch language support across the platform
  * Language switcher added to footer for easy locale selection
  * Automatic browser language detection with switchable preference banner

* **Documentation**
  * Complete guides, manuals, and glossaries now available in German and Dutch
  * Covers quick-start, concepts, operator workflows, admin tasks, and FAQs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->