### PR TITLE
Claude/setup cadexsoft local kk ra x

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,19 @@ VITE_SUPABASE_PROJECT_ID="your-project-id"
 # VITE_CAD_SERVICE_API_KEY="your-api-key-here"
 
 # =============================================================================
+# CADEXSOFT MTK — LOCAL-ONLY (Optional)
+# =============================================================================
+# Local URL of the CADEXsoft Manufacturing Toolkit service shipped in
+# services/cadexsoft/. This service MUST run on the same host or a private
+# network — the MTK license binds to the environment and CAD files are
+# customer IP. Do NOT set this to a public URL.
+#
+# See docs/CADEXSOFT_INTEGRATION.md and services/cadexsoft/README.md
+
+# VITE_CADEXSOFT_URL="http://localhost:8891"
+# VITE_CADEXSOFT_API_KEY="a-shared-secret-matching-CADEXSOFT_API_KEY-on-the-service"
+
+# =============================================================================
 # TESTING (Optional - development only)
 # =============================================================================
 

--- a/docker-compose.cadexsoft.yml
+++ b/docker-compose.cadexsoft.yml
@@ -1,0 +1,53 @@
+# Local-only CADEXsoft MTK service overlay.
+#
+# Compose this on top of docker-compose.yml whenever the operator has a valid
+# MTK license and the wheel from their Customer Corner. Kept separate because:
+#
+#  1. The service is opt-in (many deployments will not use DFM analysis).
+#  2. The wheel and license are licensed artifacts not present in the repo.
+#  3. The service must stay on a private network — it is never exposed publicly.
+#
+# Bring it up alongside the main app:
+#
+#     docker compose \
+#         -f docker-compose.yml \
+#         -f docker-compose.cadexsoft.yml \
+#         --profile cadexsoft \
+#         up -d
+#
+# Or standalone for development:
+#
+#     docker compose -f docker-compose.cadexsoft.yml --profile cadexsoft up --build
+
+services:
+  cadexsoft:
+    profiles: ["cadexsoft"]
+    build:
+      context: ./services/cadexsoft
+      dockerfile: Dockerfile
+      args:
+        # Point this at a private, pre-authenticated URL if you do not want the
+        # wheel committed to vendor/. Leave empty to use ./services/cadexsoft/vendor/.
+        MTK_WHEEL_URL: "${MTK_WHEEL_URL:-}"
+    container_name: cadexsoft
+    restart: unless-stopped
+    environment:
+      CADEXSOFT_API_KEY: "${CADEXSOFT_API_KEY:-}"
+      CADEXSOFT_CORS_ORIGINS: "${CADEXSOFT_CORS_ORIGINS:-http://localhost:8080,http://localhost:5173}"
+      CADEXSOFT_MAX_UPLOAD_BYTES: "${CADEXSOFT_MAX_UPLOAD_BYTES:-209715200}"
+      CADEXSOFT_LOG_LEVEL: "${CADEXSOFT_LOG_LEVEL:-INFO}"
+      CADEXSOFT_FORCE_STUB: "${CADEXSOFT_FORCE_STUB:-}"
+    # Bind only to loopback by default. Override with CADEXSOFT_BIND=0.0.0.0
+    # on a private network if another host needs to reach the service.
+    ports:
+      - "${CADEXSOFT_BIND:-127.0.0.1}:${CADEXSOFT_PORT:-8891}:8891"
+    volumes:
+      # License module is mounted at runtime so rotating it does not require
+      # rebuilding the image.
+      - ./services/cadexsoft/license:/srv/license:ro
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8891/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s

--- a/docs/CADEXSOFT_INTEGRATION.md
+++ b/docs/CADEXSOFT_INTEGRATION.md
@@ -1,0 +1,164 @@
+# CADEXsoft MTK Integration
+
+> **Status:** groundwork landed — service scaffold, TypeScript client, Docker
+> overlay, and env wiring. Analyzers themselves are stubs until a licensed MTK
+> Python wheel and license file are dropped in by an operator.
+>
+> **Upstream docs:** https://docs.cadexsoft.com/mtkpython/mtk_web_installation.html
+
+## What and why
+
+[CADEXsoft Manufacturing Toolkit (MTK)](https://cadexsoft.com/) is a licensed
+C++ SDK with a Python wrapper. It reads 20+ CAD formats (STEP, IGES, JT,
+SolidWorks, Parasolid, ACIS, etc.) and performs:
+
+- **DFM** (design-for-manufacturability) checks
+- **Sheet-metal** unfolding, bends, flat patterns
+- **CNC milling** feature recognition (pockets, holes, undercuts)
+- **Turning** feature recognition
+- **PMI** extraction (aligns with the existing `usePMI` hook contract)
+
+For Eryxon Flow this is particularly useful when a part hits the system and
+the shop wants an immediate readout of manufacturability risks and machining
+features before the work even reaches the floor.
+
+## Why local-only
+
+MTK is **not** cloud-native in the SaaS sense:
+
+1. The license activates against a specific environment. Spreading it across
+   elastic cloud workers violates the EULA.
+2. CAD files are customer IP. Keeping analysis on-prem (or in a private
+   tenant-owned cluster) keeps us outside the data-processing scope of
+   customer contracts.
+3. MTK analyses are CPU-bound; co-locating with the frontend user avoids
+   shipping large CAD blobs over the public internet twice.
+
+For those reasons the integration is deliberately built as a **separate
+container that binds to `127.0.0.1` by default**. It never appears in the
+cloud deployment (`docker-compose.prod.yml`) unless an operator explicitly
+composes it in.
+
+## Architecture
+
+```
+Browser (Eryxon Flow)
+    │
+    │  VITE_CADEXSOFT_URL (local only, e.g. http://localhost:8891)
+    ▼
+services/cadexsoft/   ←   FastAPI wrapper
+    │
+    │  Python calls
+    ▼
+manufacturing_toolkit (licensed wheel)   ←   mtk_license.py (mounted at runtime)
+    │
+    ▼
+Native C++ MTK engine
+```
+
+The service is orthogonal to Supabase — results come back to the browser and
+can be persisted via existing edge functions (e.g. `api-parts` metadata) if
+and when the team wires that up. The groundwork does not add any new database
+schema on purpose, so the integration is reversible.
+
+## Files introduced
+
+| Path | Purpose |
+|------|---------|
+| `services/cadexsoft/` | Python FastAPI service, Dockerfile, license placeholder |
+| `services/cadexsoft/app/main.py` | HTTP endpoints (`/health`, `/analyze/*`, `/extract/pmi`) |
+| `services/cadexsoft/app/license_loader.py` | Imports `mtk_license`, activates MTK, falls back to stub |
+| `services/cadexsoft/app/analyzers.py` | Thin wrappers around MTK — currently stubs marked `# MTK:` |
+| `services/cadexsoft/app/schemas.py` | Pydantic models (mirror of `src/integrations/cadexsoft/types.ts`) |
+| `services/cadexsoft/license/` | Runtime-mounted license; gitignored |
+| `services/cadexsoft/vendor/` | Drop-in location for the MTK `.whl`; gitignored |
+| `docker-compose.cadexsoft.yml` | Opt-in overlay with `cadexsoft` profile |
+| `src/integrations/cadexsoft/client.ts` | Browser client (timeouts, API-key header) |
+| `src/integrations/cadexsoft/types.ts` | Frontend-side contract |
+| `src/config/cadBackend.ts` | `cadexsoft` added as a first-class `CADBackendMode` |
+| `.env.example` | `VITE_CADEXSOFT_URL`, `VITE_CADEXSOFT_API_KEY` |
+
+## API contract
+
+All endpoints accept either:
+
+- a JSON body `{ file_url, file_name, part_id?, tenant_id?, options? }`, or
+- a multipart upload with `upload` + `file_name` parts.
+
+All return `AnalyzeResponse`:
+
+```ts
+{
+  status: 'ok' | 'stub' | 'error';
+  analysis: 'dfm' | 'sheet-metal' | 'cnc-milling' | 'turning' | 'pmi';
+  mtk_version: string | null;
+  processing_time_ms: number;
+  file_name: string;
+  part_id: string | null;
+  issues: Issue[];
+  features: Feature[];
+  summary: Record<string, unknown>;
+  error?: string | null;
+}
+```
+
+See `src/integrations/cadexsoft/types.ts` and
+`services/cadexsoft/app/schemas.py` — keep them in lockstep.
+
+## Getting a license & wheel
+
+1. Request an MTK Python license through your CADEXsoft Customer Corner.
+2. You will get two artifacts:
+   - `manufacturing_toolkit-<version>-py3-none-any.whl` → drop in
+     `services/cadexsoft/vendor/`
+   - `mtk_license.py` (exports `value() -> str`) → drop in
+     `services/cadexsoft/license/`
+3. Bring the service up:
+   ```bash
+   docker compose \
+       -f docker-compose.yml \
+       -f docker-compose.cadexsoft.yml \
+       --profile cadexsoft up -d
+   ```
+4. Verify:
+   ```bash
+   curl http://localhost:8891/health
+   # {"status":"ok","mtk_available":true,"license_activated":true,...}
+   ```
+
+Before the wheel arrives you will see `stub_mode: true` on `/health` and every
+`/analyze/*` call will return `status: "stub"` with an explanatory summary.
+The frontend integration can still be developed against that surface.
+
+## Wiring the frontend
+
+```ts
+import { createCadexsoftClient } from '@/integrations/cadexsoft';
+
+const client = createCadexsoftClient();
+if (client) {
+  const health = await client.health();
+  if (!health.stub_mode) {
+    const result = await client.analyze('cnc-milling', {
+      file_url: signedUrl,
+      file_name: 'part.step',
+      part_id,
+    });
+    // result.issues, result.features, result.summary
+  }
+}
+```
+
+`createCadexsoftClient()` returns `null` when `VITE_CADEXSOFT_URL` is unset, so
+it is safe to call unconditionally from components.
+
+## Next steps (out of scope for this groundwork PR)
+
+- Implement the real MTK calls in `services/cadexsoft/app/analyzers.py`
+  (search for `# MTK:` markers).
+- Hook a "Run DFM analysis" action into the part detail page.
+- Persist `issues`/`features`/`summary` onto the part record (probably in
+  `parts.metadata.mtk` to mirror `parts.metadata.pmi`).
+- Decide whether to add a Supabase realtime progress channel like `usePMI`
+  uses, or keep the frontend blocking on a direct HTTP call (fine for the
+  local-only constraint).

--- a/docs/decisions/006-cadexsoft-local-only.md
+++ b/docs/decisions/006-cadexsoft-local-only.md
@@ -1,0 +1,64 @@
+# ADR-006: CADEXsoft MTK integration is local-only
+
+**Status:** Accepted
+**Date:** 2026-04-15
+**Context:** DevOps, Integration
+
+## Decision
+
+CADEXsoft Manufacturing Toolkit (MTK) is integrated as a **separate container
+that binds to loopback by default** (`docker-compose.cadexsoft.yml`, profile
+`cadexsoft`), not as a managed cloud service and not as a dependency of the
+production Eryxon Flow deployment. The frontend reaches it via
+`VITE_CADEXSOFT_URL`, which must resolve to a local or private-network address.
+
+## Context
+
+MTK is a licensed C++ SDK with a Python wrapper. Two constraints rule out a
+cloud-first integration:
+
+1. **Licensing.** The license activates against a specific environment; it is
+   not architected for horizontally-scaled, ephemeral workers. Spreading it
+   across cloud instances would violate the EULA.
+2. **Data locality.** CAD files are customer IP. Routing them to a shared
+   cloud analyser would pull us into the data-processing scope of every
+   customer contract and make self-hosters unhappy for the same reasons.
+
+Additionally MTK analyses are CPU-bound. Co-locating with the user avoids
+shipping large CAD blobs across the public internet twice.
+
+## Consequences
+
+**Positive:**
+- Self-hosters (the primary audience) get a deployment model that matches
+  their existing single-host or private-cluster posture.
+- The cloud deployment stays free of licensed C++ binaries and proprietary
+  CAD files.
+- The service is reversible — it is an opt-in compose overlay, not a schema
+  change or a required dependency.
+- Stub mode means the frontend integration can be built and reviewed before
+  the license arrives.
+
+**Negative:**
+- No "turn it on from the SaaS dashboard" story. Operators must obtain a
+  license and drop artifacts onto disk.
+- Extra operational surface (another container, another health check).
+- Cross-host deployments need operators to explicitly override
+  `CADEXSOFT_BIND` and secure the network path themselves.
+
+## Alternatives Considered
+
+1. **Host MTK in Supabase Edge Functions.** Rejected — edge functions run on
+   Deno in a cloud runtime we do not control. MTK is a C++ wheel; it cannot
+   run there. Licensing scope would also be broken.
+2. **Build a shared cloud "CAD analysis" microservice.** Rejected on
+   licensing and data-locality grounds (see Context).
+3. **Use the existing `byob` slot without calling CADEXsoft out specifically.**
+   Rejected — CADEXsoft has a concrete, well-defined API surface (DFM,
+   sheet-metal, CNC, turning, PMI) that deserves first-class types and a
+   dedicated client. Keeping `byob` generic preserves a separate extension
+   slot for future third-party services.
+4. **Run the Python SDK in-process inside the existing Eryxon3D custom
+   backend.** Rejected — Eryxon3D solves a different problem (geometry and
+   PMI tessellation) and bundling two licensed C++ stacks into one container
+   couples their release cycles and licensing boundaries.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eryxon-flow",
-  "version": "0.3.3",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eryxon-flow",
-      "version": "0.3.3",
+      "version": "0.4.1",
       "license": "BSL-1.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/services/cadexsoft/.gitignore
+++ b/services/cadexsoft/.gitignore
@@ -1,0 +1,10 @@
+# Licensed artifacts — never commit.
+license/mtk_license.py
+vendor/*.whl
+vendor/*.tar.gz
+
+# Python build/cache
+__pycache__/
+*.pyc
+.venv/
+*.egg-info/

--- a/services/cadexsoft/Dockerfile
+++ b/services/cadexsoft/Dockerfile
@@ -1,0 +1,56 @@
+# CADEXsoft MTK Python service — local deployment.
+#
+# The MTK Python wheel is a licensed, non-public artifact. Drop it into
+# services/cadexsoft/vendor/ before building, or provide MTK_WHEEL_URL as a
+# private, pre-authenticated URL.
+#
+# Supported Python versions per CADEXsoft docs: 3.7 – 3.11.
+FROM python:3.11-slim-bookworm
+
+# Native runtime libs required by the MTK C++ shared objects.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libgl1 \
+        libglu1-mesa \
+        libxrender1 \
+        libxext6 \
+        libgomp1 \
+        ca-certificates \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /srv
+
+# Python dependencies first for layer caching.
+COPY requirements.txt /srv/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Optional MTK wheel install. Build fails gracefully into stub mode if absent —
+# the service still boots so integration work can proceed without the license.
+ARG MTK_WHEEL_URL=""
+COPY vendor/ /tmp/vendor/
+RUN set -eux; \
+    if [ -n "$MTK_WHEEL_URL" ]; then \
+        curl -fSL "$MTK_WHEEL_URL" -o /tmp/mtk.whl && pip install --no-cache-dir /tmp/mtk.whl; \
+    elif ls /tmp/vendor/manufacturing_toolkit-*.whl >/dev/null 2>&1; then \
+        pip install --no-cache-dir /tmp/vendor/manufacturing_toolkit-*.whl; \
+    else \
+        echo "[cadexsoft] No MTK wheel provided — service will run in stub mode."; \
+    fi; \
+    rm -rf /tmp/vendor /tmp/mtk.whl
+
+# License module. Mounted at runtime via docker-compose so the wheel install can
+# be cached independently of license rotations.
+COPY app /srv/app
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/srv:/srv/license \
+    CADEXSOFT_HOST=0.0.0.0 \
+    CADEXSOFT_PORT=8891
+
+EXPOSE 8891
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -fsS http://localhost:8891/health || exit 1
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8891"]

--- a/services/cadexsoft/README.md
+++ b/services/cadexsoft/README.md
@@ -1,0 +1,82 @@
+# CADEXsoft MTK Python Service — Local Integration
+
+> **Local-only.** This service MUST run on the same machine or private network as your
+> Eryxon Flow deployment. CADEXsoft Manufacturing Toolkit (MTK) is a licensed C++ SDK
+> with a Python wrapper and a license key that ties to a specific environment.
+> See https://docs.cadexsoft.com/mtkpython/mtk_web_installation.html
+
+## What this service does
+
+Wraps the CADEXsoft MTK Python SDK behind a small HTTP API that Eryxon Flow can call
+from the browser (via `VITE_CADEXSOFT_URL`). It accepts a CAD file (STEP, IGES, JT,
+SolidWorks, etc.), runs manufacturing-toolkit analyses, and returns a JSON payload
+that the MES can store alongside a part.
+
+Groundwork capabilities (stubs until license is activated):
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /health` | Liveness + license status |
+| `POST /analyze/dfm` | Generic design-for-manufacturability checks |
+| `POST /analyze/sheet-metal` | Unfolding, bends, flat pattern, notches |
+| `POST /analyze/cnc-milling` | Feature recognition, pockets, holes, undercuts |
+| `POST /analyze/turning` | Turnable features, grooves, thread recognition |
+| `POST /extract/pmi` | PMI extraction (aligns with existing `usePMI` hook contract) |
+
+All endpoints accept `{ file_url, file_name }` or a multipart upload.
+
+## Prerequisites
+
+1. **License file from CADEXsoft Customer Corner.**
+   You will receive a `mtk_license.py` (a Python module exporting a function
+   that returns the license string). Place it at
+   `services/cadexsoft/license/mtk_license.py` — this path is **gitignored**,
+   never commit a real license.
+
+2. **MTK Python wheel** from your Customer Corner download. Either:
+   - drop the `.whl` file into `services/cadexsoft/vendor/` and the Dockerfile
+     will `pip install` it, or
+   - set `MTK_WHEEL_URL` to a private, authenticated URL before building.
+
+3. **Docker + docker-compose** on the host that will run the service.
+
+## Running locally
+
+```bash
+# 1. Drop the license file in place
+cp /path/to/mtk_license.py services/cadexsoft/license/mtk_license.py
+
+# 2. Drop the MTK wheel in services/cadexsoft/vendor/ (file stays out of git)
+mkdir -p services/cadexsoft/vendor
+cp /path/to/manufacturing_toolkit-*.whl services/cadexsoft/vendor/
+
+# 3. Start the service (opt-in profile so it does not run by default)
+docker compose --profile cadexsoft up -d cadexsoft
+
+# 4. Verify
+curl http://localhost:8891/health
+```
+
+Then in your Eryxon Flow `.env`:
+
+```bash
+VITE_CADEXSOFT_URL="http://localhost:8891"
+VITE_CADEXSOFT_API_KEY="a-shared-secret-you-pick"
+```
+
+And set the same value as `CADEXSOFT_API_KEY` in the container environment.
+
+## Why local-only?
+
+- The MTK license binds to the machine/environment it is activated on.
+- CAD files are customer IP — keep them off shared cloud infra unless explicitly
+  contracted.
+- Analyses are CPU-bound and benefit from co-location with the frontend user.
+
+## Development without the license
+
+The service ships a **stub mode**: if the license file or the `manufacturing_toolkit`
+package is not importable, every analysis endpoint returns a deterministic
+`{"status": "stub", ...}` payload so the frontend integration can be exercised
+end-to-end before the license arrives. Check `/health` → `mtk_available` to see
+which mode is active.

--- a/services/cadexsoft/app/analyzers.py
+++ b/services/cadexsoft/app/analyzers.py
@@ -1,0 +1,97 @@
+"""Thin analyzer wrappers around the MTK Python API.
+
+Every function accepts an in-memory CAD file payload and returns an
+``AnalyzeResponse``-shaped dict. When MTK is not installed or the license is
+not active, we return a deterministic stub payload so the frontend integration
+can be built end-to-end.
+
+The real MTK calls are marked with ``# MTK:`` comments so they are easy to
+locate once the licensed SDK is wired in.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Tuple
+
+from .license_loader import LicenseStatus
+from .schemas import AnalysisKind
+
+
+def _stub_payload(kind: AnalysisKind, file_name: str, part_id: str | None,
+                  status: LicenseStatus) -> Dict[str, Any]:
+    return {
+        "status": "stub",
+        "analysis": kind,
+        "mtk_version": status.mtk_version,
+        "processing_time_ms": 0,
+        "file_name": file_name,
+        "part_id": part_id,
+        "issues": [],
+        "features": [],
+        "summary": {
+            "note": (
+                "CADEXsoft MTK is not active on this host. Install the wheel and "
+                "place the license module to enable real analysis."
+            ),
+            "stub_mode_reason": status.error,
+        },
+    }
+
+
+def _read_cad(file_bytes: bytes, file_name: str):
+    """Dispatch to the right MTK reader based on extension.
+
+    Stub implementation — real implementation will instantiate the appropriate
+    reader from ``manufacturing_toolkit`` based on the file extension (STEP,
+    IGES, JT, SolidWorks, Parasolid, ACIS, ...).
+    """
+    # MTK: from manufacturing_toolkit.core.step import StepReader
+    # MTK: model = StepReader().ReadFile(file_name, file_bytes)
+    raise NotImplementedError("Wire up MTK readers once the wheel is installed")
+
+
+def run_analysis(kind: AnalysisKind, file_bytes: bytes, file_name: str,
+                 part_id: str | None, options: Dict[str, Any],
+                 status: LicenseStatus) -> Tuple[int, Dict[str, Any]]:
+    """Execute an analysis, returning (http_status, response_dict)."""
+    if status.stub_mode:
+        return 200, _stub_payload(kind, file_name, part_id, status)
+
+    start = time.monotonic()
+    try:
+        model = _read_cad(file_bytes, file_name)  # noqa: F841 — placeholder
+        # MTK: dispatch based on `kind` → MTK analyzers, map results into
+        # the `Issue`/`Feature` schema shared with the frontend.
+        raise NotImplementedError(
+            f"MTK analyzer for '{kind}' is not yet wired up. "
+            "See services/cadexsoft/README.md."
+        )
+    except NotImplementedError as exc:
+        elapsed = int((time.monotonic() - start) * 1000)
+        return 501, {
+            "status": "error",
+            "analysis": kind,
+            "mtk_version": status.mtk_version,
+            "processing_time_ms": elapsed,
+            "file_name": file_name,
+            "part_id": part_id,
+            "issues": [],
+            "features": [],
+            "summary": {},
+            "error": str(exc),
+        }
+    except Exception as exc:  # pragma: no cover - defensive
+        elapsed = int((time.monotonic() - start) * 1000)
+        return 500, {
+            "status": "error",
+            "analysis": kind,
+            "mtk_version": status.mtk_version,
+            "processing_time_ms": elapsed,
+            "file_name": file_name,
+            "part_id": part_id,
+            "issues": [],
+            "features": [],
+            "summary": {},
+            "error": f"{type(exc).__name__}: {exc}",
+        }

--- a/services/cadexsoft/app/license_loader.py
+++ b/services/cadexsoft/app/license_loader.py
@@ -1,0 +1,86 @@
+"""Loads the CADEXsoft MTK license, if available, and activates it.
+
+The real license module is delivered by CADEXsoft as a Python source file that
+exports a ``value()`` function returning the license string. We keep that file
+outside the Docker image (mounted at runtime) so wheel builds can be cached
+independently of license rotation.
+
+If either the license module or the ``manufacturing_toolkit`` package cannot
+be imported we fall back to stub mode — the HTTP surface still works, which
+lets the frontend integration be built and exercised before a real license
+arrives.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+log = logging.getLogger("cadexsoft.license")
+
+
+@dataclass(frozen=True)
+class LicenseStatus:
+    mtk_available: bool
+    license_activated: bool
+    mtk_version: Optional[str]
+    error: Optional[str]
+
+    @property
+    def stub_mode(self) -> bool:
+        return not (self.mtk_available and self.license_activated)
+
+
+def _load_license_string() -> Optional[str]:
+    try:
+        import mtk_license  # type: ignore
+    except ImportError as exc:
+        log.warning("mtk_license module not importable: %s", exc)
+        return None
+    try:
+        value = mtk_license.value()  # type: ignore[attr-defined]
+    except Exception as exc:  # pragma: no cover - depends on customer file
+        log.error("mtk_license.value() raised: %s", exc)
+        return None
+    if not isinstance(value, str) or not value.strip():
+        log.error("mtk_license.value() returned non-string or empty value")
+        return None
+    if "REPLACE_ME" in value:
+        log.warning("mtk_license appears to still be the placeholder example")
+        return None
+    return value
+
+
+def activate() -> LicenseStatus:
+    """Attempt to import MTK and activate the license.
+
+    Never raises — returns a structured status so ``/health`` can report what
+    the integration host sees without crashing the whole service.
+    """
+    if os.getenv("CADEXSOFT_FORCE_STUB", "").lower() in ("1", "true", "yes"):
+        return LicenseStatus(False, False, None, "CADEXSOFT_FORCE_STUB is set")
+
+    try:
+        import manufacturing_toolkit as mtk  # type: ignore
+    except ImportError as exc:
+        return LicenseStatus(False, False, None, f"manufacturing_toolkit not installed: {exc}")
+
+    license_str = _load_license_string()
+    if license_str is None:
+        return LicenseStatus(True, False, getattr(mtk, "__version__", None),
+                             "license module missing or placeholder")
+
+    try:
+        # The MTK Python API exposes a LicenseManager. The exact module path
+        # can vary across releases; try the documented one and fall back.
+        try:
+            from manufacturing_toolkit.core import LicenseManager  # type: ignore
+        except ImportError:
+            from manufacturing_toolkit import LicenseManager  # type: ignore
+        LicenseManager.Activate(license_str)
+    except Exception as exc:  # pragma: no cover - depends on licensed SDK
+        return LicenseStatus(True, False, getattr(mtk, "__version__", None), str(exc))
+
+    return LicenseStatus(True, True, getattr(mtk, "__version__", None), None)

--- a/services/cadexsoft/app/main.py
+++ b/services/cadexsoft/app/main.py
@@ -1,0 +1,180 @@
+"""CADEXsoft MTK Python service — FastAPI entrypoint.
+
+Run locally with:
+
+    uvicorn app.main:app --host 0.0.0.0 --port 8891
+
+or via Docker Compose (`docker compose --profile cadexsoft up cadexsoft`).
+
+This service is designed to run **on the same host or private network** as
+Eryxon Flow. It is not intended for public internet exposure — the MTK license
+binds to the host and CAD files are customer IP.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+from typing import Optional
+
+import httpx
+from fastapi import Depends, FastAPI, File, Form, HTTPException, Request, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+
+from . import analyzers
+from .license_loader import LicenseStatus, activate
+from .schemas import AnalysisKind, AnalyzeRequest, AnalyzeResponse, HealthResponse
+
+logging.basicConfig(level=os.getenv("CADEXSOFT_LOG_LEVEL", "INFO"))
+log = logging.getLogger("cadexsoft")
+
+API_KEY = os.getenv("CADEXSOFT_API_KEY", "").strip()
+MAX_UPLOAD_BYTES = int(os.getenv("CADEXSOFT_MAX_UPLOAD_BYTES", str(200 * 1024 * 1024)))
+ALLOWED_ORIGINS = [
+    o.strip() for o in os.getenv(
+        "CADEXSOFT_CORS_ORIGINS",
+        "http://localhost:8080,http://localhost:3000,http://localhost:5173",
+    ).split(",") if o.strip()
+]
+
+app = FastAPI(
+    title="CADEXsoft MTK Service",
+    version="0.1.0",
+    description=(
+        "Local-only wrapper around the CADEXsoft Manufacturing Toolkit (MTK) "
+        "Python SDK. Powers DFM, sheet-metal, CNC-milling, turning and PMI "
+        "analysis for Eryxon Flow."
+    ),
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ALLOWED_ORIGINS,
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["Content-Type", "X-API-Key", "Authorization"],
+)
+
+
+@app.on_event("startup")
+def _activate_license() -> None:
+    status = activate()
+    app.state.license_status = status
+    if status.stub_mode:
+        log.warning("MTK running in STUB mode: %s", status.error)
+    else:
+        log.info("MTK license activated (version=%s)", status.mtk_version)
+
+
+def _license_status(request: Request) -> LicenseStatus:
+    return request.app.state.license_status
+
+
+def _require_api_key(request: Request) -> None:
+    if not API_KEY:
+        return  # auth disabled — caller must have chosen this explicitly
+    supplied = request.headers.get("x-api-key") or ""
+    authz = request.headers.get("authorization") or ""
+    if authz.lower().startswith("bearer "):
+        supplied = supplied or authz[7:]
+    if supplied != API_KEY:
+        raise HTTPException(status_code=401, detail="invalid or missing API key")
+
+
+async def _resolve_payload(
+    body: Optional[AnalyzeRequest],
+    upload: Optional[UploadFile],
+    file_name_form: Optional[str],
+) -> tuple[bytes, str, Optional[str], Optional[str], dict]:
+    """Accept either JSON body or multipart upload, return raw bytes + metadata."""
+    if upload is not None:
+        data = await upload.read()
+        if len(data) > MAX_UPLOAD_BYTES:
+            raise HTTPException(status_code=413, detail="file exceeds max upload size")
+        return data, file_name_form or upload.filename or "upload.bin", None, None, {}
+
+    if body is None:
+        raise HTTPException(status_code=400, detail="missing request body")
+
+    if body.file_base64:
+        try:
+            data = base64.b64decode(body.file_base64, validate=True)
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=f"invalid base64: {exc}") from exc
+    elif body.file_url:
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            resp = await client.get(body.file_url)
+            if resp.status_code >= 400:
+                raise HTTPException(
+                    status_code=502,
+                    detail=f"failed to fetch file_url (HTTP {resp.status_code})",
+                )
+            data = resp.content
+    else:
+        raise HTTPException(
+            status_code=400,
+            detail="either file_url or file_base64 must be provided",
+        )
+
+    if len(data) > MAX_UPLOAD_BYTES:
+        raise HTTPException(status_code=413, detail="file exceeds max upload size")
+
+    return data, body.file_name, body.part_id, body.tenant_id, body.options
+
+
+async def _run(
+    kind: AnalysisKind,
+    request: Request,
+    body: Optional[AnalyzeRequest],
+    upload: Optional[UploadFile],
+    file_name_form: Optional[str],
+) -> JSONResponse:
+    _require_api_key(request)
+    data, file_name, part_id, _tenant_id, options = await _resolve_payload(
+        body, upload, file_name_form
+    )
+    status_code, payload = analyzers.run_analysis(
+        kind, data, file_name, part_id, options, _license_status(request)
+    )
+    # Validate against the shared schema so drift between client/server is caught.
+    AnalyzeResponse.model_validate(payload)
+    return JSONResponse(status_code=status_code, content=payload)
+
+
+@app.get("/health", response_model=HealthResponse)
+def health(request: Request) -> HealthResponse:
+    status = _license_status(request)
+    return HealthResponse(
+        status="ok" if not status.stub_mode else "degraded",
+        mtk_available=status.mtk_available,
+        license_activated=status.license_activated,
+        mtk_version=status.mtk_version,
+        stub_mode=status.stub_mode,
+        error=status.error,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Analysis endpoints — all accept JSON (AnalyzeRequest) or multipart upload.
+# ---------------------------------------------------------------------------
+
+def _analyze_route(kind: AnalysisKind):
+    async def handler(
+        request: Request,
+        body: Optional[AnalyzeRequest] = None,
+        upload: Optional[UploadFile] = File(default=None),
+        file_name: Optional[str] = Form(default=None),
+    ) -> JSONResponse:
+        return await _run(kind, request, body, upload, file_name)
+
+    handler.__name__ = f"analyze_{kind.replace('-', '_')}"
+    return handler
+
+
+app.post("/analyze/dfm", response_model=AnalyzeResponse)(_analyze_route("dfm"))
+app.post("/analyze/sheet-metal", response_model=AnalyzeResponse)(_analyze_route("sheet-metal"))
+app.post("/analyze/cnc-milling", response_model=AnalyzeResponse)(_analyze_route("cnc-milling"))
+app.post("/analyze/turning", response_model=AnalyzeResponse)(_analyze_route("turning"))
+app.post("/extract/pmi", response_model=AnalyzeResponse)(_analyze_route("pmi"))

--- a/services/cadexsoft/app/main.py
+++ b/services/cadexsoft/app/main.py
@@ -87,13 +87,23 @@ async def _resolve_payload(
     body: Optional[AnalyzeRequest],
     upload: Optional[UploadFile],
     file_name_form: Optional[str],
+    part_id_form: Optional[str] = None,
+    tenant_id_form: Optional[str] = None,
+    options_form: Optional[str] = None,
 ) -> tuple[bytes, str, Optional[str], Optional[str], dict]:
     """Accept either JSON body or multipart upload, return raw bytes + metadata."""
     if upload is not None:
         data = await upload.read()
         if len(data) > MAX_UPLOAD_BYTES:
             raise HTTPException(status_code=413, detail="file exceeds max upload size")
-        return data, file_name_form or upload.filename or "upload.bin", None, None, {}
+        opts: dict = {}
+        if options_form:
+            import json
+            try:
+                opts = json.loads(options_form)
+            except json.JSONDecodeError:
+                raise HTTPException(status_code=400, detail="invalid JSON in options field")
+        return data, file_name_form or upload.filename or "upload.bin", part_id_form, tenant_id_form, opts
 
     if body is None:
         raise HTTPException(status_code=400, detail="missing request body")
@@ -130,10 +140,13 @@ async def _run(
     body: Optional[AnalyzeRequest],
     upload: Optional[UploadFile],
     file_name_form: Optional[str],
+    part_id_form: Optional[str] = None,
+    tenant_id_form: Optional[str] = None,
+    options_form: Optional[str] = None,
 ) -> JSONResponse:
     _require_api_key(request)
     data, file_name, part_id, _tenant_id, options = await _resolve_payload(
-        body, upload, file_name_form
+        body, upload, file_name_form, part_id_form, tenant_id_form, options_form
     )
     status_code, payload = analyzers.run_analysis(
         kind, data, file_name, part_id, options, _license_status(request)
@@ -166,8 +179,11 @@ def _analyze_route(kind: AnalysisKind):
         body: Optional[AnalyzeRequest] = None,
         upload: Optional[UploadFile] = File(default=None),
         file_name: Optional[str] = Form(default=None),
+        part_id: Optional[str] = Form(default=None),
+        tenant_id: Optional[str] = Form(default=None),
+        options: Optional[str] = Form(default=None),
     ) -> JSONResponse:
-        return await _run(kind, request, body, upload, file_name)
+        return await _run(kind, request, body, upload, file_name, part_id, tenant_id, options)
 
     handler.__name__ = f"analyze_{kind.replace('-', '_')}"
     return handler

--- a/services/cadexsoft/app/schemas.py
+++ b/services/cadexsoft/app/schemas.py
@@ -1,0 +1,70 @@
+"""Request/response models for the CADEXsoft integration service.
+
+These shapes are the contract between the Eryxon Flow frontend
+(`src/integrations/cadexsoft/`) and this service. Keep them in sync with
+`cadexsoft.types.ts`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+AnalysisKind = Literal["dfm", "sheet-metal", "cnc-milling", "turning", "pmi"]
+
+
+class AnalyzeRequest(BaseModel):
+    """Body for POST /analyze/*.
+
+    Either ``file_url`` (a URL the service can fetch — e.g. a Supabase signed
+    URL) or ``file_base64`` must be provided. ``file_name`` is used to pick the
+    CAD reader by extension.
+    """
+
+    file_url: Optional[str] = None
+    file_base64: Optional[str] = None
+    file_name: str = Field(..., min_length=1)
+    part_id: Optional[str] = None
+    tenant_id: Optional[str] = None
+    options: Dict[str, Any] = Field(default_factory=dict)
+
+
+class Issue(BaseModel):
+    id: str
+    severity: Literal["info", "warning", "error"]
+    category: str
+    message: str
+    face_ids: List[str] = Field(default_factory=list)
+    edge_ids: List[str] = Field(default_factory=list)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class Feature(BaseModel):
+    id: str
+    kind: str  # e.g. "hole", "pocket", "bend", "slot"
+    parameters: Dict[str, Any] = Field(default_factory=dict)
+    face_ids: List[str] = Field(default_factory=list)
+
+
+class AnalyzeResponse(BaseModel):
+    status: Literal["ok", "stub", "error"]
+    analysis: AnalysisKind
+    mtk_version: Optional[str] = None
+    processing_time_ms: int = 0
+    file_name: str
+    part_id: Optional[str] = None
+    issues: List[Issue] = Field(default_factory=list)
+    features: List[Feature] = Field(default_factory=list)
+    summary: Dict[str, Any] = Field(default_factory=dict)
+    error: Optional[str] = None
+
+
+class HealthResponse(BaseModel):
+    status: Literal["ok", "degraded"]
+    mtk_available: bool
+    license_activated: bool
+    mtk_version: Optional[str] = None
+    stub_mode: bool
+    error: Optional[str] = None

--- a/services/cadexsoft/license/mtk_license.py.example
+++ b/services/cadexsoft/license/mtk_license.py.example
@@ -1,0 +1,14 @@
+"""Placeholder for the CADEXsoft-issued license module.
+
+The real file is delivered through your CADEXsoft Customer Corner as a Python
+source file (`.py`). Copy it to `services/cadexsoft/license/mtk_license.py` —
+that path is gitignored so secrets never reach the repo.
+
+The real file exports a `value()` function that returns the license key string.
+MTK activates the key the first time any MTK API is used.
+"""
+
+
+def value() -> str:
+    # Replace this with the exact contents delivered by CADEXsoft.
+    return "REPLACE_ME_WITH_REAL_LICENSE_KEY"

--- a/services/cadexsoft/requirements.txt
+++ b/services/cadexsoft/requirements.txt
@@ -1,0 +1,11 @@
+# CADEXsoft MTK service runtime dependencies.
+#
+# The Manufacturing Toolkit Python wheel itself is NOT listed here — it must be
+# installed separately from the Customer Corner download (see Dockerfile and
+# README). That wheel bundles the native C++ libraries and is licensed software.
+
+fastapi==0.115.0
+uvicorn[standard]==0.30.6
+pydantic==2.9.2
+python-multipart==0.0.12
+httpx==0.27.2

--- a/services/cadexsoft/vendor/.gitkeep
+++ b/services/cadexsoft/vendor/.gitkeep
@@ -1,0 +1,3 @@
+# Drop the manufacturing_toolkit-*.whl from your CADEXsoft Customer Corner here.
+# The file itself is gitignored. This placeholder keeps the directory in the
+# repo so the Dockerfile COPY step does not fail on a clean checkout.

--- a/src/config/cadBackend.ts
+++ b/src/config/cadBackend.ts
@@ -211,11 +211,15 @@ export function getActiveTimeout(): number {
 /**
  * Determine the best available backend mode
  *
- * Priority: custom > cadexsoft > byob > frontend
+ * Priority: custom > byob > frontend
+ *
+ * cadexsoft is excluded from auto-detection because useCADProcessing talks to
+ * `/process` (the Eryxon3D/generic contract) while the CADEXsoft service
+ * exposes `/analyze/*`. Auto-selecting cadexsoft would cause 404s on the
+ * generic path. Operators must opt in with VITE_CAD_BACKEND_MODE=cadexsoft.
  */
 export function determineBestBackend(): CADBackendMode {
   if (isBackendAvailable('custom')) return 'custom';
-  if (isBackendAvailable('cadexsoft')) return 'cadexsoft';
   if (isBackendAvailable('byob')) return 'byob';
   return 'frontend';
 }

--- a/src/config/cadBackend.ts
+++ b/src/config/cadBackend.ts
@@ -5,12 +5,13 @@
  *
  * Supported Modes:
  * - 'custom': Eryxon3D Docker-based backend (recommended)
- * - 'byob': Bring Your Own Backend (placeholder for CAD Exchanger SDK, etc.)
+ * - 'cadexsoft': CADEXsoft MTK local Python service (licensed, local-only)
+ * - 'byob': Bring Your Own Backend (generic CAD service)
  * - 'frontend': Browser-only processing via occt-import-js (fallback)
  */
 import { logger } from "@/lib/logger";
 
-export type CADBackendMode = 'custom' | 'byob' | 'frontend';
+export type CADBackendMode = 'custom' | 'cadexsoft' | 'byob' | 'frontend';
 
 export interface CADBackendConfig {
   /** Active backend mode */
@@ -18,6 +19,14 @@ export interface CADBackendConfig {
 
   /** Custom backend (Eryxon3D) configuration */
   custom: {
+    enabled: boolean;
+    url: string;
+    apiKey: string;
+    timeout: number;
+  };
+
+  /** CADEXsoft MTK Python service (local-only, licensed) */
+  cadexsoft: {
     enabled: boolean;
     url: string;
     apiKey: string;
@@ -67,6 +76,13 @@ const defaultConfig: CADBackendConfig = {
     timeout: 120000, // 2 minutes
   },
 
+  cadexsoft: {
+    enabled: !!import.meta.env.VITE_CADEXSOFT_URL,
+    url: import.meta.env.VITE_CADEXSOFT_URL || 'http://localhost:8891',
+    apiKey: import.meta.env.VITE_CADEXSOFT_API_KEY || '',
+    timeout: 180000, // 3 minutes — MTK analyses can be CPU-bound
+  },
+
   byob: {
     enabled: false,
     url: import.meta.env.VITE_BYOB_CAD_URL || '',
@@ -108,6 +124,7 @@ export function setCADConfig(config: Partial<CADBackendConfig>): void {
     ...activeConfig,
     ...config,
     custom: { ...activeConfig.custom, ...config.custom },
+    cadexsoft: { ...activeConfig.cadexsoft, ...config.cadexsoft },
     byob: { ...activeConfig.byob, ...config.byob },
     frontend: { ...activeConfig.frontend, ...config.frontend },
     features: { ...activeConfig.features, ...config.features },
@@ -128,6 +145,8 @@ export function isBackendAvailable(mode: CADBackendMode): boolean {
   switch (mode) {
     case 'custom':
       return activeConfig.custom.enabled && !!activeConfig.custom.url;
+    case 'cadexsoft':
+      return activeConfig.cadexsoft.enabled && !!activeConfig.cadexsoft.url;
     case 'byob':
       return activeConfig.byob.enabled && !!activeConfig.byob.url;
     case 'frontend':
@@ -144,6 +163,8 @@ export function getActiveBackendUrl(): string | null {
   switch (activeConfig.mode) {
     case 'custom':
       return activeConfig.custom.url;
+    case 'cadexsoft':
+      return activeConfig.cadexsoft.url;
     case 'byob':
       return activeConfig.byob.url;
     case 'frontend':
@@ -160,6 +181,8 @@ export function getActiveApiKey(): string {
   switch (activeConfig.mode) {
     case 'custom':
       return activeConfig.custom.apiKey;
+    case 'cadexsoft':
+      return activeConfig.cadexsoft.apiKey;
     case 'byob':
       return activeConfig.byob.apiKey;
     default:
@@ -174,6 +197,8 @@ export function getActiveTimeout(): number {
   switch (activeConfig.mode) {
     case 'custom':
       return activeConfig.custom.timeout;
+    case 'cadexsoft':
+      return activeConfig.cadexsoft.timeout;
     case 'byob':
       return activeConfig.byob.timeout;
     case 'frontend':
@@ -186,10 +211,11 @@ export function getActiveTimeout(): number {
 /**
  * Determine the best available backend mode
  *
- * Priority: custom > byob > frontend
+ * Priority: custom > cadexsoft > byob > frontend
  */
 export function determineBestBackend(): CADBackendMode {
   if (isBackendAvailable('custom')) return 'custom';
+  if (isBackendAvailable('cadexsoft')) return 'cadexsoft';
   if (isBackendAvailable('byob')) return 'byob';
   return 'frontend';
 }
@@ -200,7 +226,7 @@ export function determineBestBackend(): CADBackendMode {
 export function initCADConfig(): void {
   // Check for mode override from environment
   const envMode = import.meta.env.VITE_CAD_BACKEND_MODE as CADBackendMode | undefined;
-  if (envMode && ['custom', 'byob', 'frontend'].includes(envMode)) {
+  if (envMode && ['custom', 'cadexsoft', 'byob', 'frontend'].includes(envMode)) {
     activeConfig.mode = envMode;
   } else {
     // Auto-detect best available backend

--- a/src/hooks/useCADProcessing.test.ts
+++ b/src/hooks/useCADProcessing.test.ts
@@ -30,6 +30,7 @@ vi.mock('@/config/cadBackend', () => ({
   getCADConfig: vi.fn(() => ({
     mode: 'custom',
     custom: { enabled: true, url: 'http://localhost:8888', apiKey: 'test-key', timeout: 5000 },
+    cadexsoft: { enabled: false, url: '', apiKey: '', timeout: 5000 },
     byob: { enabled: false, url: '', apiKey: '', timeout: 5000, headers: {} },
     frontend: { enabled: true, wasmUrl: '', maxFileSize: 50000000 },
     features: { pmiExtraction: true, thumbnails: false, geometry: true },
@@ -177,6 +178,7 @@ describe('useCADProcessing', () => {
     vi.mocked(getCADConfig).mockReturnValueOnce({
       mode: 'frontend',
       custom: { enabled: false, url: '', apiKey: '', timeout: 5000 },
+      cadexsoft: { enabled: false, url: '', apiKey: '', timeout: 5000 },
       byob: { enabled: false, url: '', apiKey: '', timeout: 5000 },
       frontend: { enabled: true, wasmUrl: '', maxFileSize: 50000000 },
       features: { pmiExtraction: true, thumbnails: false, geometry: true },

--- a/src/integrations/cadexsoft/client.ts
+++ b/src/integrations/cadexsoft/client.ts
@@ -1,0 +1,171 @@
+/**
+ * CADEXsoft MTK service client.
+ *
+ * The service is expected to run on the same host or private network as the
+ * deployment (see `services/cadexsoft/README.md`). This client is deliberately
+ * thin — no retries, no caching — higher-level hooks can layer those on.
+ */
+
+import { logger } from '@/lib/logger';
+import type {
+  AnalysisKind,
+  AnalyzeRequest,
+  AnalyzeResponse,
+  HealthResponse,
+} from './types';
+
+const log = {
+  debug: (msg: string, data?: unknown) => logger.debug('cadexsoft', msg, data),
+  warn: (msg: string, data?: unknown) => logger.warn('cadexsoft', msg, data),
+  error: (msg: string, data?: unknown) => logger.error('cadexsoft', msg, data),
+};
+
+function readEnv(key: string): string | undefined {
+  const runtime = (window as unknown as { __ENV__?: Record<string, string> }).__ENV__;
+  return runtime?.[key] ?? (import.meta.env as Record<string, string | undefined>)[key];
+}
+
+export interface CadexsoftClientConfig {
+  /** Base URL of the local CADEXsoft service, e.g. http://localhost:8891 */
+  baseUrl: string;
+  /** Optional shared secret matching CADEXSOFT_API_KEY on the service. */
+  apiKey?: string;
+  /** Request timeout in ms. Defaults to 120s — CAD analysis can be slow. */
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+export class CadexsoftServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly body?: unknown,
+  ) {
+    super(message);
+    this.name = 'CadexsoftServiceError';
+  }
+}
+
+export function createCadexsoftClient(
+  overrides: Partial<CadexsoftClientConfig> = {},
+): CadexsoftClient | null {
+  const baseUrl = overrides.baseUrl ?? readEnv('VITE_CADEXSOFT_URL') ?? '';
+  if (!baseUrl) {
+    return null;
+  }
+  return new CadexsoftClient({
+    baseUrl: baseUrl.replace(/\/+$/, ''),
+    apiKey: overrides.apiKey ?? readEnv('VITE_CADEXSOFT_API_KEY') ?? undefined,
+    timeoutMs: overrides.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  });
+}
+
+/** Convenience: returns true when a CADEXsoft service URL is configured. */
+export function isCadexsoftConfigured(): boolean {
+  return Boolean(readEnv('VITE_CADEXSOFT_URL'));
+}
+
+export class CadexsoftClient {
+  constructor(private readonly config: CadexsoftClientConfig) {}
+
+  private headers(extra?: Record<string, string>): Record<string, string> {
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      ...extra,
+    };
+    if (this.config.apiKey) {
+      headers['X-API-Key'] = this.config.apiKey;
+    }
+    return headers;
+  }
+
+  private async request<T>(
+    path: string,
+    init: RequestInit,
+  ): Promise<T> {
+    const url = `${this.config.baseUrl}${path}`;
+    const controller = new AbortController();
+    const timer = setTimeout(
+      () => controller.abort(),
+      this.config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    );
+    try {
+      const response = await fetch(url, {
+        ...init,
+        signal: controller.signal,
+      });
+
+      const text = await response.text();
+      const body = text ? safeJsonParse(text) : null;
+
+      if (!response.ok) {
+        log.warn(`HTTP ${response.status} from ${path}`, body);
+        throw new CadexsoftServiceError(
+          `CADEXsoft service error (HTTP ${response.status})`,
+          response.status,
+          body,
+        );
+      }
+
+      return body as T;
+    } catch (err) {
+      if (err instanceof CadexsoftServiceError) throw err;
+      if ((err as Error).name === 'AbortError') {
+        log.error('CADEXsoft request timed out', { path });
+        throw new CadexsoftServiceError('CADEXsoft request timed out', 408);
+      }
+      log.error('CADEXsoft request failed', err);
+      throw new CadexsoftServiceError(
+        `CADEXsoft network error: ${(err as Error).message}`,
+        0,
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  health(): Promise<HealthResponse> {
+    return this.request<HealthResponse>('/health', { method: 'GET', headers: this.headers() });
+  }
+
+  analyze(
+    kind: AnalysisKind,
+    request: AnalyzeRequest,
+  ): Promise<AnalyzeResponse> {
+    const path = kind === 'pmi' ? '/extract/pmi' : `/analyze/${kind}`;
+    return this.request<AnalyzeResponse>(path, {
+      method: 'POST',
+      headers: this.headers({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify(request),
+    });
+  }
+
+  analyzeUpload(
+    kind: AnalysisKind,
+    file: File,
+    extra: Partial<Pick<AnalyzeRequest, 'part_id' | 'tenant_id' | 'options'>> = {},
+  ): Promise<AnalyzeResponse> {
+    const path = kind === 'pmi' ? '/extract/pmi' : `/analyze/${kind}`;
+    const body = new FormData();
+    body.append('upload', file);
+    body.append('file_name', file.name);
+    if (extra.part_id) body.append('part_id', extra.part_id);
+    if (extra.tenant_id) body.append('tenant_id', extra.tenant_id);
+    if (extra.options) body.append('options', JSON.stringify(extra.options));
+
+    return this.request<AnalyzeResponse>(path, {
+      method: 'POST',
+      headers: this.headers(), // let fetch set multipart boundary
+      body,
+    });
+  }
+}
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}

--- a/src/integrations/cadexsoft/index.ts
+++ b/src/integrations/cadexsoft/index.ts
@@ -1,0 +1,25 @@
+/**
+ * CADEXsoft MTK integration — public surface.
+ *
+ * The service this talks to is **local-only** by contract. See
+ * `docs/CADEXSOFT_INTEGRATION.md` and `services/cadexsoft/README.md` for
+ * deployment details.
+ */
+
+export {
+  CadexsoftClient,
+  CadexsoftServiceError,
+  createCadexsoftClient,
+  isCadexsoftConfigured,
+} from './client';
+export type { CadexsoftClientConfig } from './client';
+export type {
+  AnalysisKind,
+  AnalyzeRequest,
+  AnalyzeResponse,
+  AnalyzeStatus,
+  Feature,
+  HealthResponse,
+  Issue,
+  IssueSeverity,
+} from './types';

--- a/src/integrations/cadexsoft/types.ts
+++ b/src/integrations/cadexsoft/types.ts
@@ -1,0 +1,68 @@
+/**
+ * CADEXsoft MTK service types.
+ *
+ * Mirror of `services/cadexsoft/app/schemas.py`. Keep the two in sync — the
+ * Python service validates its own responses against the Pydantic models, and
+ * this file is the contract on the frontend side.
+ */
+
+export type AnalysisKind =
+  | 'dfm'
+  | 'sheet-metal'
+  | 'cnc-milling'
+  | 'turning'
+  | 'pmi';
+
+export interface AnalyzeRequest {
+  /** Fetchable URL (e.g. Supabase signed URL). Mutually exclusive with file_base64. */
+  file_url?: string;
+  /** Base64-encoded file bytes. Mutually exclusive with file_url. */
+  file_base64?: string;
+  file_name: string;
+  part_id?: string;
+  tenant_id?: string;
+  options?: Record<string, unknown>;
+}
+
+export type IssueSeverity = 'info' | 'warning' | 'error';
+
+export interface Issue {
+  id: string;
+  severity: IssueSeverity;
+  category: string;
+  message: string;
+  face_ids: string[];
+  edge_ids: string[];
+  metadata: Record<string, unknown>;
+}
+
+export interface Feature {
+  id: string;
+  kind: string;
+  parameters: Record<string, unknown>;
+  face_ids: string[];
+}
+
+export type AnalyzeStatus = 'ok' | 'stub' | 'error';
+
+export interface AnalyzeResponse {
+  status: AnalyzeStatus;
+  analysis: AnalysisKind;
+  mtk_version: string | null;
+  processing_time_ms: number;
+  file_name: string;
+  part_id: string | null;
+  issues: Issue[];
+  features: Feature[];
+  summary: Record<string, unknown>;
+  error?: string | null;
+}
+
+export interface HealthResponse {
+  status: 'ok' | 'degraded';
+  mtk_available: boolean;
+  license_activated: boolean;
+  mtk_version: string | null;
+  stub_mode: boolean;
+  error?: string | null;
+}


### PR DESCRIPTION
## Summary
<!-- 1-3 bullet points -->

## Changes
<!-- What was modified and why -->

## Checklist
- [ ] `npm run build` passes
- [ ] `npm run test:run` passes
- [ ] New tables have RLS policies
- [ ] New UI text uses i18n keys (EN + NL + DE)
- [ ] Edge functions have `deno.json` with import map
- [ ] Column names verified against actual DB schema


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added local CADEXsoft Manufacturing Toolkit (MTK) service integration with analysis endpoints for DFM, sheet metal, CNC milling, turning, and PMI extraction.
  * Added health check endpoint and support for file analysis via URL or direct upload with optional API key authentication.

* **Documentation**
  * Added integration guides and architecture documentation for local MTK service setup and deployment.

* **Configuration**
  * Added Docker Compose support and environment variables for local MTK service deployment on a private network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->