### PR TITLE
claude/fix-turnstile-login-cxRmr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eryxon-flow",
-  "version": "0.3.3",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eryxon-flow",
-      "version": "0.3.3",
+      "version": "0.4.1",
       "license": "BSL-1.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -15,7 +15,6 @@
         "@fontsource/inter": "^5.2.8",
         "@fontsource/inter-tight": "^5.2.7",
         "@hookform/resolvers": "^5.2.2",
-        "@marsidev/react-turnstile": "^1.4.2",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-aspect-ratio": "^1.1.8",
@@ -1292,16 +1291,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@marsidev/react-turnstile": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@marsidev/react-turnstile/-/react-turnstile-1.4.2.tgz",
-      "integrity": "sha512-xs1qOuyeMOz6t9BXXCXWiukC0/0+48vR08B7uwNdG05wCMnbcNgxiFmdFKDOFbM76qFYFRYlGeRfhfq1U/iZmA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^17.0.2 || ^18.0.0 || ^19.0",
-        "react-dom": "^17.0.2 || ^18.0.0 || ^19.0"
       }
     },
     "node_modules/@mswjs/interceptors": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@fontsource/inter": "^5.2.8",
     "@fontsource/inter-tight": "^5.2.7",
     "@hookform/resolvers": "^5.2.2",
-    "@marsidev/react-turnstile": "^1.4.2",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-aspect-ratio": "^1.1.8",

--- a/src/components/auth/TurnstileWidget.tsx
+++ b/src/components/auth/TurnstileWidget.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useRef, useCallback } from "react";
+
+/**
+ * Cloudflare Turnstile widget — uses the explicit rendering API directly.
+ *
+ * Key design choice: this widget is **non-blocking**.  If the script fails to
+ * load, or the challenge never completes, the parent form can still submit.
+ * The parent owns the `captchaToken` state and decides whether to require it.
+ */
+
+// ── Cloudflare Turnstile type declarations ──────────────────────────────────
+
+interface TurnstileRenderOptions {
+  sitekey: string;
+  callback?: (token: string) => void;
+  "error-callback"?: () => void;
+  "expired-callback"?: () => void;
+  theme?: "light" | "dark" | "auto";
+  size?: "normal" | "compact";
+  action?: string;
+}
+
+interface TurnstileAPI {
+  render: (container: string | HTMLElement, options: TurnstileRenderOptions) => string;
+  reset: (widgetId: string) => void;
+  remove: (widgetId: string) => void;
+}
+
+declare global {
+  interface Window {
+    turnstile?: TurnstileAPI;
+  }
+}
+
+// ── Script loader (singleton — idempotent across multiple mounts) ───────────
+
+const SCRIPT_URL =
+  "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+
+let scriptPromise: Promise<void> | null = null;
+
+function loadTurnstileScript(): Promise<void> {
+  if (window.turnstile) return Promise.resolve();
+
+  if (scriptPromise) return scriptPromise;
+
+  scriptPromise = new Promise<void>((resolve, reject) => {
+    // Check if script tag already exists (e.g. from a previous mount)
+    const existing = document.querySelector<HTMLScriptElement>(
+      `script[src^="https://challenges.cloudflare.com/turnstile"]`,
+    );
+    if (existing) {
+      existing.addEventListener("load", () => resolve());
+      existing.addEventListener("error", () => reject(new Error("Turnstile script failed to load")));
+      if (window.turnstile) resolve();
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.src = SCRIPT_URL;
+    script.async = true;
+    script.defer = true;
+    script.addEventListener("load", () => resolve());
+    script.addEventListener("error", () => {
+      scriptPromise = null; // allow retry
+      reject(new Error("Turnstile script failed to load"));
+    });
+    document.head.appendChild(script);
+  });
+
+  return scriptPromise;
+}
+
+// ── Component ───────────────────────────────────────────────────────────────
+
+interface TurnstileWidgetProps {
+  siteKey: string;
+  onToken: (token: string) => void;
+  onError?: () => void;
+  onExpire?: () => void;
+  theme?: "light" | "dark" | "auto";
+  size?: "normal" | "compact";
+  /** Bump this value to force a widget reset (e.g. after form submission). */
+  resetKey?: number;
+}
+
+export function TurnstileWidget({
+  siteKey,
+  onToken,
+  onError,
+  onExpire,
+  theme = "dark",
+  size = "normal",
+  resetKey = 0,
+}: TurnstileWidgetProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const widgetIdRef = useRef<string | null>(null);
+
+  // Keep callback refs fresh without re-rendering the widget
+  const onTokenRef = useRef(onToken);
+  const onErrorRef = useRef(onError);
+  const onExpireRef = useRef(onExpire);
+  onTokenRef.current = onToken;
+  onErrorRef.current = onError;
+  onExpireRef.current = onExpire;
+
+  const renderWidget = useCallback(() => {
+    if (!containerRef.current || !window.turnstile) return;
+
+    // Clean up any existing widget in this container
+    if (widgetIdRef.current) {
+      try {
+        window.turnstile.remove(widgetIdRef.current);
+      } catch {
+        // Widget may already be removed
+      }
+      widgetIdRef.current = null;
+    }
+
+    try {
+      widgetIdRef.current = window.turnstile.render(containerRef.current, {
+        sitekey: siteKey,
+        theme,
+        size,
+        callback: (token: string) => {
+          console.debug("[Turnstile] Token received");
+          onTokenRef.current(token);
+        },
+        "error-callback": () => {
+          console.warn("[Turnstile] Challenge error");
+          onErrorRef.current?.();
+        },
+        "expired-callback": () => {
+          console.debug("[Turnstile] Token expired, re-rendering");
+          onExpireRef.current?.();
+          // Auto-reset on expiry so a fresh challenge appears
+          if (widgetIdRef.current && window.turnstile) {
+            try {
+              window.turnstile.reset(widgetIdRef.current);
+            } catch {
+              // Ignore reset errors
+            }
+          }
+        },
+      });
+      console.debug("[Turnstile] Widget rendered", widgetIdRef.current);
+    } catch (err) {
+      console.warn("[Turnstile] Failed to render widget:", err);
+    }
+  }, [siteKey, theme, size]);
+
+  // Load script & render on mount; re-render when resetKey changes
+  useEffect(() => {
+    let cancelled = false;
+
+    loadTurnstileScript()
+      .then(() => {
+        if (!cancelled) renderWidget();
+      })
+      .catch((err) => {
+        console.warn("[Turnstile] Script load failed:", err);
+      });
+
+    return () => {
+      cancelled = true;
+      if (widgetIdRef.current && window.turnstile) {
+        try {
+          window.turnstile.remove(widgetIdRef.current);
+        } catch {
+          // Ignore removal errors during unmount
+        }
+        widgetIdRef.current = null;
+      }
+    };
+  }, [renderWidget, resetKey]);
+
+  return <div ref={containerRef} />;
+}

--- a/src/components/auth/TurnstileWidget.tsx
+++ b/src/components/auth/TurnstileWidget.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
+import { logger } from "@/lib/logger";
 
 /**
  * Cloudflare Turnstile widget — uses the explicit rendering API directly.
@@ -17,7 +18,6 @@ interface TurnstileRenderOptions {
   "expired-callback"?: () => void;
   theme?: "light" | "dark" | "auto";
   size?: "normal" | "compact";
-  action?: string;
 }
 
 interface TurnstileAPI {
@@ -36,39 +36,55 @@ declare global {
 
 const SCRIPT_URL =
   "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+const SCRIPT_SELECTOR = `script[src^="https://challenges.cloudflare.com/turnstile"]`;
 
 let scriptPromise: Promise<void> | null = null;
 
 function loadTurnstileScript(): Promise<void> {
   if (window.turnstile) return Promise.resolve();
-
   if (scriptPromise) return scriptPromise;
 
   scriptPromise = new Promise<void>((resolve, reject) => {
-    // Check if script tag already exists (e.g. from a previous mount)
-    const existing = document.querySelector<HTMLScriptElement>(
-      `script[src^="https://challenges.cloudflare.com/turnstile"]`,
-    );
-    if (existing) {
-      existing.addEventListener("load", () => resolve());
-      existing.addEventListener("error", () => reject(new Error("Turnstile script failed to load")));
-      if (window.turnstile) resolve();
-      return;
-    }
+    const existing = document.querySelector<HTMLScriptElement>(SCRIPT_SELECTOR);
+    const script = existing ?? document.createElement("script");
 
-    const script = document.createElement("script");
-    script.src = SCRIPT_URL;
-    script.async = true;
-    script.defer = true;
-    script.addEventListener("load", () => resolve());
-    script.addEventListener("error", () => {
-      scriptPromise = null; // allow retry
+    const handleError = () => {
+      scriptPromise = null;
+      script.remove();
       reject(new Error("Turnstile script failed to load"));
-    });
-    document.head.appendChild(script);
+    };
+
+    script.addEventListener("load", () => resolve(), { once: true });
+    script.addEventListener("error", handleError, { once: true });
+
+    if (!existing) {
+      script.src = SCRIPT_URL;
+      script.async = true;
+      script.defer = true;
+      document.head.appendChild(script);
+    }
   });
 
   return scriptPromise;
+}
+
+// ── Hook ────────────────────────────────────────────────────────────────────
+
+/**
+ * Owns captcha token state + a reset counter that forces the widget to
+ * re-render with a fresh challenge.  Tokens are single-use — callers must
+ * invoke `reset()` after every submission attempt.
+ */
+export function useTurnstile() {
+  const [captchaToken, setCaptchaToken] = useState<string | null>(null);
+  const [resetKey, setResetKey] = useState(0);
+
+  const reset = useCallback(() => {
+    setCaptchaToken(null);
+    setResetKey((k) => k + 1);
+  }, []);
+
+  return { captchaToken, setCaptchaToken, resetKey, reset };
 }
 
 // ── Component ───────────────────────────────────────────────────────────────
@@ -96,69 +112,70 @@ export function TurnstileWidget({
   const containerRef = useRef<HTMLDivElement>(null);
   const widgetIdRef = useRef<string | null>(null);
 
-  // Keep callback refs fresh without re-rendering the widget
+  // Callback refs are read inside Turnstile's own callbacks, which are
+  // registered once with the widget.  Keeping refs fresh lets the parent pass
+  // inline closures without re-rendering the widget on every parent render.
   const onTokenRef = useRef(onToken);
   const onErrorRef = useRef(onError);
   const onExpireRef = useRef(onExpire);
-  onTokenRef.current = onToken;
-  onErrorRef.current = onError;
-  onExpireRef.current = onExpire;
+  useEffect(() => {
+    onTokenRef.current = onToken;
+    onErrorRef.current = onError;
+    onExpireRef.current = onExpire;
+  }, [onToken, onError, onExpire]);
 
-  const renderWidget = useCallback(() => {
-    if (!containerRef.current || !window.turnstile) return;
-
-    // Clean up any existing widget in this container
-    if (widgetIdRef.current) {
-      try {
-        window.turnstile.remove(widgetIdRef.current);
-      } catch {
-        // Widget may already be removed
-      }
-      widgetIdRef.current = null;
-    }
-
-    try {
-      widgetIdRef.current = window.turnstile.render(containerRef.current, {
-        sitekey: siteKey,
-        theme,
-        size,
-        callback: (token: string) => {
-          console.debug("[Turnstile] Token received");
-          onTokenRef.current(token);
-        },
-        "error-callback": () => {
-          console.warn("[Turnstile] Challenge error");
-          onErrorRef.current?.();
-        },
-        "expired-callback": () => {
-          console.debug("[Turnstile] Token expired, re-rendering");
-          onExpireRef.current?.();
-          // Auto-reset on expiry so a fresh challenge appears
-          if (widgetIdRef.current && window.turnstile) {
-            try {
-              window.turnstile.reset(widgetIdRef.current);
-            } catch {
-              // Ignore reset errors
-            }
-          }
-        },
-      });
-      console.debug("[Turnstile] Widget rendered", widgetIdRef.current);
-    } catch (err) {
-      console.warn("[Turnstile] Failed to render widget:", err);
-    }
-  }, [siteKey, theme, size]);
-
-  // Load script & render on mount; re-render when resetKey changes
   useEffect(() => {
     let cancelled = false;
+
+    const renderWidget = () => {
+      if (!containerRef.current || !window.turnstile) return;
+
+      if (widgetIdRef.current) {
+        try {
+          window.turnstile.remove(widgetIdRef.current);
+        } catch {
+          // Widget may already be removed
+        }
+        widgetIdRef.current = null;
+      }
+
+      try {
+        widgetIdRef.current = window.turnstile.render(containerRef.current, {
+          sitekey: siteKey,
+          theme,
+          size,
+          callback: (token: string) => {
+            logger.debug("TurnstileWidget", "Token received");
+            onTokenRef.current(token);
+          },
+          "error-callback": () => {
+            logger.warn("TurnstileWidget", "Challenge error");
+            onErrorRef.current?.();
+          },
+          "expired-callback": () => {
+            logger.debug("TurnstileWidget", "Token expired, re-rendering");
+            onExpireRef.current?.();
+            if (widgetIdRef.current && window.turnstile) {
+              try {
+                window.turnstile.reset(widgetIdRef.current);
+              } catch {
+                // Ignore reset errors
+              }
+            }
+          },
+        });
+        logger.debug("TurnstileWidget", "Widget rendered", { widgetId: widgetIdRef.current });
+      } catch (err) {
+        logger.warn("TurnstileWidget", "Failed to render widget", err);
+      }
+    };
 
     loadTurnstileScript()
       .then(() => {
         if (!cancelled) renderWidget();
       })
       .catch((err) => {
-        console.warn("[Turnstile] Script load failed:", err);
+        logger.warn("TurnstileWidget", "Script load failed", err);
       });
 
     return () => {
@@ -172,7 +189,7 @@ export function TurnstileWidget({
         widgetIdRef.current = null;
       }
     };
-  }, [renderWidget, resetKey]);
+  }, [siteKey, theme, size, resetKey]);
 
   return <div ref={containerRef} />;
 }

--- a/src/i18n/locales/de/auth.json
+++ b/src/i18n/locales/de/auth.json
@@ -24,8 +24,6 @@
     "haveAccount": "Haben Sie bereits ein Konto? Melden Sie sich an",
     "fillAllFields": "Bitte füllen Sie alle Felder aus",
     "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten",
-    "captchaRequired": "Bitte vervollständigen Sie die Captcha-Verifizierung",
-    "captchaError": "Captcha-Verifizierung fehlgeschlagen. Bitte versuchen Sie es erneut.",
     "agreeToTerms": "Ich stimme dem",
     "privacyPolicy": "Datenschutzrichtlinie",
     "and": "und den",

--- a/src/i18n/locales/en/auth.json
+++ b/src/i18n/locales/en/auth.json
@@ -24,8 +24,6 @@
     "haveAccount": "Already have an account? Sign in",
     "fillAllFields": "Please fill in all fields",
     "unexpectedError": "An unexpected error occurred",
-    "captchaRequired": "Please complete the captcha verification",
-    "captchaError": "Captcha verification failed. Please try again.",
     "agreeToTerms": "I agree to the",
     "privacyPolicy": "Privacy Policy",
     "and": "and",

--- a/src/i18n/locales/nl/auth.json
+++ b/src/i18n/locales/nl/auth.json
@@ -24,8 +24,6 @@
     "haveAccount": "Heeft u al een account? Meld u aan",
     "fillAllFields": "Vul alle velden in",
     "unexpectedError": "Er is een onverwachte fout opgetreden",
-    "captchaRequired": "Voltooi alstublieft de captcha-verificatie",
-    "captchaError": "Captcha-verificatie mislukt. Probeer het opnieuw.",
     "agreeToTerms": "Ik ga akkoord met het",
     "privacyPolicy": "Privacybeleid",
     "and": "en",

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -10,12 +10,11 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Loader2, ArrowRight, CheckCircle2, Info, Monitor } from "lucide-react";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { AuthCardHeader, AuthShell } from "@/components/auth/AuthShell";
-import { TurnstileWidget } from "@/components/auth/TurnstileWidget";
+import { TurnstileWidget, useTurnstile } from "@/components/auth/TurnstileWidget";
 import { Link } from "react-router-dom";
 import { ROUTES } from "@/routes";
 
 const TURNSTILE_SITE_KEY = import.meta.env.VITE_TURNSTILE_SITE_KEY as string | undefined;
-const TURNSTILE_ENABLED = Boolean(TURNSTILE_SITE_KEY);
 
 export default function Auth() {
   const { t } = useTranslation();
@@ -29,8 +28,7 @@ export default function Auth() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
-  const [captchaToken, setCaptchaToken] = useState<string | null>(null);
-  const [turnstileResetKey, setTurnstileResetKey] = useState(0);
+  const { captchaToken, setCaptchaToken, resetKey, reset: resetTurnstile } = useTurnstile();
   const { signIn, signUp, profile } = useAuth();
   const navigate = useNavigate();
 
@@ -95,10 +93,7 @@ export default function Auth() {
     } catch (err) {
       setError(t("auth.unexpectedError"));
     } finally {
-      // Tokens are single-use — bump the reset key so the widget
-      // re-renders with a fresh challenge for the next attempt.
-      setCaptchaToken(null);
-      setTurnstileResetKey((k) => k + 1);
+      resetTurnstile();
       setLoading(false);
     }
   };
@@ -246,16 +241,16 @@ export default function Auth() {
           </Alert>
         )}
 
-        {TURNSTILE_ENABLED && TURNSTILE_SITE_KEY && (
+        {TURNSTILE_SITE_KEY && (
           <div className="flex justify-center">
             <TurnstileWidget
               siteKey={TURNSTILE_SITE_KEY}
-              onToken={(token) => setCaptchaToken(token)}
+              onToken={setCaptchaToken}
               onError={() => setCaptchaToken(null)}
               onExpire={() => setCaptchaToken(null)}
               theme="dark"
               size="normal"
-              resetKey={turnstileResetKey}
+              resetKey={resetKey}
             />
           </div>
         )}

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -1,7 +1,6 @@
-import { useState, useRef, lazy, Suspense } from "react";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import type { TurnstileInstance } from "@marsidev/react-turnstile";
 import { useAuth } from "@/contexts/AuthContext";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -11,17 +10,12 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Loader2, ArrowRight, CheckCircle2, Info, Monitor } from "lucide-react";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { AuthCardHeader, AuthShell } from "@/components/auth/AuthShell";
+import { TurnstileWidget } from "@/components/auth/TurnstileWidget";
 import { Link } from "react-router-dom";
 import { ROUTES } from "@/routes";
 
-// Lazy-load Turnstile — only fetched when VITE_TURNSTILE_SITE_KEY is set.
-// Self-hosted deployments without Turnstile pay zero bundle cost.
-const TURNSTILE_ENABLED = Boolean(import.meta.env.VITE_TURNSTILE_SITE_KEY);
-const LazyTurnstile = TURNSTILE_ENABLED
-  ? lazy(() =>
-      import("@marsidev/react-turnstile").then((m) => ({ default: m.Turnstile }))
-    )
-  : null;
+const TURNSTILE_SITE_KEY = import.meta.env.VITE_TURNSTILE_SITE_KEY as string | undefined;
+const TURNSTILE_ENABLED = Boolean(TURNSTILE_SITE_KEY);
 
 export default function Auth() {
   const { t } = useTranslation();
@@ -36,7 +30,7 @@ export default function Auth() {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [captchaToken, setCaptchaToken] = useState<string | null>(null);
-  const turnstileRef = useRef<TurnstileInstance | null>(null);
+  const [turnstileResetKey, setTurnstileResetKey] = useState(0);
   const { signIn, signUp, profile } = useAuth();
   const navigate = useNavigate();
 
@@ -56,12 +50,6 @@ export default function Auth() {
     setLoading(true);
 
     try {
-      if (TURNSTILE_ENABLED && !captchaToken) {
-        setError(t("auth.captchaRequired"));
-        setLoading(false);
-        return;
-      }
-
       if (isLogin) {
         const { error } = await signIn(email, password, captchaToken);
         if (error) {
@@ -107,10 +95,10 @@ export default function Auth() {
     } catch (err) {
       setError(t("auth.unexpectedError"));
     } finally {
-      // Tokens are single-use — always reset the widget after every
-      // submission so a fresh token is generated for the next attempt.
-      turnstileRef.current?.reset();
+      // Tokens are single-use — bump the reset key so the widget
+      // re-renders with a fresh challenge for the next attempt.
       setCaptchaToken(null);
+      setTurnstileResetKey((k) => k + 1);
       setLoading(false);
     }
   };
@@ -258,35 +246,25 @@ export default function Auth() {
           </Alert>
         )}
 
-        {TURNSTILE_ENABLED && LazyTurnstile && (
-          <Suspense fallback={<div className="flex justify-center py-2"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>}>
-            <div className="flex justify-center">
-              <LazyTurnstile
-                ref={turnstileRef}
-                siteKey={import.meta.env.VITE_TURNSTILE_SITE_KEY!}
-                onSuccess={(token: string) => setCaptchaToken(token)}
-                onError={() => {
-                  setError(t("auth.captchaError"));
-                  setCaptchaToken(null);
-                }}
-                onExpire={() => {
-                  setCaptchaToken(null);
-                  turnstileRef.current?.reset();
-                }}
-                options={{
-                  theme: "dark",
-                  size: "normal",
-                }}
-              />
-            </div>
-          </Suspense>
+        {TURNSTILE_ENABLED && TURNSTILE_SITE_KEY && (
+          <div className="flex justify-center">
+            <TurnstileWidget
+              siteKey={TURNSTILE_SITE_KEY}
+              onToken={(token) => setCaptchaToken(token)}
+              onError={() => setCaptchaToken(null)}
+              onExpire={() => setCaptchaToken(null)}
+              theme="dark"
+              size="normal"
+              resetKey={turnstileResetKey}
+            />
+          </div>
         )}
 
         <div className="pt-2">
           <Button
             type="submit"
             className="w-full cta-button"
-            disabled={loading || (!isLogin && !termsAgreed) || (TURNSTILE_ENABLED && !captchaToken)}
+            disabled={loading || (!isLogin && !termsAgreed)}
           >
             {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
             {isLogin ? t("auth.signIn") : t("auth.signUp")}

--- a/src/pages/auth/ForgotPassword.tsx
+++ b/src/pages/auth/ForgotPassword.tsx
@@ -9,12 +9,11 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Loader2, ArrowLeft, Factory, CheckCircle2, Mail } from "lucide-react";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { AuthCardHeader, AuthShell } from "@/components/auth/AuthShell";
-import { TurnstileWidget } from "@/components/auth/TurnstileWidget";
+import { TurnstileWidget, useTurnstile } from "@/components/auth/TurnstileWidget";
 import { ROUTES } from "@/routes";
 import { logger } from "@/lib/logger";
 
 const TURNSTILE_SITE_KEY = import.meta.env.VITE_TURNSTILE_SITE_KEY as string | undefined;
-const TURNSTILE_ENABLED = Boolean(TURNSTILE_SITE_KEY);
 
 export default function ForgotPassword() {
   const { t } = useTranslation();
@@ -22,8 +21,7 @@ export default function ForgotPassword() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
-  const [captchaToken, setCaptchaToken] = useState<string | null>(null);
-  const [turnstileResetKey, setTurnstileResetKey] = useState(0);
+  const { captchaToken, setCaptchaToken, resetKey, reset: resetTurnstile } = useTurnstile();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -46,10 +44,7 @@ export default function ForgotPassword() {
       logger.error('ForgotPassword', 'Password reset error', err);
       setError(t("auth.unexpectedError"));
     } finally {
-      // Tokens are single-use — bump the reset key so the widget
-      // re-renders with a fresh challenge for the next attempt.
-      setCaptchaToken(null);
-      setTurnstileResetKey((k) => k + 1);
+      resetTurnstile();
       setLoading(false);
     }
   };
@@ -109,16 +104,16 @@ export default function ForgotPassword() {
             </Alert>
           )}
 
-          {TURNSTILE_ENABLED && TURNSTILE_SITE_KEY && (
+          {TURNSTILE_SITE_KEY && (
             <div className="flex justify-center">
               <TurnstileWidget
                 siteKey={TURNSTILE_SITE_KEY}
-                onToken={(token) => setCaptchaToken(token)}
+                onToken={setCaptchaToken}
                 onError={() => setCaptchaToken(null)}
                 onExpire={() => setCaptchaToken(null)}
                 theme="dark"
                 size="normal"
-                resetKey={turnstileResetKey}
+                resetKey={resetKey}
               />
             </div>
           )}

--- a/src/pages/auth/ForgotPassword.tsx
+++ b/src/pages/auth/ForgotPassword.tsx
@@ -1,7 +1,6 @@
-import { useState, useRef, lazy, Suspense } from "react";
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import type { TurnstileInstance } from "@marsidev/react-turnstile";
 import { supabase } from "@/integrations/supabase/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -10,17 +9,12 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Loader2, ArrowLeft, Factory, CheckCircle2, Mail } from "lucide-react";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { AuthCardHeader, AuthShell } from "@/components/auth/AuthShell";
+import { TurnstileWidget } from "@/components/auth/TurnstileWidget";
 import { ROUTES } from "@/routes";
 import { logger } from "@/lib/logger";
 
-const TURNSTILE_ENABLED = Boolean(import.meta.env.VITE_TURNSTILE_SITE_KEY);
-const LazyTurnstile = TURNSTILE_ENABLED
-  ? lazy(() =>
-      import("@marsidev/react-turnstile").then((m) => ({
-        default: m.Turnstile,
-      })),
-    )
-  : null;
+const TURNSTILE_SITE_KEY = import.meta.env.VITE_TURNSTILE_SITE_KEY as string | undefined;
+const TURNSTILE_ENABLED = Boolean(TURNSTILE_SITE_KEY);
 
 export default function ForgotPassword() {
   const { t } = useTranslation();
@@ -29,18 +23,12 @@ export default function ForgotPassword() {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
   const [captchaToken, setCaptchaToken] = useState<string | null>(null);
-  const turnstileRef = useRef<TurnstileInstance | null>(null);
+  const [turnstileResetKey, setTurnstileResetKey] = useState(0);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
     setLoading(true);
-
-    if (TURNSTILE_ENABLED && !captchaToken) {
-      setError(t("auth.captchaRequired"));
-      setLoading(false);
-      return;
-    }
 
     try {
       const { error } = await supabase.auth.resetPasswordForEmail(email, {
@@ -58,9 +46,10 @@ export default function ForgotPassword() {
       logger.error('ForgotPassword', 'Password reset error', err);
       setError(t("auth.unexpectedError"));
     } finally {
-      // Tokens are single-use — always reset after submission.
-      turnstileRef.current?.reset();
+      // Tokens are single-use — bump the reset key so the widget
+      // re-renders with a fresh challenge for the next attempt.
       setCaptchaToken(null);
+      setTurnstileResetKey((k) => k + 1);
       setLoading(false);
     }
   };
@@ -120,41 +109,25 @@ export default function ForgotPassword() {
             </Alert>
           )}
 
-          {TURNSTILE_ENABLED && LazyTurnstile && (
-            <Suspense
-              fallback={
-                <div className="flex justify-center py-2">
-                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-                </div>
-              }
-            >
-              <div className="flex justify-center">
-                <LazyTurnstile
-                  ref={turnstileRef}
-                  siteKey={import.meta.env.VITE_TURNSTILE_SITE_KEY!}
-                  onSuccess={(token: string) => setCaptchaToken(token)}
-                  onError={() => {
-                    setError(t("auth.captchaError"));
-                    setCaptchaToken(null);
-                  }}
-                  onExpire={() => {
-                    setCaptchaToken(null);
-                    turnstileRef.current?.reset();
-                  }}
-                  options={{
-                    theme: "dark",
-                    size: "normal",
-                  }}
-                />
-              </div>
-            </Suspense>
+          {TURNSTILE_ENABLED && TURNSTILE_SITE_KEY && (
+            <div className="flex justify-center">
+              <TurnstileWidget
+                siteKey={TURNSTILE_SITE_KEY}
+                onToken={(token) => setCaptchaToken(token)}
+                onError={() => setCaptchaToken(null)}
+                onExpire={() => setCaptchaToken(null)}
+                theme="dark"
+                size="normal"
+                resetKey={turnstileResetKey}
+              />
+            </div>
           )}
 
           <div className="pt-2">
             <Button
               type="submit"
               className="w-full cta-button"
-              disabled={loading || (TURNSTILE_ENABLED && !captchaToken)}
+              disabled={loading}
             >
               {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               {t("auth.sendResetLink")}


### PR DESCRIPTION
The Turnstile widget was permanently blocking the submit button because
the third-party @marsidev/react-turnstile widget never completed its
challenge (likely due to site-key/domain mismatch), keeping captchaToken
as null and the button disabled with no error message.

Changes:
- Replace @marsidev/react-turnstile with a custom TurnstileWidget that
  uses Cloudflare's explicit rendering API directly (zero third-party
  wrapper risk)
- Make Turnstile non-blocking: the submit button is NEVER disabled by
  captcha state. If the widget completes, the token is sent for extra
  protection. If it doesn't, the form still submits.
- Add console.debug/warn logging for Turnstile lifecycle events to aid
  future debugging
- Tokens are still single-use with reset-on-submit via a resetKey prop
- Remove @marsidev/react-turnstile dependency from package.json

https://claude.ai/code/session_01DqXHHqAVxz2v4ARWLbLxAm