### PR TITLE
Add browser navigation buttons to layouts

### DIFF
--- a/src/components/AdminLayout.tsx
+++ b/src/components/AdminLayout.tsx
@@ -47,6 +47,7 @@ import {
   Boxes,
 } from "lucide-react";
 import { TenantSwitcher } from "@/components/admin/TenantSwitcher";
+import { NavigationButtons } from "@/components/NavigationButtons";
 import { Link, useLocation } from "react-router-dom";
 import { useState } from "react";
 import { cn } from "@/lib/utils";
@@ -751,6 +752,9 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
         <main className="flex-1 overflow-y-auto">
           <TrialStatusBanner />
           <div className="container mx-auto p-3 pt-14 md:p-4 md:pt-4 lg:p-5">
+            <div className="mb-2 hidden md:block">
+              <NavigationButtons />
+            </div>
             {children}
           </div>
         </main>

--- a/src/components/NavigationButtons.tsx
+++ b/src/components/NavigationButtons.tsx
@@ -15,6 +15,7 @@ export function NavigationButtons() {
         onClick={() => navigate(-1)}
         className="h-7 w-7 p-0"
         title={t("common.goBack")}
+        aria-label={t("common.goBack")}
       >
         <ChevronLeft className="h-4 w-4" />
       </Button>
@@ -24,6 +25,7 @@ export function NavigationButtons() {
         onClick={() => navigate(1)}
         className="h-7 w-7 p-0"
         title={t("common.goForward", "Go Forward")}
+        aria-label={t("common.goForward", "Go Forward")}
       >
         <ChevronRight className="h-4 w-4" />
       </Button>

--- a/src/components/NavigationButtons.tsx
+++ b/src/components/NavigationButtons.tsx
@@ -1,0 +1,32 @@
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function NavigationButtons() {
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex items-center gap-0.5">
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => navigate(-1)}
+        className="h-7 w-7 p-0"
+        title={t("common.goBack")}
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => navigate(1)}
+        className="h-7 w-7 p-0"
+        title={t("common.goForward", "Go Forward")}
+      >
+        <ChevronRight className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/src/components/operator/OperatorFooterBar.tsx
+++ b/src/components/operator/OperatorFooterBar.tsx
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 import { formatDistanceToNow } from "date-fns";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { ROUTES } from "@/routes";
 
 interface ActiveEntry {
   id: string;
@@ -170,7 +171,7 @@ export default function OperatorFooterBar() {
   };
 
   const handleReportIssue = () => {
-    navigate("/work-queue");
+    navigate(ROUTES.OPERATOR.WORK_QUEUE);
     toast.info(t("production.openOperationForIssue"));
   };
 

--- a/src/components/operator/OperatorLayout.tsx
+++ b/src/components/operator/OperatorLayout.tsx
@@ -40,6 +40,7 @@ import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { AppTour } from "@/components/onboarding";
 import { cn } from "@/lib/utils";
 import { GlobalSearch, SearchTriggerButton } from "@/components/GlobalSearch";
+import { NavigationButtons } from "@/components/NavigationButtons";
 import { TrialStatusBanner } from "@/components/admin/TrialStatusBanner";
 import { ROUTES } from "@/routes";
 
@@ -152,6 +153,7 @@ export const OperatorLayout = ({
           <div className="flex h-12 items-center justify-between px-3 sm:px-4">
             {/* Left: Back to Admin or Tenant Name */}
             <div className="flex min-w-0 items-center gap-2">
+              <NavigationButtons />
               {showBackToAdmin ? (
                 <Button
                   variant="ghost"

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -115,6 +115,7 @@
     "cancel": "Abbrechen",
     "continue": "Fortfahren",
     "goBack": "Zurück",
+    "goForward": "Vorwärts",
     "closeWindow": "Schließen",
     "saveChanges": "Änderungen speichern",
     "discardChanges": "Änderungen verwerfen",

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -1398,6 +1398,7 @@
     "cancel": "Abbrechen",
     "continue": "Fortfahren",
     "goBack": "Zurück",
+    "goForward": "Vorwärts",
     "closeWindow": "Schließen",
     "saveChanges": "Änderungen speichern",
     "discardChanges": "Änderungen verwerfen",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -117,6 +117,7 @@
     "cancel": "Cancel",
     "continue": "Continue",
     "goBack": "Go Back",
+    "goForward": "Go Forward",
     "closeWindow": "Close",
     "saveChanges": "Save Changes",
     "discardChanges": "Discard Changes",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -1714,6 +1714,7 @@
     "cancel": "Cancel",
     "continue": "Continue",
     "goBack": "Go Back",
+    "goForward": "Go Forward",
     "closeWindow": "Close",
     "saveChanges": "Save Changes",
     "discardChanges": "Discard Changes",

--- a/src/i18n/locales/nl/common.json
+++ b/src/i18n/locales/nl/common.json
@@ -116,6 +116,7 @@
     "cancel": "Annuleren",
     "continue": "Doorgaan",
     "goBack": "Terug",
+    "goForward": "Vooruit",
     "closeWindow": "Sluiten",
     "saveChanges": "Wijzigingen opslaan",
     "discardChanges": "Wijzigingen negeren",

--- a/src/i18n/locales/nl/translation.json
+++ b/src/i18n/locales/nl/translation.json
@@ -1665,6 +1665,7 @@
     "cancel": "Annuleren",
     "continue": "Doorgaan",
     "goBack": "Terug",
+    "goForward": "Vooruit",
     "closeWindow": "Sluiten",
     "saveChanges": "Wijzigingen opslaan",
     "discardChanges": "Wijzigingen negeren",

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
-import { Link, useLocation } from "react-router-dom";
-import { Compass, ArrowLeft } from "lucide-react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import { Compass, ArrowLeft, RotateCcw } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -9,6 +9,7 @@ import { logger } from "@/lib/logger";
 const NotFound = () => {
   const { t } = useTranslation();
   const location = useLocation();
+  const navigate = useNavigate();
 
   useEffect(() => {
     logger.warn("Router", "404: User accessed non-existent route", location.pathname);
@@ -30,12 +31,18 @@ const NotFound = () => {
           <p className="mt-2 max-w-md break-words whitespace-normal text-sm text-muted-foreground">
             {location.pathname}
           </p>
-          <Button asChild className="mt-6 min-h-11 rounded-xl px-4">
-            <Link to="/">
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              {t("common.returnToHome")}
-            </Link>
-          </Button>
+          <div className="mt-6 flex items-center gap-3">
+            <Button onClick={() => navigate(-1)} variant="outline" className="min-h-11 rounded-xl px-4">
+              <RotateCcw className="mr-2 h-4 w-4" />
+              {t("common.goBack")}
+            </Button>
+            <Button asChild className="min-h-11 rounded-xl px-4">
+              <Link to="/">
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                {t("common.returnToHome")}
+              </Link>
+            </Button>
+          </div>
         </div>
       </Card>
     </div>

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -42,9 +42,9 @@ export default function Auth() {
 
   if (profile) {
     if (profile.role === "admin") {
-      navigate("/dashboard");
+      navigate(ROUTES.ADMIN.DASHBOARD);
     } else {
-      navigate("/queue");
+      navigate(ROUTES.OPERATOR.WORK_QUEUE);
     }
     return null;
   }


### PR DESCRIPTION
## Summary
- Created a new `NavigationButtons` component that provides back/forward navigation using browser history
- Integrated navigation buttons into admin and operator layouts for improved UX
- Enhanced 404 page with a "Go Back" option alongside the existing "Return to Home" button
- Added i18n translations for "Go Forward" across all supported languages (EN, DE, NL)

## Changes
- **New Component**: `NavigationButtons.tsx` - Reusable component with back/forward chevron buttons using `navigate(-1)` and `navigate(1)` from react-router-dom
- **AdminLayout**: Added `NavigationButtons` component in a hidden-on-mobile container above main content
- **OperatorLayout**: Added `NavigationButtons` component in the header's left section
- **NotFound Page**: Replaced single "Return to Home" button with a two-button layout offering both "Go Back" and "Return to Home" options
- **Auth Page**: Refactored hardcoded navigation paths to use `ROUTES` constants for consistency
- **OperatorFooterBar**: Updated hardcoded route to use `ROUTES.OPERATOR.WORK_QUEUE` constant
- **i18n**: Added `goForward` translation key to all locale files (en, de, nl) in both common.json and translation.json

## Checklist
- [x] `npm run build` passes
- [x] `npm run test:run` passes
- [x] New UI text uses i18n keys (EN + NL + DE)

https://claude.ai/code/session_016E9VMdNMeV2bpn7Tfmw3Lp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added back/forward navigation buttons to admin and operator headers (visible on medium+ screens) for easier browser-like navigation.
  * Enhanced the 404 page with a "go back" button option alongside the home navigation.

* **Internationalization**
  * Added localized "Go Forward" labels in English, German, and Dutch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->