### PR TITLE
fix: support self-hosted Supabase deployments

### DIFF
--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -1,0 +1,166 @@
+# Self-Hosting Eryxon Flow
+
+This guide covers running Eryxon Flow with a self-hosted Supabase instance using `supabase start`.
+
+## Prerequisites
+
+- Docker Desktop running
+- Supabase CLI (`brew install supabase/tap/supabase`)
+- Node.js 20+ (for building the frontend)
+- ~10 GB free Docker disk space (for Supabase images)
+
+## Quick Start
+
+### 1. Start local Supabase
+
+```bash
+cd eryxon-flow
+supabase start
+```
+
+This starts PostgreSQL, GoTrue (auth), PostgREST, Realtime, Storage, and Studio. Migrations from `supabase/migrations/` are applied automatically.
+
+Note the output — you'll need the **Publishable key** and **API URL** (default: `http://127.0.0.1:54321`).
+
+### 2. Start Edge Functions
+
+```bash
+supabase functions serve
+```
+
+Required for API key generation, data export/import, webhooks, and other server-side features.
+
+### 3. Build and run the frontend
+
+```bash
+docker build \
+  --build-arg VITE_SUPABASE_URL="http://127.0.0.1:54321" \
+  --build-arg VITE_SUPABASE_PUBLISHABLE_KEY="<your-publishable-key>" \
+  --build-arg VITE_SUPABASE_PROJECT_ID="local" \
+  --build-arg VITE_DEFAULT_LANGUAGE="en" \
+  -t eryxon-flow:local .
+
+docker run -d --name eryxon-flow --restart unless-stopped -p 8082:80 eryxon-flow:local
+```
+
+Open http://localhost:8082
+
+### 4. Create your first user
+
+```sql
+-- Connect to local DB
+psql postgresql://postgres:postgres@127.0.0.1:54322/postgres
+
+-- Create tenant
+INSERT INTO tenants (id, name, company_name, plan, status, timezone)
+VALUES (gen_random_uuid(), 'My Company', 'My Company', 'premium', 'active', 'Europe/Amsterdam')
+RETURNING id;
+
+-- Create auth user (replace <tenant-id> with the returned UUID)
+INSERT INTO auth.users (id, instance_id, email, encrypted_password, email_confirmed_at, role, aud, created_at, updated_at, confirmation_token, raw_app_meta_data, raw_user_meta_data,
+  email_change, email_change_token_new, email_change_token_current, phone_change, phone_change_token, reauthentication_token, recovery_token)
+VALUES (
+  gen_random_uuid(), '00000000-0000-0000-0000-000000000000',
+  'admin@example.com', crypt('your-password', gen_salt('bf')),
+  now(), 'authenticated', 'authenticated', now(), now(), '',
+  '{"provider":"email","providers":["email"]}',
+  '{"full_name":"Admin User"}',
+  '', '', '', '', '', '', ''
+) RETURNING id;
+
+-- Update the auto-created profile (trigger creates it, we fix tenant + role)
+UPDATE profiles SET
+  tenant_id = '<tenant-id>',
+  role = 'admin',
+  is_root_admin = true,
+  full_name = 'Admin User',
+  active = true
+WHERE id = '<user-id>';
+```
+
+## Known Issues & Workarounds
+
+### Captcha not needed
+
+Self-hosted Supabase has no Cloudflare Turnstile. Do **not** set `VITE_TURNSTILE_SITE_KEY` — the frontend automatically skips captcha when the key is absent.
+
+### GoTrue NULL string columns
+
+When manually inserting into `auth.users`, set all token/change columns to empty strings (not NULL):
+
+```
+email_change='', email_change_token_new='', email_change_token_current='',
+phone_change='', phone_change_token='', reauthentication_token='', recovery_token=''
+```
+
+GoTrue crashes with `Scan error on column "email_change": converting NULL to string` if these are NULL.
+
+### Phone uniqueness constraint
+
+The `auth.users.phone` column has a unique constraint. When inserting multiple users, leave `phone` unset (NULL) rather than setting it to empty string `''`.
+
+### `factory_holidays` vs `factory_calendar`
+
+The Factory Calendar UI reads from `factory_calendar` (individual date rows with `day_type`), **not** from `factory_holidays`. To show holidays on the calendar, insert into `factory_calendar`:
+
+```sql
+INSERT INTO factory_calendar (id, tenant_id, date, day_type, name, capacity_multiplier)
+VALUES (gen_random_uuid(), '<tenant-id>', '2026-04-06', 'holiday', 'Easter Monday', 0);
+```
+
+Valid `day_type` values: `'holiday'`, `'closure'`, `'half_day'`, `'working'`.
+
+### Storage bucket mime types
+
+The `parts-cad` bucket only allows CAD file types by default. To also store PDFs (technical drawings):
+
+```sql
+UPDATE storage.buckets
+SET allowed_mime_types = '{model/step,model/stl,application/sla,application/octet-stream,model/3mf,application/pdf}'
+WHERE name = 'parts-cad';
+```
+
+### File paths in `parts.file_paths`
+
+Paths should be relative to the bucket root, **without** the bucket name prefix:
+
+```
+-- Correct:
+ARRAY['MyPart/drawing.stp', 'MyPart/drawing.pdf']
+
+-- Wrong (causes double prefix in signed URL):
+ARRAY['parts-cad/MyPart/drawing.stp']
+```
+
+## Useful Commands
+
+```bash
+# Reset DB (re-apply all migrations)
+supabase db reset
+
+# Access Supabase Studio (admin UI)
+open http://127.0.0.1:54323
+
+# Direct DB access
+psql postgresql://postgres:postgres@127.0.0.1:54322/postgres
+
+# Backup
+docker exec supabase_db_<project> pg_dump -U postgres --no-owner postgres > backup.sql
+
+# Rebuild frontend after code changes
+docker rm -f eryxon-flow
+docker build --build-arg VITE_SUPABASE_URL="http://127.0.0.1:54321" \
+  --build-arg VITE_SUPABASE_PUBLISHABLE_KEY="<key>" \
+  --build-arg VITE_SUPABASE_PROJECT_ID="local" \
+  -t eryxon-flow:local .
+docker run -d --name eryxon-flow --restart unless-stopped -p 8082:80 eryxon-flow:local
+```
+
+## Ports
+
+| Service | Port |
+|---------|------|
+| Frontend (nginx) | 8082 (configurable) |
+| Supabase API (Kong) | 54321 |
+| PostgreSQL | 54322 |
+| Supabase Studio | 54323 |

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -88,7 +88,7 @@ Self-hosted Supabase has no Cloudflare Turnstile. Do **not** set `VITE_TURNSTILE
 
 When manually inserting into `auth.users`, set all token/change columns to empty strings (not NULL):
 
-```
+```sql
 email_change='', email_change_token_new='', email_change_token_current='',
 phone_change='', phone_change_token='', reauthentication_token='', recovery_token=''
 ```
@@ -124,7 +124,7 @@ WHERE name = 'parts-cad';
 
 Paths should be relative to the bucket root, **without** the bucket name prefix:
 
-```
+```sql
 -- Correct:
 ARRAY['MyPart/drawing.stp', 'MyPart/drawing.pdf']
 

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
             content="Eryxon Flow - Manufacturing Execution System"
         />
         <meta name="theme-color" content="#2563eb" />
-        <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.supabase.co https://challenges.cloudflare.com; connect-src 'self' blob: https://*.supabase.co wss://*.supabase.co https://challenges.cloudflare.com https://cdn.jsdelivr.net; font-src 'self' data:; frame-src 'self' https://challenges.cloudflare.com; object-src 'none'; base-uri 'self';" />
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.supabase.co http://127.0.0.1:* http://localhost:* https://challenges.cloudflare.com; connect-src 'self' blob: https://*.supabase.co wss://*.supabase.co http://127.0.0.1:* ws://127.0.0.1:* http://localhost:* ws://localhost:* https://challenges.cloudflare.com https://cdn.jsdelivr.net; font-src 'self' data:; frame-src 'self' https://challenges.cloudflare.com; object-src 'none'; base-uri 'self';" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <link rel="apple-touch-icon" href="/favicon.svg" />
     </head>

--- a/src/pages/admin/config/ApiKeys.tsx
+++ b/src/pages/admin/config/ApiKeys.tsx
@@ -70,7 +70,7 @@ export default function ConfigApiKeys() {
       if (!session) throw new Error('Not authenticated');
 
       const response = await fetch(
-        `https://${import.meta.env.VITE_SUPABASE_PROJECT_ID}.supabase.co/functions/v1/api-key-generate`,
+        `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/api-key-generate`,
         {
           method: 'POST',
           headers: {
@@ -361,7 +361,7 @@ export default function ConfigApiKeys() {
                 <div className="flex-1">
                   <p className="text-sm font-medium">Base URL</p>
                   <code className="text-xs bg-muted px-2 py-1 rounded block break-all">
-                    {`https://${import.meta.env.VITE_SUPABASE_PROJECT_ID || 'your-project-id'}.supabase.co/functions/v1`}
+                    {`${import.meta.env.VITE_SUPABASE_URL}/functions/v1`}
                   </code>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

- **CSP fix**: Add `localhost`/`127.0.0.1` to Content-Security-Policy `connect-src` and `img-src` so the frontend can reach a local Supabase instance
- **Edge Functions URL fix**: `ApiKeys.tsx` hardcoded `https://${PROJECT_ID}.supabase.co/functions/v1/` which fails on self-hosted (`local.supabase.co` doesn't resolve). Now uses `VITE_SUPABASE_URL` directly, consistent with `DataExport.tsx` and `DataImport.tsx`
- **Self-hosting guide**: New `docs/SELF_HOSTING.md` covering setup, user creation, known issues (GoTrue NULL columns, phone uniqueness, factory_calendar vs factory_holidays, storage bucket mime types, file_paths format)

## Context

Discovered during a pilot self-hosted deployment using `supabase start` with local Docker. Every issue in the doc was hit and resolved during setup.

## Changes

| File | Change |
|------|--------|
| `index.html` | Add local URLs to CSP connect-src and img-src |
| `src/pages/admin/config/ApiKeys.tsx` | Use `VITE_SUPABASE_URL` for functions endpoint |
| `docs/SELF_HOSTING.md` | Full self-hosting guide with known issues |

## Test plan

- [ ] Verify cloud deployment still works (CSP additions are additive, not replacing)
- [ ] Verify self-hosted: `supabase start` → build with local URL → login → API key generation works
- [ ] Verify STEP/PDF file upload and signed URL generation in self-hosted mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive self-hosting guide for deploying on self-managed Supabase, including setup prerequisites, step-by-step deployment instructions, and known issues with workarounds.

* **Bug Fixes**
  * Fixed API key generation endpoint configuration for self-hosted deployments.
  * Updated security policy to support local development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->