### PR TITLE
Add localized landing pages (DE + NL parity)

### DIFF
--- a/website/src/content/docs/de/index.mdx
+++ b/website/src/content/docs/de/index.mdx
@@ -1,0 +1,246 @@
+---
+title: Eryxon Flow - MES für Lohnfertiger
+description: Manufacturing Execution System für Lohnfertiger. Self-hostbar, API-first, und für die Werkstatt gebaut.
+template: splash
+hero:
+  title: |
+    MES für <span class="text-primary">Lohnfertiger</span>
+  tagline: Die Werkstatt-App, die Ihre Werker tatsächlich nutzen. Echtzeit-Auftragsverfolgung, tabletfreundliche Terminals und ERP-Integration für die Einzelfertigung.
+  actions:
+    - text: Gehostete Version Öffnen
+      link: https://app.eryxon.eu
+      icon: external
+      variant: primary
+    - text: Dokumentation Lesen
+      link: /de/introduction/
+      icon: right-arrow
+      variant: minimal
+---
+
+import Section from "~/components/Section.astro";
+import Card from "~/components/user-components/NewCard.astro";
+import Grid from "~/components/user-components/Grid.astro";
+import HeroTabs from "~/components/HeroTabs.astro";
+import HeroTabsItem from "~/components/HeroTabsItem.astro";
+import LinkButton from "~/components/LinkButton.astro";
+import ListCard from "~/components/user-components/ListCard.astro";
+import ThemeDemo from "~/components/ThemeDemo.astro";
+
+<Section title="Gebaut für die <span class='text-primary'>Produktion</span>" description="Echtzeit-Werkerterminals, Kapazitätsplanung und ERP-Integration ab Werk.">
+
+<Grid columns={3}>
+  <Card title="Echtzeit-Tracking" icon="seti:clock" iconColor="#38bdf8">
+    Werker erfassen Zeit und Status auf Touch-Tablets. Live-Einblick in jeden Auftrag über WebSockets.
+  </Card>
+  <Card title="Auftragsverwaltung" icon="seti:plan" iconColor="#a78bfa">
+    Verfolgen Sie Aufträge, Teile und Arbeitsgänge durch die Produktion. Visuelle Arbeitswarteschlangen nach konfigurierbaren Stufen.
+  </Card>
+  <Card title="Self-Hostbar" icon="seti:lock" iconColor="#34d399">
+    Ihre Produktionsdaten bleiben Ihre. Betreiben Sie es auf Ihrer eigenen Infrastruktur ohne Nutzungslimits. BSL 1.1 (frei für interne Nutzung).
+  </Card>
+  <Card title="ERP-Integration" icon="seti:db" iconColor="#fb923c">
+    Synchronisieren Sie Aufträge und Teile aus Ihrem ERP über REST-API und Webhooks. CSV-Import/Export inklusive.
+  </Card>
+  <Card title="Papierlose Werkstatt" icon="seti:image" iconColor="#f472b6">
+    Zeichnungen (PDF), 3D-STEP-Dateien und Arbeitsanweisungen anhängen. Eingebauter 3D-Viewer mit Messungen und PDF-Viewer.
+  </Card>
+  <Card title="Dashboard & Analysen" icon="seti:chart" iconColor="#facc15">
+    Live-Produktionsstatistiken, aktive Aufträge und Werkeraktivität auf einen Blick.
+  </Card>
+</Grid>
+</Section>
+
+<Section
+  title="So <span class='text-primary'>funktioniert's</span>"
+  description="Einfacher Workflow von Auftrag bis Lieferung."
+>
+  <HeroTabs>
+    <HeroTabsItem
+      title="Produktion Verfolgen"
+      subtitle="Live-Dashboard zeigt aktive Werker, offene Problemmeldungen, UB pro Zelle und Fristen auf einen Blick."
+      number={1}
+      image="/src/assets/step-1.png"
+      imageAlt="Eryxon Flow Dashboard mit Produktionsstatistiken und QRM-Kapazitätsübersicht"
+    />
+    <HeroTabsItem
+      title="Werker Ziehen Arbeit"
+      subtitle="Kanban-Arbeitswarteschlange auf Tablets. Werker sehen ihre Arbeitsgänge pro Stufe, erfassen Zeit und melden Probleme."
+      number={2}
+      image="/src/assets/step-2.png"
+      imageAlt="Eryxon Flow Kanban-Arbeitswarteschlange mit Spalten pro Produktionsstufe"
+    />
+    <HeroTabsItem
+      title="Teile in 3D Betrachten"
+      subtitle="STEP-Dateien direkt im Browser öffnen. Abstände, Winkel und Dicken in der Werkstatt messen."
+      number={3}
+      image="/src/assets/step-3.png"
+      imageAlt="Eryxon Flow Werkerterminal mit 3D-STEP-Viewer und Teiledetails"
+    />
+  </HeroTabs>
+</Section>
+
+<Section title="Wichtige <span class='text-primary'>Funktionen</span>" description="Was Eryxon Flow von generischen MES-Tools unterscheidet.">
+<Grid columns={3}>
+
+<ListCard title="Kapazitätsplanung" icon="seti:plan" image="/src/assets/overview.png">
+- Visuelle Zellenauslastung pro Tag
+- Auto-Planung mit einem Klick
+- Drag & Drop zum Umplanen
+
+<LinkButton href="/de/features/scheduling/" variant="text" className="mt-6 mb-8 ml-4">Mehr erfahren</LinkButton>
+</ListCard>
+
+<ListCard title="3D-STEP-Viewer" icon="seti:image">
+- Browserbasiert, keine Plugins
+- Abstände und Winkel messen
+- Explosionsansicht für Baugruppen
+
+<LinkButton href="/de/features/3d-viewer/" variant="text" className="mt-6 mb-8 ml-4">Mehr erfahren</LinkButton>
+</ListCard>
+</Grid>
+
+<Grid columns={3}>
+<ListCard title="Qualität & NCR" icon="seti:lock" image="/src/assets/darkmode-demo.png">
+- Vollständiger Aktivitäts-Audit-Trail
+- Non-Conformance-Berichte
+- Problemverfolgung pro Arbeitsgang
+
+<LinkButton href="/de/guides/quality-management/" variant="text" className="mt-6 mb-8 ml-4">Mehr erfahren</LinkButton>
+</ListCard>
+
+<ListCard title="Zeiterfassung" icon="seti:clock">
+- Start/Stopp pro Arbeitsgang
+- Wöchentliche Aktivitätsübersicht
+- Automatische Zeitberechnungen
+
+<LinkButton href="/de/guides/operator-manual/" variant="text" className="mt-6 mb-8 ml-4">Werkerhandbuch</LinkButton>
+</ListCard>
+</Grid>
+</Section>
+
+<Section
+  title="Admin- & <span class='text-primary'>Werker</span>-Ansichten"
+  description="Eine App, zwei Oberflächen. Wechseln Sie zwischen Admin-Übersicht und Werker-Arbeitsansicht."
+>
+<ThemeDemo
+  darkImage="/src/assets/darkmode-demo.png"
+  lightImage="/src/assets/lightmode-demo.png"
+/>
+</Section>
+
+<Section title="Warum <span class='text-primary'>Eryxon Flow?</span>">
+<Grid columns={2}>
+<Card title="Für Lohnfertiger" icon="seti:home" iconColor="#38bdf8">
+  High Mix, Low Volume. Tausende einzigartige Teile pro Jahr? Genau dafür haben wir das gebaut.
+</Card>
+<Card title="Entwicklerfreundlich" icon="seti:code" iconColor="#34d399">
+  API-first mit 22 REST-Endpunkten, Webhooks, MQTT und MCP-Server. Bauen Sie Integrationen nach Ihren Wünschen.
+</Card>
+</Grid>
+
+<div class="flex flex-wrap justify-center gap-4 mt-12 pb-12">
+    <LinkButton href="https://app.eryxon.eu" variant="primary">Live-Demo Testen</LinkButton>
+    <LinkButton href="/de/guides/quick-start/" variant="minimal">Schnellstart-Anleitung</LinkButton>
+    <LinkButton href="https://github.com/SheetMetalConnect/eryxon-flow" variant="minimal">Auf GitHub Starren</LinkButton>
+</div>
+</Section>
+
+<Section title="Schnelle <span class='text-primary'>Navigation</span>" description="Direkt zur benötigten Dokumentation springen.">
+  <Grid columns={3}>
+    <ListCard title="Erste Schritte" icon="rocket" number="4">
+      - [Schnellstart](/de/guides/quick-start/)
+      - [Deployment](/de/guides/deployment/)
+      - [Self-Hosting](/de/guides/self-hosting/)
+      - [Roadmap](/de/roadmap/)
+    </ListCard>
+
+    <ListCard title="Benutzerhandbücher" icon="open-book" number="3">
+      - [Werkerhandbuch](/de/guides/operator-manual/)
+      - [Adminhandbuch](/de/guides/admin-manual/)
+      - [Qualitätsmanagement](/de/guides/quality-management/)
+    </ListCard>
+
+    <ListCard title="Funktionen" icon="star" number="4">
+      - [3D-Viewer](/de/features/3d-viewer/)
+      - [ERP-Integration](/de/features/erp-integration/)
+      - [Kapazitätsplanung](/de/features/scheduling/)
+      - [Chargenverwaltung](/de/features/batch-management/)
+    </ListCard>
+  </Grid>
+  <Grid columns={3}>
+    <ListCard title="API & Integration" icon="seti:json" number="4">
+      - [REST API Übersicht](/de/architecture/connectivity-rest-api/)
+      - [REST API Referenz](/de/api/rest-api-reference/)
+      - [Payload-Referenz](/de/api/payload-reference/)
+      - [MCP Server](/de/api/mcp-server-reference/)
+    </ListCard>
+
+    <ListCard title="Architektur" icon="puzzle" number="3">
+      - [App-Architektur](/de/architecture/app-architecture/)
+      - [Konnektivität](/de/architecture/connectivity-overview/)
+      - [Sicherheit](/de/architecture/security-architecture/)
+    </ListCard>
+
+    <ListCard title="Hilfe" icon="support" number="2">
+      - [FAQ](/de/guides/faq/)
+      - [Fehlerbehebung](/de/guides/troubleshooting/)
+    </ListCard>
+  </Grid>
+</Section>
+
+<Section title="Lizenz & <span class='text-primary'>Bedingungen</span>">
+  <div class="bg-dark/50 p-8 rounded-2xl border border-white/5">
+    <div class="grid md:grid-cols-2 gap-8 items-center">
+      <div>
+        <h3 class="text-2xl font-bold mb-4">Business Source License 1.1</h3>
+        <p class="text-gray-400 mb-6">
+          Eryxon Flow ist source-available und kostenlos für Ihre eigenen Fertigungsaktivitäten nutzbar.
+          Self-hosted-Installationen haben keine Nutzungslimits.
+        </p>
+        <div class="space-y-3">
+          <div class="flex items-center gap-3">
+            <div class="text-primary font-bold">&#10003;</div>
+            <span>Kostenlos für internen Geschäftsgebrauch</span>
+          </div>
+          <div class="flex items-center gap-3">
+            <div class="text-primary font-bold">&#10003;</div>
+            <span>Anpassen, forken und selbst hosten</span>
+          </div>
+          <div class="flex items-center gap-3">
+            <div class="text-primary font-bold">&#10003;</div>
+            <span>Keine Nutzungslimits beim Self-Hosting</span>
+          </div>
+          <div class="flex items-center gap-3 text-red-400">
+            <div class="font-bold">&#10007;</div>
+            <span>Kein kommerzieller Weiterverkauf oder konkurrierendes SaaS</span>
+          </div>
+        </div>
+      </div>
+      <div class="text-center">
+        <p class="mb-6 text-sm italic text-gray-500">
+          „Nutzen Sie es, passen Sie es an, machen Sie es zu Ihrem. Hosten Sie es nur nicht, um anderen gegen Bezahlung Zugang zu gewähren."
+        </p>
+        <LinkButton href="https://github.com/SheetMetalConnect/eryxon-flow/blob/main/LICENSE" variant="minimal">
+          Vollständige Lizenzbedingungen auf GitHub lesen
+        </LinkButton>
+      </div>
+    </div>
+  </div>
+</Section>
+
+<Section title="Support & <span class='text-primary'>Dienstleistungen</span>">
+  <Grid columns={2}>
+    <Card title="Community-Support" icon="seti:github" iconColor="#a78bfa">
+      Self-Hosting wird von der Community über GitHub unterstützt.
+      <br/><br/>
+      <strong>Issues:</strong> Fehlermeldungen und Feature-Wünsche<br/>
+      <strong>Dokumentation:</strong> <a href="/de/guides/quick-start/" class="text-primary hover:underline">Hier starten</a>
+    </Card>
+
+    <Card title="Professionelle Dienstleistungen" icon="seti:notebook" iconColor="#fb923c">
+      Hilfe bei ERP-Integration oder komplexen Deployments benötigt?
+      <br/><br/>
+      <a href="https://www.vanenkhuizen.com/" target="_blank" class="text-primary font-semibold hover:underline">vanenkhuizen.com</a> bietet Beratung für die Digitalisierung der Fertigung.
+    </Card>
+  </Grid>
+</Section>

--- a/website/src/content/docs/de/introduction.md
+++ b/website/src/content/docs/de/introduction.md
@@ -1,9 +1,9 @@
 ---
 title: Willkommen bei Eryxon Flow
-description: Das einfache, elegante und leistungsstarke Manufacturing Execution System, mit dem Ihre Mitarbeiter gerne arbeiten. Entwickelt für die Blechbearbeitung.
+description: Das einfache, elegante und leistungsstarke Manufacturing Execution System, mit dem Ihre Mitarbeiter gerne arbeiten. Entwickelt für die Metallverarbeitung.
 ---
 
-**Das einfache, elegante und leistungsstarke Manufacturing Execution System, mit dem Ihre Mitarbeiter gerne arbeiten. Entwickelt für die Blechbearbeitung.**
+**Das einfache, elegante und leistungsstarke Manufacturing Execution System, mit dem Ihre Mitarbeiter gerne arbeiten. Entwickelt für die Metallverarbeitung.**
 
 > **Jetzt ausprobieren:** Erkunden Sie die [Live-Demo auf app.eryxon.eu](https://app.eryxon.eu) — keine Installation erforderlich.
 

--- a/website/src/content/docs/nl/index.mdx
+++ b/website/src/content/docs/nl/index.mdx
@@ -23,6 +23,8 @@ import Grid from "~/components/user-components/Grid.astro";
 import HeroTabs from "~/components/HeroTabs.astro";
 import HeroTabsItem from "~/components/HeroTabsItem.astro";
 import LinkButton from "~/components/LinkButton.astro";
+import ListCard from "~/components/user-components/ListCard.astro";
+import ThemeDemo from "~/components/ThemeDemo.astro";
 
 <Section title="Gebouwd voor <span class='text-primary'>Productie</span>" description="Real-time operator terminals, capaciteitsplanning en ERP-integratie.">
 
@@ -78,42 +80,112 @@ import LinkButton from "~/components/LinkButton.astro";
   </HeroTabs>
 </Section>
 
+<Section title="Belangrijkste <span class='text-primary'>Mogelijkheden</span>" description="Wat Eryxon Flow onderscheidt van generieke MES-tools.">
+<Grid columns={3}>
+
+<ListCard title="Capaciteitsplanning" icon="seti:plan" image="/src/assets/overview.png">
+- Visuele celbelasting per dag
+- Auto-planning met een klik
+- Drag & drop om bewerkingen te herplannen
+
+<LinkButton href="/nl/features/scheduling/" variant="text" className="mt-6 mb-8 ml-4">Meer informatie</LinkButton>
+</ListCard>
+
+<ListCard title="3D STEP Viewer" icon="seti:image">
+- Browsergebaseerd, geen plugins
+- Afstanden en hoeken meten
+- Explosieweergave voor assemblages
+
+<LinkButton href="/nl/features/3d-viewer/" variant="text" className="mt-6 mb-8 ml-4">Meer informatie</LinkButton>
+</ListCard>
+</Grid>
+
+<Grid columns={3}>
+<ListCard title="Kwaliteit & NCR" icon="seti:lock" image="/src/assets/darkmode-demo.png">
+- Volledig activiteiten-auditspoor
+- Non-conformance rapporten
+- Issue-tracking per bewerking
+
+<LinkButton href="/nl/guides/quality-management/" variant="text" className="mt-6 mb-8 ml-4">Meer informatie</LinkButton>
+</ListCard>
+
+<ListCard title="Tijdregistratie" icon="seti:clock">
+- Start/stop per bewerking
+- Wekelijks activiteitenoverzicht
+- Automatische tijdberekeningen
+
+<LinkButton href="/nl/guides/operator-manual/" variant="text" className="mt-6 mb-8 ml-4">Handleiding Operator</LinkButton>
+</ListCard>
+</Grid>
+</Section>
+
+<Section
+  title="Admin- & <span class='text-primary'>Operator</span>weergaven"
+  description="Een app, twee interfaces. Wissel tussen admin-overzicht en operator-werkweergave."
+>
+<ThemeDemo
+  darkImage="/src/assets/darkmode-demo.png"
+  lightImage="/src/assets/lightmode-demo.png"
+/>
+</Section>
+
 <Section title="Waarom <span class='text-primary'>Eryxon Flow?</span>">
 <Grid columns={2}>
 <Card title="Voor Job Shops" icon="seti:home" iconColor="#38bdf8">
   High mix, low volume. Beheert u duizenden unieke onderdelen? Daarvoor hebben we Eryxon gebouwd.
 </Card>
 <Card title="Ontwikkelaar Vriendelijk" icon="seti:code" iconColor="#34d399">
-  API-first ontwerp. Breid functionaliteit uit, bouw eigen integraties en blijf eigenaar van uw data.
+  API-first met 22 REST-endpoints, webhooks, MQTT en MCP-server. Bouw integraties op uw manier.
 </Card>
 </Grid>
 
 <div class="flex flex-wrap justify-center gap-4 mt-12 pb-12">
-    <LinkButton href="/nl/guides/quick-start/" variant="primary">Start Introductie</LinkButton>
+    <LinkButton href="https://app.eryxon.eu" variant="primary">Live Demo Proberen</LinkButton>
+    <LinkButton href="/nl/guides/quick-start/" variant="minimal">Start Introductie</LinkButton>
     <LinkButton href="https://github.com/SheetMetalConnect/eryxon-flow" variant="minimal">Star op GitHub</LinkButton>
 </div>
 
 </Section>
 
-import ListCard from "~/components/user-components/ListCard.astro";
-
 <Section title="Snelle <span class='text-primary'>Navigatie</span>" description="Ga direct naar de documentatie die u nodig heeft.">
   <Grid columns={3}>
-    <ListCard title="Aan de slag" icon="rocket" number="3">
-      - [Snel starten](/nl/guides/quick-start/)
-      - [Installatie](/nl/guides/deployment/)
-      - [Zelf hosten](/nl/guides/self-hosting/)
+    <ListCard title="Aan de Slag" icon="rocket" number="4">
+      - [Snel Starten](/nl/guides/quick-start/)
+      - [Deployment](/nl/guides/deployment/)
+      - [Zelf Hosten](/nl/guides/self-hosting/)
+      - [Roadmap](/nl/roadmap/)
     </ListCard>
 
     <ListCard title="Handleidingen" icon="open-book" number="3">
-      - [Operator Handleiding](/nl/guides/operator-manual/)
-      - [Admin Handleiding](/nl/guides/admin-manual/)
+      - [Handleiding Operator](/nl/guides/operator-manual/)
+      - [Handleiding Admin](/nl/guides/admin-manual/)
       - [Kwaliteitsbeheer](/nl/guides/quality-management/)
     </ListCard>
 
-    <ListCard title="API" icon="seti:json" number="2">
-      - [REST API](/nl/architecture/connectivity-rest-api/)
-      - [MQTT & Webhooks](/nl/architecture/connectivity-mqtt/)
+    <ListCard title="Functies" icon="star" number="4">
+      - [3D Viewer](/nl/features/3d-viewer/)
+      - [ERP-Integratie](/nl/features/erp-integration/)
+      - [Planning & Capaciteit](/nl/features/scheduling/)
+      - [Batchbeheer](/nl/features/batch-management/)
+    </ListCard>
+  </Grid>
+  <Grid columns={3}>
+    <ListCard title="API & Integratie" icon="seti:json" number="4">
+      - [REST API Overzicht](/nl/architecture/connectivity-rest-api/)
+      - [REST API Referentie](/nl/api/rest-api-reference/)
+      - [Payload Referentie](/nl/api/payload-reference/)
+      - [MCP Server](/nl/api/mcp-server-reference/)
+    </ListCard>
+
+    <ListCard title="Architectuur" icon="puzzle" number="3">
+      - [App-Architectuur](/nl/architecture/app-architecture/)
+      - [Connectiviteit](/nl/architecture/connectivity-overview/)
+      - [Beveiliging](/nl/architecture/security-architecture/)
+    </ListCard>
+
+    <ListCard title="Hulp" icon="support" number="2">
+      - [FAQ](/nl/guides/faq/)
+      - [Probleemoplossing](/nl/guides/troubleshooting/)
     </ListCard>
   </Grid>
 </Section>


### PR DESCRIPTION
## Summary

- **German landing page** (`de/index.mdx`) — full translation of all sections: hero, features grid, HeroTabs workflow, Key Capabilities (capacity planning, 3D viewer, quality/NCR, time tracking), Admin/Werker views with ThemeDemo, Why Eryxon, Quick Navigation, License & Terms, Support & Services
- **Dutch landing page** (`nl/index.mdx`) — added missing sections to reach full parity with EN: Key Capabilities with ListCard components, Admin/Operator views with ThemeDemo, expanded Quick Navigation (features, architecture, API rows), added Live Demo CTA
- **DE introduction fix** — changed "Blechbearbeitung" → "Metallverarbeitung" (metals fabrication broadly, not just sheet metal)

All internal links use correct locale-prefixed paths (`/de/...`, `/nl/...`).

## Test plan

- [ ] Verify `/de/` landing page renders all sections with correct German text and images
- [ ] Verify `/nl/` landing page now shows Key Capabilities, ThemeDemo, and full Quick Navigation
- [ ] Confirm all internal links on both landing pages resolve correctly (no 404s)
- [ ] Check language switcher navigates between EN ↔ NL ↔ DE landing pages
- [ ] Verify DE introduction page says "Metallverarbeitung" not "Blechbearbeitung"

https://claude.ai/code/session_01EmKB2QoSadAvDcvKTyGN65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new German localized landing page with feature highlights, workflow guides, and quick navigation links.
  * Updated German introduction copy to reflect broader industry focus.
  * Enhanced Dutch documentation with expanded features section, admin/operator interface preview, reorganized navigation structure, and new call-to-action buttons for live demo access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->