### PR TITLE
docs(website): v0.5 refresh + native mobile apps announcement

### DIFF
--- a/website/src/content/docs/architecture/connectivity-mqtt.md
+++ b/website/src/content/docs/architecture/connectivity-mqtt.md
@@ -63,7 +63,17 @@ The MQTT client wrapper in `src/lib/mqtt-client.ts` was hardened in v0.5 for sho
 - **Dead letter logging** — final failures are written to the `mqtt_logs` table with the original payload and error so operators can review and replay
 - **Injectable transport** — the wrapper accepts a transport implementation, so deployments can swap broker libraries or stub the transport in tests
 
-If you self-host and need to inspect failed publishes, query `mqtt_logs` filtered by `tenant_id` and `status = 'failed'`.
+If you self-host and need to inspect failed publishes, look at the `mqtt_logs` table. Tenant scope lives on `mqtt_publishers`, so filter by the tenant's publisher IDs and use the `success` boolean:
+
+```sql
+SELECT l.*
+FROM mqtt_logs l
+WHERE l.mqtt_publisher_id IN (
+  SELECT id FROM mqtt_publishers WHERE tenant_id = '<your-tenant-id>'
+)
+  AND l.success = false
+ORDER BY l.created_at DESC;
+```
 
 ---
 

--- a/website/src/content/docs/architecture/connectivity-mqtt.md
+++ b/website/src/content/docs/architecture/connectivity-mqtt.md
@@ -53,6 +53,18 @@ Result:
 }
 ```
 
+### Reliability (v0.5)
+
+The MQTT client wrapper in `src/lib/mqtt-client.ts` was hardened in v0.5 for shop-floor reliability:
+
+- **Exponential backoff retry** — 3 attempts with increasing delay before giving up on a publish
+- **Per-attempt timeout** — each publish attempt has its own deadline so a stuck broker can't wedge the worker
+- **Circuit breaker** — after 5 consecutive failures the breaker opens for 30 seconds, dropping new publishes fast instead of piling them up
+- **Dead letter logging** — final failures are written to the `mqtt_logs` table with the original payload and error so operators can review and replay
+- **Injectable transport** — the wrapper accepts a transport implementation, so deployments can swap broker libraries or stub the transport in tests
+
+If you self-host and need to inspect failed publishes, query `mqtt_logs` filtered by `tenant_id` and `status = 'failed'`.
+
 ---
 
 ## Testing Outbound Integrations

--- a/website/src/content/docs/de/index.mdx
+++ b/website/src/content/docs/de/index.mdx
@@ -1,11 +1,11 @@
 ---
 title: Eryxon Flow - MES für Lohnfertiger
-description: Manufacturing Execution System für Lohnfertiger. Self-hostbar, API-first, und für die Werkstatt gebaut.
+description: Manufacturing Execution System für Lohnfertiger. Self-hostbar, API-first, mit nativer Browser-, Android- und iOS-App für die Werkstatt.
 template: splash
 hero:
   title: |
     MES für <span class="text-primary">Lohnfertiger</span>
-  tagline: Die Werkstatt-App, die Ihre Werker tatsächlich nutzen. Echtzeit-Auftragsverfolgung, tabletfreundliche Terminals und ERP-Integration für die Einzelfertigung.
+  tagline: Die Werkstatt-App, die Ihre Werker tatsächlich nutzen. Echtzeit-Auftragsverfolgung im Browser, native Android- und iOS-App — gebaut für die Einzelfertigung.
   actions:
     - text: Gehostete Version Öffnen
       link: https://app.eryxon.eu
@@ -26,16 +26,46 @@ import LinkButton from "~/components/LinkButton.astro";
 import ListCard from "~/components/user-components/ListCard.astro";
 import ThemeDemo from "~/components/ThemeDemo.astro";
 
-<Section title="Aktueller <span class='text-primary'>Status</span>" description="v0.5.1 ist der aktuelle Wartungs-Hotfix.">
+<div class="flex flex-wrap items-center justify-center gap-3 -mt-8 mb-4">
+  <span class="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary ring-1 ring-inset ring-primary/20">
+    <span class="inline-block h-2 w-2 rounded-full bg-primary animate-pulse"></span>
+    Nativ im Browser
+  </span>
+  <span class="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-3 py-1 text-sm font-medium text-emerald-400 ring-1 ring-inset ring-emerald-500/20">
+    Android (Nativ) — Bald Verfügbar
+  </span>
+  <span class="inline-flex items-center gap-2 rounded-full bg-sky-500/10 px-3 py-1 text-sm font-medium text-sky-400 ring-1 ring-inset ring-sky-500/20">
+    iOS — Bald Verfügbar
+  </span>
+</div>
+
+<Section title="Eine Plattform, <span class='text-primary'>jeder Bildschirm</span>" description="Vom Bürotablet bis zum Werkstatt-Terminal — Eryxon Flow läuft nativ dort, wo Ihr Team arbeitet.">
+<Grid columns={4}>
+  <Card title="Web-App" icon="seti:globe" iconColor="#38bdf8" size="sm">
+    **Heute live.** Tabletfreundliche, responsive Web-App. Keine Installation — einfach den Browser öffnen. Echtzeit-Updates über WebSockets.
+  </Card>
+  <Card title="Android (Nativ)" icon="seti:mobile" iconColor="#34d399" size="sm">
+    **In Entwicklung.** Gebaut für Werkstatt-Zuverlässigkeit mit **Offline-Unterstützung** und **schnellem Start**. Für robuste Tablets und Smartphones.
+  </Card>
+  <Card title="iOS" icon="seti:mobile" iconColor="#a78bfa" size="sm">
+    **In Entwicklung.** Native iPhone- und iPad-App für Manager und Werker auf Apple-Geräten.
+  </Card>
+  <Card title="REST · MCP · MQTT" icon="seti:json" iconColor="#fb923c" size="sm">
+    **Heute live.** 24 REST-Endpunkte, MCP-Server, MQTT und Webhooks. Bauen Sie eigene Clients und Integrationen.
+  </Card>
+</Grid>
+</Section>
+
+<Section title="Aktueller <span class='text-primary'>Status</span>" description="v0.5.x ist die stabile Linie. Native Mobile-Apps sind als nächstes dran.">
 <Grid columns={3}>
   <Card title="Stabile Release" icon="seti:tag" iconColor="#38bdf8">
-    v0.5.1 wurde am 6. Mai 2026 als aktueller Wartungs-Hotfix veröffentlicht. v0.5.0 bleibt die letzte Release mit aktiver Entwicklung.
+    **v0.5.1** ist die aktuelle stabile Release, veröffentlicht am 6. Mai 2026. v0.5.0 brachte Planungs-Adapter, MCP-HTTP-Transport und MQTT-Härtung.
   </Card>
   <Card title="Gehostete Version" icon="seti:globe" iconColor="#34d399">
-    Die gehostete Version bleibt online wie sie ist. Neue Produktionseinführungen sollten Self-Hosting oder einen gepflegten Fork einplanen.
+    Die gehostete Version unter [app.eryxon.eu](https://app.eryxon.eu) ist online und kostenlos testbar. Self-Hosting ist für Produktiv-Deployments vollständig dokumentiert.
   </Card>
-  <Card title="Entwicklung Pausiert" icon="seti:lock" iconColor="#fb923c">
-    Die aktive Entwicklung ist derzeit pausiert. Sie können Eryxon Flow unter den BSL 1.1 Lizenzbedingungen nutzen, forken und anpassen.
+  <Card title="Native Apps Kommen" icon="seti:mobile" iconColor="#fb923c">
+    Native **Android**-App (mit Offline-Unterstützung und schnellem Start) und **iOS**-App sind in Entwicklung. Die Web-App bleibt heute die primäre Oberfläche.
   </Card>
 </Grid>
 </Section>
@@ -142,13 +172,44 @@ import ThemeDemo from "~/components/ThemeDemo.astro";
 />
 </Section>
 
+<Section title="Native <span class='text-primary'>Mobile-Apps</span>" description="Native Android- und iOS-Apps in Entwicklung — für Werkstatt-Zuverlässigkeit, die ein Browser allein nicht liefern kann.">
+<Grid columns={2}>
+  <Card title="Android — Nativ, Offline-Fähig" icon="seti:mobile" iconColor="#34d399">
+    Nativ entwickelt (kein Web-Wrapper) für **schnellen Start** und **Offline-Unterstützung**, sodass Werker auch bei WLAN-Aussetzern weiter Zeit erfassen und Arbeit ziehen können.
+
+    - Native UI für robuste Tablets und Smartphones
+    - Offline-Warteschlange für Zeitbuchungen und Statusänderungen, Synchronisierung bei Wiederverbindung
+    - Schneller App-Start — Werker warten nicht zwischen Scans
+    - Kamera für Problemfotos und Barcode-Scannen
+
+    <span class="inline-flex items-center rounded-full bg-emerald-500/10 px-3 py-1 mt-4 text-sm font-medium text-emerald-400 ring-1 ring-inset ring-emerald-500/20">In Entwicklung</span>
+  </Card>
+  <Card title="iOS — iPhone & iPad" icon="seti:mobile" iconColor="#a78bfa">
+    Native iOS-App für Manager, Vorarbeiter und Werker auf Apple-Geräten. Dieselben Echtzeit-Daten wie die Web-App, optimiert für Touch.
+
+    - Native iPad- und iPhone-Layouts
+    - Echtzeit-Auftragsstatus und Werker-Aktivität
+    - Push-Benachrichtigungen für Probleme und Genehmigungen
+    - Kamera-Aufnahme für NCRs
+
+    <span class="inline-flex items-center rounded-full bg-sky-500/10 px-3 py-1 mt-4 text-sm font-medium text-sky-400 ring-1 ring-inset ring-sky-500/20">In Entwicklung</span>
+  </Card>
+</Grid>
+
+<div class="text-center mt-8">
+  <p class="text-sm" style="color: color-mix(in srgb, var(--sl-color-white) 60%, transparent);">
+    Heute funktioniert die responsive Web-App unter <a href="https://app.eryxon.eu" class="text-primary hover:underline">app.eryxon.eu</a> auf jedem browserfähigen Gerät. Native Apps werden parallel zur Web-App erscheinen — gleiche Backend, gleiche API.
+  </p>
+</div>
+</Section>
+
 <Section title="Warum <span class='text-primary'>Eryxon Flow?</span>">
 <Grid columns={2}>
 <Card title="Für Lohnfertiger" icon="seti:home" iconColor="#38bdf8">
   High Mix, Low Volume. Tausende einzigartige Teile pro Jahr? Genau dafür haben wir das gebaut.
 </Card>
 <Card title="Entwicklerfreundlich" icon="seti:code" iconColor="#34d399">
-  API-first mit 22 REST-Endpunkten, Webhooks, MQTT und MCP-Server. Bauen Sie Integrationen nach Ihren Wünschen.
+  API-first mit 24 REST-Endpunkten, Webhooks, MQTT, MCP-Server und steckbaren Planungs-Adaptern (FrePPLe, Odoo). Bauen Sie Integrationen nach Ihren Wünschen.
 </Card>
 </Grid>
 

--- a/website/src/content/docs/de/index.mdx
+++ b/website/src/content/docs/de/index.mdx
@@ -1,11 +1,11 @@
 ---
 title: Eryxon Flow - MES für Lohnfertiger
-description: Manufacturing Execution System für Lohnfertiger. Self-hostbar, API-first, mit nativer Browser-, Android- und iOS-App für die Werkstatt.
+description: Manufacturing Execution System für Lohnfertiger. Self-hostbar, API-first Browser-App heute — native Android- und iOS-Apps in Kürze.
 template: splash
 hero:
   title: |
     MES für <span class="text-primary">Lohnfertiger</span>
-  tagline: Die Werkstatt-App, die Ihre Werker tatsächlich nutzen. Echtzeit-Auftragsverfolgung im Browser, native Android- und iOS-App — gebaut für die Einzelfertigung.
+  tagline: Die Werkstatt-App, die Ihre Werker tatsächlich nutzen. Heute Echtzeit-Auftragsverfolgung im Browser — native Android- und iOS-Apps bald verfügbar.
   actions:
     - text: Gehostete Version Öffnen
       link: https://app.eryxon.eu
@@ -198,7 +198,7 @@ import ThemeDemo from "~/components/ThemeDemo.astro";
 
 <div class="text-center mt-8">
   <p class="text-sm" style="color: color-mix(in srgb, var(--sl-color-white) 60%, transparent);">
-    Heute funktioniert die Beta-Web-App unter <a href="https://app.eryxon.eu" class="text-primary hover:underline">app.eryxon.eu</a> auf jedem browserfähigen Gerät. Native Apps werden parallel zur Web-App erscheinen — gleiche Backend, gleiche API.
+    Heute funktioniert die Beta-Web-App unter <a href="https://app.eryxon.eu" class="text-primary hover:underline">app.eryxon.eu</a> auf jedem browserfähigen Gerät. Native Apps werden parallel zur Web-App erscheinen — gleiches Backend, gleiche API.
   </p>
 </div>
 </Section>

--- a/website/src/content/docs/de/index.mdx
+++ b/website/src/content/docs/de/index.mdx
@@ -27,9 +27,9 @@ import ListCard from "~/components/user-components/ListCard.astro";
 import ThemeDemo from "~/components/ThemeDemo.astro";
 
 <div class="flex flex-wrap items-center justify-center gap-3 -mt-8 mb-4">
-  <span class="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary ring-1 ring-inset ring-primary/20">
-    <span class="inline-block h-2 w-2 rounded-full bg-primary animate-pulse"></span>
-    Nativ im Browser
+  <span class="inline-flex items-center gap-2 rounded-full bg-amber-500/10 px-3 py-1 text-sm font-medium text-amber-400 ring-1 ring-inset ring-amber-500/20">
+    <span class="inline-block h-2 w-2 rounded-full bg-amber-400 animate-pulse"></span>
+    Web-App — Beta
   </span>
   <span class="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-3 py-1 text-sm font-medium text-emerald-400 ring-1 ring-inset ring-emerald-500/20">
     Android (Nativ) — Bald Verfügbar
@@ -39,33 +39,33 @@ import ThemeDemo from "~/components/ThemeDemo.astro";
   </span>
 </div>
 
-<Section title="Eine Plattform, <span class='text-primary'>jeder Bildschirm</span>" description="Vom Bürotablet bis zum Werkstatt-Terminal — Eryxon Flow läuft nativ dort, wo Ihr Team arbeitet.">
+<Section title="Eine Plattform, <span class='text-primary'>jeder Bildschirm</span>" description="Vom Bürotablet bis zum Werkstatt-Terminal — Eryxon Flow läuft nativ dort, wo Ihr Team arbeitet. Die meisten Bereiche sind heute Beta; der MCP-Server ist die erste Schnittstelle, die diesen Status verlassen hat.">
 <Grid columns={4}>
-  <Card title="Web-App" icon="seti:globe" iconColor="#38bdf8" size="sm">
-    **Heute live.** Tabletfreundliche, responsive Web-App. Keine Installation — einfach den Browser öffnen. Echtzeit-Updates über WebSockets.
+  <Card title="Web-App" icon="seti:globe" iconColor="#fbbf24" size="sm">
+    **Beta.** Tabletfreundliche, responsive Web-App. Keine Installation — einfach den Browser öffnen. Echtzeit-Updates über WebSockets. Gehostete Version kostenlos testbar.
   </Card>
   <Card title="Android (Nativ)" icon="seti:mobile" iconColor="#34d399" size="sm">
-    **In Entwicklung.** Gebaut für Werkstatt-Zuverlässigkeit mit **Offline-Unterstützung** und **schnellem Start**. Für robuste Tablets und Smartphones.
+    **Bald Verfügbar.** Native Android-App mit **Offline-Unterstützung** und **schnellem Start**. Für robuste Tablets und Smartphones in der Werkstatt.
   </Card>
   <Card title="iOS" icon="seti:mobile" iconColor="#a78bfa" size="sm">
-    **In Entwicklung.** Native iPhone- und iPad-App für Manager und Werker auf Apple-Geräten.
+    **Bald Verfügbar.** Native iPhone- und iPad-App für Manager und Werker auf Apple-Geräten.
   </Card>
-  <Card title="REST · MCP · MQTT" icon="seti:json" iconColor="#fb923c" size="sm">
-    **Heute live.** 24 REST-Endpunkte, MCP-Server, MQTT und Webhooks. Bauen Sie eigene Clients und Integrationen.
+  <Card title="MCP · REST · MQTT" icon="seti:json" iconColor="#fb923c" size="sm">
+    **MCP-Server: Live.** REST-API, Webhooks und MQTT sind in **Beta** zusammen mit der Web-App. Heute 24 REST-Endpunkte.
   </Card>
 </Grid>
 </Section>
 
-<Section title="Aktueller <span class='text-primary'>Status</span>" description="v0.5.x ist die stabile Linie. Native Mobile-Apps sind als nächstes dran.">
+<Section title="Aktueller <span class='text-primary'>Status</span>" description="v0.5.x ist die stabile Linie. Die meisten Oberflächen sind Beta — MCP ist live, native Mobile-Apps folgen.">
 <Grid columns={3}>
   <Card title="Stabile Release" icon="seti:tag" iconColor="#38bdf8">
-    **v0.5.1** ist die aktuelle stabile Release, veröffentlicht am 6. Mai 2026. v0.5.0 brachte Planungs-Adapter, MCP-HTTP-Transport und MQTT-Härtung.
+    **v0.5.1** ist die aktuelle stabile Release, veröffentlicht am 6. Mai 2026. v0.5.0 brachte Planungs-Adapter, MCP-HTTP-Transport und MQTT-Härtung. Die App selbst ist weiterhin **Beta**.
   </Card>
-  <Card title="Gehostete Version" icon="seti:globe" iconColor="#34d399">
-    Die gehostete Version unter [app.eryxon.eu](https://app.eryxon.eu) ist online und kostenlos testbar. Self-Hosting ist für Produktiv-Deployments vollständig dokumentiert.
+  <Card title="Gehostete Version (Beta)" icon="seti:globe" iconColor="#fbbf24">
+    Die gehostete Version unter [app.eryxon.eu](https://app.eryxon.eu) ist online und kostenlos testbar. Self-Hosting ist für Produktiv-Deployments dokumentiert — rechnen Sie mit Beta-typischen Ecken und Kanten.
   </Card>
-  <Card title="Native Apps Kommen" icon="seti:mobile" iconColor="#fb923c">
-    Native **Android**-App (mit Offline-Unterstützung und schnellem Start) und **iOS**-App sind in Entwicklung. Die Web-App bleibt heute die primäre Oberfläche.
+  <Card title="Native Apps Kommen" icon="seti:mobile" iconColor="#34d399">
+    Native **Android**-App (mit Offline-Unterstützung und schnellem Start) und **iOS**-App folgen bald. Die Web-App bleibt heute die primäre Oberfläche.
   </Card>
 </Grid>
 </Section>
@@ -172,7 +172,7 @@ import ThemeDemo from "~/components/ThemeDemo.astro";
 />
 </Section>
 
-<Section title="Native <span class='text-primary'>Mobile-Apps</span>" description="Native Android- und iOS-Apps in Entwicklung — für Werkstatt-Zuverlässigkeit, die ein Browser allein nicht liefern kann.">
+<Section title="Native <span class='text-primary'>Mobile-Apps</span>" description="Native Android- und iOS-Apps bald verfügbar — für Werkstatt-Zuverlässigkeit, die ein Browser allein nicht liefern kann.">
 <Grid columns={2}>
   <Card title="Android — Nativ, Offline-Fähig" icon="seti:mobile" iconColor="#34d399">
     Nativ entwickelt (kein Web-Wrapper) für **schnellen Start** und **Offline-Unterstützung**, sodass Werker auch bei WLAN-Aussetzern weiter Zeit erfassen und Arbeit ziehen können.
@@ -182,7 +182,7 @@ import ThemeDemo from "~/components/ThemeDemo.astro";
     - Schneller App-Start — Werker warten nicht zwischen Scans
     - Kamera für Problemfotos und Barcode-Scannen
 
-    <span class="inline-flex items-center rounded-full bg-emerald-500/10 px-3 py-1 mt-4 text-sm font-medium text-emerald-400 ring-1 ring-inset ring-emerald-500/20">In Entwicklung</span>
+    <span class="inline-flex items-center rounded-full bg-emerald-500/10 px-3 py-1 mt-4 text-sm font-medium text-emerald-400 ring-1 ring-inset ring-emerald-500/20">Bald Verfügbar</span>
   </Card>
   <Card title="iOS — iPhone & iPad" icon="seti:mobile" iconColor="#a78bfa">
     Native iOS-App für Manager, Vorarbeiter und Werker auf Apple-Geräten. Dieselben Echtzeit-Daten wie die Web-App, optimiert für Touch.
@@ -192,13 +192,13 @@ import ThemeDemo from "~/components/ThemeDemo.astro";
     - Push-Benachrichtigungen für Probleme und Genehmigungen
     - Kamera-Aufnahme für NCRs
 
-    <span class="inline-flex items-center rounded-full bg-sky-500/10 px-3 py-1 mt-4 text-sm font-medium text-sky-400 ring-1 ring-inset ring-sky-500/20">In Entwicklung</span>
+    <span class="inline-flex items-center rounded-full bg-sky-500/10 px-3 py-1 mt-4 text-sm font-medium text-sky-400 ring-1 ring-inset ring-sky-500/20">Bald Verfügbar</span>
   </Card>
 </Grid>
 
 <div class="text-center mt-8">
   <p class="text-sm" style="color: color-mix(in srgb, var(--sl-color-white) 60%, transparent);">
-    Heute funktioniert die responsive Web-App unter <a href="https://app.eryxon.eu" class="text-primary hover:underline">app.eryxon.eu</a> auf jedem browserfähigen Gerät. Native Apps werden parallel zur Web-App erscheinen — gleiche Backend, gleiche API.
+    Heute funktioniert die Beta-Web-App unter <a href="https://app.eryxon.eu" class="text-primary hover:underline">app.eryxon.eu</a> auf jedem browserfähigen Gerät. Native Apps werden parallel zur Web-App erscheinen — gleiche Backend, gleiche API.
   </p>
 </div>
 </Section>

--- a/website/src/content/docs/de/introduction.md
+++ b/website/src/content/docs/de/introduction.md
@@ -67,7 +67,7 @@ Verfolgen Sie in Echtzeit, wer anwesend ist und woran gearbeitet wird. Kein Rate
 
 ## Integration-First-Architektur
 
-**100% API-gesteuert.** Ihr ERP sendet Aufträge, Teile und Aufgaben über 24 REST-API-Endpunkte. Eryxon sendet Abschlussereignisse zurück über Webhooks oder MQTT — beide in v0.5 mit Retry, Circuit Breaker und Dead-Letter-Logging gehärtet. Der MCP-Server ermöglicht KI/Automatisierungs-Integration mit stdio für lokale Clients und Streamable HTTP für vertrauenswürdige selbstgehostete Deployments.
+**100% API-gesteuert.** Ihr ERP sendet Aufträge, Teile und Aufgaben über 24 REST-API-Endpunkte (Beta). Eryxon sendet Abschlussereignisse zurück über Webhooks (Beta) oder MQTT (Beta) — der MQTT-Client bringt in v0.5 Retry, Circuit Breaker und Dead-Letter-Logging mit. Der MCP-Server (Live) ermöglicht KI/Automatisierungs-Integration mit stdio für lokale Clients und Streamable HTTP für vertrauenswürdige selbstgehostete Deployments.
 
 ### Dateihandhabung
 Fordern Sie eine signierte Upload-URL über die API an, laden Sie STEP- und PDF-Dateien direkt in den Supabase Storage hoch und referenzieren Sie dann den Dateipfad beim Erstellen von Aufträgen oder Teilen. Große Dateien (typisch 5-50 MB) werden direkt in den Speicher hochgeladen — keine Timeouts, keine API-Engpässe.

--- a/website/src/content/docs/de/introduction.md
+++ b/website/src/content/docs/de/introduction.md
@@ -65,7 +65,7 @@ Verfolgen Sie in Echtzeit, wer anwesend ist und woran gearbeitet wird. Kein Rate
 
 ## Integration-First-Architektur
 
-**100% API-gesteuert.** Ihr ERP sendet Aufträge, Teile und Aufgaben über die REST-API. Eryxon sendet Abschlussereignisse zurück über Webhooks. Der MCP-Server ermöglicht KI/Automatisierungs-Integration.
+**100% API-gesteuert.** Ihr ERP sendet Aufträge, Teile und Aufgaben über 24 REST-API-Endpunkte. Eryxon sendet Abschlussereignisse zurück über Webhooks oder MQTT — beide in v0.5 mit Retry, Circuit Breaker und Dead-Letter-Logging gehärtet. Der MCP-Server ermöglicht KI/Automatisierungs-Integration mit stdio für lokale Clients und Streamable HTTP für vertrauenswürdige selbstgehostete Deployments.
 
 ### Dateihandhabung
 Fordern Sie eine signierte Upload-URL über die API an, laden Sie STEP- und PDF-Dateien direkt in den Supabase Storage hoch und referenzieren Sie dann den Dateipfad beim Erstellen von Aufträgen oder Teilen. Große Dateien (typisch 5-50 MB) werden direkt in den Speicher hochgeladen — keine Timeouts, keine API-Engpässe.
@@ -73,8 +73,8 @@ Fordern Sie eine signierte Upload-URL über die API an, laden Sie STEP- und PDF-
 ### Benutzerdefinierte Metadaten
 Fügen Sie JSON-Payloads zu Aufträgen, Teilen und Aufgaben hinzu für Ihre spezifischen Anforderungen — Werkzeuganforderungen, Formnummern, Maschineneinstellungen, Materialspezifikationen, alles was Ihre Werkstatt nachverfolgen muss.
 
-### ERP-Integrationen
-Partner wie **Sheet Metal Connect e.U.** bauen Integrationen für gängige ERP-Systeme. Oder bauen Sie Ihre eigene mit unseren GitHub-Starter-Kits mit Beispielcode und Dokumentation.
+### ERP- & Planungs-Integrationen
+Partner wie **Sheet Metal Connect e.U.** bauen Integrationen für gängige ERP-Systeme. Oder bauen Sie Ihre eigene mit unseren GitHub-Starter-Kits mit Beispielcode und Dokumentation. v0.5 liefert außerdem steckbare Planungs-Adapter für **FrePPLe** (produktionsreif) und **Odoo MRP** (Scaffold).
 
 ### Montage-Verfolgung
 Teile können Eltern-Kind-Beziehungen haben. Visuelle Gruppierung zeigt Baugruppen mit verschachtelten Komponenten. Nicht-blockierende Abhängigkeitswarnungen erinnern Werker daran, wann Unterteile fertig sein sollten, bevor Montageaufgaben beginnen — sie können dies aber bei Bedarf überschreiben.

--- a/website/src/content/docs/de/introduction.md
+++ b/website/src/content/docs/de/introduction.md
@@ -5,7 +5,9 @@ description: Das einfache, elegante und leistungsstarke Manufacturing Execution 
 
 **Das einfache, elegante und leistungsstarke Manufacturing Execution System, mit dem Ihre Mitarbeiter gerne arbeiten. Entwickelt für die Metallverarbeitung.**
 
-> **Jetzt ausprobieren:** Öffnen Sie die [gehostete Version auf app.eryxon.eu](https://app.eryxon.eu) - keine Installation erforderlich. Sie bleibt online wie sie ist.
+> **Status:** Der Großteil von Eryxon Flow ist im **Beta**-Status — Web-App, REST-API, Webhooks, MQTT und die Planungs-Adapter für FrePPLe und Odoo. Der **MCP-Server ist Live**. Native **Android**- und **iOS**-Apps folgen bald.
+
+> **Jetzt ausprobieren:** Öffnen Sie die [gehostete Version auf app.eryxon.eu](https://app.eryxon.eu) — keine Installation erforderlich.
 
 ## Was Es Macht
 
@@ -74,7 +76,7 @@ Fordern Sie eine signierte Upload-URL über die API an, laden Sie STEP- und PDF-
 Fügen Sie JSON-Payloads zu Aufträgen, Teilen und Aufgaben hinzu für Ihre spezifischen Anforderungen — Werkzeuganforderungen, Formnummern, Maschineneinstellungen, Materialspezifikationen, alles was Ihre Werkstatt nachverfolgen muss.
 
 ### ERP- & Planungs-Integrationen
-Partner wie **Sheet Metal Connect e.U.** bauen Integrationen für gängige ERP-Systeme. Oder bauen Sie Ihre eigene mit unseren GitHub-Starter-Kits mit Beispielcode und Dokumentation. v0.5 liefert außerdem steckbare Planungs-Adapter für **FrePPLe** (produktionsreif) und **Odoo MRP** (Scaffold).
+Partner wie **Sheet Metal Connect e.U.** bauen Integrationen für gängige ERP-Systeme. Oder bauen Sie Ihre eigene mit unseren GitHub-Starter-Kits mit Beispielcode und Dokumentation. v0.5 liefert außerdem steckbare Planungs-Adapter im **Beta**-Status für **FrePPLe** und **Odoo MRP**.
 
 ### Montage-Verfolgung
 Teile können Eltern-Kind-Beziehungen haben. Visuelle Gruppierung zeigt Baugruppen mit verschachtelten Komponenten. Nicht-blockierende Abhängigkeitswarnungen erinnern Werker daran, wann Unterteile fertig sein sollten, bevor Montageaufgaben beginnen — sie können dies aber bei Bedarf überschreiben.

--- a/website/src/content/docs/features/erp-integration.md
+++ b/website/src/content/docs/features/erp-integration.md
@@ -49,12 +49,12 @@ Navigate to **Admin → Data Import** in the web UI.
 
 Best for: Pulling work orders and resources from a dedicated planning system without writing custom REST sync code.
 
-| Adapter | Source | Notes |
-|---------|--------|-------|
-| **FrePPLe** | FrePPLe REST API | Production-ready: pull work orders + resources, push start and completion, Basic Auth, pagination |
-| **Odoo MRP** | Odoo `mrp.production` over JSON-RPC | Scaffold: pull work orders, push execution feedback |
+| Adapter | Source | Status | Notes |
+|---------|--------|--------|-------|
+| **FrePPLe** | FrePPLe REST API | Beta | Pull work orders + resources, push start and completion, Basic Auth, pagination |
+| **Odoo MRP** | Odoo `mrp.production` over JSON-RPC | Beta | Pull work orders, push execution feedback |
 
-Adapters share a single TypeScript interface (`src/lib/planning/`) using ISA-95 aligned vocabulary. Pick one at runtime with `createPlanningAdapter(config)`.
+Both adapters are **Beta** — interfaces and behavior may still change, so pilot them on non-critical work first. Adapters share a single TypeScript interface (`src/lib/planning/`) using ISA-95 aligned vocabulary. Pick one at runtime with `createPlanningAdapter(config)`.
 
 ## Supported Entities
 

--- a/website/src/content/docs/features/erp-integration.md
+++ b/website/src/content/docs/features/erp-integration.md
@@ -37,11 +37,24 @@ Best for: Webhook-driven updates, event-based sync, real-time integration.
 | `POST` | `/api-{entity}/bulk-sync` | Batch upsert (up to 1000) |
 | `DELETE` | `/api-{entity}?id={uuid}` | Hard delete |
 
+24 integration endpoints are available across jobs, parts, operations, batches, cells, resources, materials, time entries, webhooks, and assignments. See the [REST API reference](/api/rest-api-reference/) for the full catalog.
+
 ### 2. CSV Batch Import (UI-based)
 
 Best for: Initial data migration, periodic bulk updates, manual imports.
 
 Navigate to **Admin → Data Import** in the web UI.
+
+### 3. Planning Adapters (v0.5)
+
+Best for: Pulling work orders and resources from a dedicated planning system without writing custom REST sync code.
+
+| Adapter | Source | Notes |
+|---------|--------|-------|
+| **FrePPLe** | FrePPLe REST API | Production-ready: pull work orders + resources, push start and completion, Basic Auth, pagination |
+| **Odoo MRP** | Odoo `mrp.production` over JSON-RPC | Scaffold: pull work orders, push execution feedback |
+
+Adapters share a single TypeScript interface (`src/lib/planning/`) using ISA-95 aligned vocabulary. Pick one at runtime with `createPlanningAdapter(config)`.
 
 ## Supported Entities
 

--- a/website/src/content/docs/features/scheduling.md
+++ b/website/src/content/docs/features/scheduling.md
@@ -51,4 +51,17 @@ The Capacity Matrix page at **Admin → Capacity Matrix** shows:
 - Only cell capacity is considered, not worker availability or materials
 - No what-if scenario simulation
 
-For complex scheduling needs, use a dedicated APS tool and sync dates via the [REST API](/architecture/connectivity-rest-api/) or [CSV Import](/features/csv-import/).
+For complex scheduling needs, use a dedicated APS tool and sync dates via the [REST API](/architecture/connectivity-rest-api/), [CSV Import](/features/csv-import/), or one of the planning adapters below.
+
+## Planning Adapters (v0.5)
+
+Eryxon Flow ships with a planning adapter interface in `src/lib/planning/` that bridges external planning and scheduling tools using ISA-95 aligned vocabulary. Use it to pull work orders and resources from your planner into Eryxon and push start and completion feedback back.
+
+| Adapter | Status | Auth | Capabilities |
+|---------|--------|------|--------------|
+| **FrePPLe** | Production-ready | Basic Auth | Pull work orders + resources, push order start and completion, pagination handling |
+| **Odoo MRP** | Scaffold | JSON-RPC | Pull work orders from `mrp.production`, push execution feedback |
+
+Select an adapter at runtime with the `createPlanningAdapter(config)` factory. The FrePPLe adapter is covered by 20 unit tests (connection, mapping, pagination, error handling, auth).
+
+Adapters are not enabled by default — they are an opt-in integration surface for self-hosted deployments and forks.

--- a/website/src/content/docs/features/scheduling.md
+++ b/website/src/content/docs/features/scheduling.md
@@ -59,9 +59,9 @@ Eryxon Flow ships with a planning adapter interface in `src/lib/planning/` that 
 
 | Adapter | Status | Auth | Capabilities |
 |---------|--------|------|--------------|
-| **FrePPLe** | Production-ready | Basic Auth | Pull work orders + resources, push order start and completion, pagination handling |
-| **Odoo MRP** | Scaffold | JSON-RPC | Pull work orders from `mrp.production`, push execution feedback |
+| **FrePPLe** | Beta | Basic Auth | Pull work orders + resources, push order start and completion, pagination handling |
+| **Odoo MRP** | Beta | JSON-RPC | Pull work orders from `mrp.production`, push execution feedback |
 
-Select an adapter at runtime with the `createPlanningAdapter(config)` factory. The FrePPLe adapter is covered by 20 unit tests (connection, mapping, pagination, error handling, auth).
+Both adapters are **Beta** — interfaces and behavior may still change. The FrePPLe adapter is covered by 20 unit tests (connection, mapping, pagination, error handling, auth); the Odoo adapter has narrower coverage. Pilot them on non-critical work first.
 
-Adapters are not enabled by default — they are an opt-in integration surface for self-hosted deployments and forks.
+Select an adapter at runtime with the `createPlanningAdapter(config)` factory. Adapters are not enabled by default — they are an opt-in integration surface for self-hosted deployments and forks.

--- a/website/src/content/docs/features/scheduling.md
+++ b/website/src/content/docs/features/scheduling.md
@@ -62,6 +62,6 @@ Eryxon Flow ships with a planning adapter interface in `src/lib/planning/` that 
 | **FrePPLe** | Beta | Basic Auth | Pull work orders + resources, push order start and completion, pagination handling |
 | **Odoo MRP** | Beta | JSON-RPC | Pull work orders from `mrp.production`, push execution feedback |
 
-Both adapters are **Beta** — interfaces and behavior may still change. The FrePPLe adapter is covered by 20 unit tests (connection, mapping, pagination, error handling, auth); the Odoo adapter has narrower coverage. Pilot them on non-critical work first.
+Both adapters are **Beta** — interfaces and behavior may still change. The FrePPLe adapter is covered by 21 unit tests (connection, mapping, pagination, error handling, auth); the Odoo adapter has narrower coverage (2 tests today). Pilot them on non-critical work first.
 
 Select an adapter at runtime with the `createPlanningAdapter(config)` factory. Adapters are not enabled by default — they are an opt-in integration surface for self-hosted deployments and forks.

--- a/website/src/content/docs/guides/changelog.md
+++ b/website/src/content/docs/guides/changelog.md
@@ -11,17 +11,17 @@ Eryxon Flow is free to use, fork, and adapt under the Business Source License 1.
 
 ## v0.5.1 - May 6, 2026
 
-Maintenance hotfix for release metadata and final handoff docs.
+Maintenance hotfix for release metadata and handoff docs. (Native Android and iOS app development started after this release.)
 
 ### Fixed
 
 - Refreshed stale OpenTrace knowledge graph counts after regenerating the local index
 - Aligned the README BSL conversion summary with the repository `LICENSE`
-- Marked v0.5.1 as the current maintenance hotfix while preserving v0.5.0 as the final active-development release
+- Tagged v0.5.1 as the current maintenance hotfix on top of v0.5.0
 
 ## v0.5.0 - May 6, 2026
 
-Final active-development release for self-hosted planning integration and shop floor execution.
+Last web-app feature release before the native mobile push. Adds self-hosted planning integration and shop floor execution hardening.
 
 ### Highlights
 

--- a/website/src/content/docs/guides/changelog.md
+++ b/website/src/content/docs/guides/changelog.md
@@ -5,7 +5,7 @@ description: Release history and current maintenance status for Eryxon Flow.
 
 ## Current Status
 
-The latest stable release is **v0.5.1**, published on May 6, 2026. Web app development on the v0.5.x line is in maintenance mode. **Native Android and iOS apps are now in development** — Android is being built natively with offline support and fast cold start, and iOS is in active development. The hosted version at [app.eryxon.eu](https://app.eryxon.eu) remains online and free to try.
+The latest stable release is **v0.5.1**, published on May 6, 2026. Most of Eryxon Flow is still **Beta** — including the web app, REST API, webhooks, MQTT, and the FrePPLe and Odoo planning adapters. The **MCP server is Live**. Native **Android** and **iOS** apps are coming soon (Android is being built natively with offline support and fast cold start). The hosted version at [app.eryxon.eu](https://app.eryxon.eu) remains online and free to try.
 
 Eryxon Flow is free to use, fork, and adapt under the Business Source License 1.1 terms. The native mobile apps will share the same backend and REST/MCP/MQTT API as the web app.
 

--- a/website/src/content/docs/guides/changelog.md
+++ b/website/src/content/docs/guides/changelog.md
@@ -5,9 +5,9 @@ description: Release history and current maintenance status for Eryxon Flow.
 
 ## Current Status
 
-The latest release is **v0.5.1**, published on May 6, 2026. Active development is currently on hold. The hosted version at [app.eryxon.eu](https://app.eryxon.eu) remains online as-is.
+The latest stable release is **v0.5.1**, published on May 6, 2026. Web app development on the v0.5.x line is in maintenance mode. **Native Android and iOS apps are now in development** — Android is being built natively with offline support and fast cold start, and iOS is in active development. The hosted version at [app.eryxon.eu](https://app.eryxon.eu) remains online and free to try.
 
-Eryxon Flow is free to use, fork, and adapt under the Business Source License 1.1 terms. For new production deployments, use the self-hosting guides and plan to maintain your own fork if you need changes beyond v0.5.1.
+Eryxon Flow is free to use, fork, and adapt under the Business Source License 1.1 terms. The native mobile apps will share the same backend and REST/MCP/MQTT API as the web app.
 
 ## v0.5.1 - May 6, 2026
 

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -1,11 +1,11 @@
 ---
 title: Eryxon Flow - MES for Job Shops
-description: Manufacturing Execution System for Job Shops. Self-hostable, API-first, and built for the shop floor.
+description: Manufacturing Execution System for Job Shops. Self-hostable, API-first, with native browser, Android, and iOS apps for the shop floor.
 template: splash
 hero:
   title: |
     MES for <span class="text-primary">Job Shops</span>
-  tagline: The shop floor app your operators will actually use. Real-time job tracking, tablet-friendly terminals, and ERP integration built for custom manufacturing.
+  tagline: The shop floor app your operators will actually use. Real-time job tracking on browser, native Android, and iOS — built for custom manufacturing.
   actions:
     - text: Open Hosted Version
       link: https://app.eryxon.eu
@@ -26,16 +26,46 @@ import LinkButton from "~/components/LinkButton.astro";
 import ListCard from "~/components/user-components/ListCard.astro";
 import ThemeDemo from "~/components/ThemeDemo.astro";
 
-<Section title="Current <span class='text-primary'>Status</span>" description="v0.5.1 is the current maintenance hotfix.">
+<div class="flex flex-wrap items-center justify-center gap-3 -mt-8 mb-4">
+  <span class="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary ring-1 ring-inset ring-primary/20">
+    <span class="inline-block h-2 w-2 rounded-full bg-primary animate-pulse"></span>
+    Native in Browser
+  </span>
+  <span class="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-3 py-1 text-sm font-medium text-emerald-400 ring-1 ring-inset ring-emerald-500/20">
+    Android (Native) — Coming Soon
+  </span>
+  <span class="inline-flex items-center gap-2 rounded-full bg-sky-500/10 px-3 py-1 text-sm font-medium text-sky-400 ring-1 ring-inset ring-sky-500/20">
+    iOS — Coming Soon
+  </span>
+</div>
+
+<Section title="One Platform, <span class='text-primary'>Every Screen</span>" description="From the office tablet to the shop floor terminal — Eryxon Flow runs natively where your team works.">
+<Grid columns={4}>
+  <Card title="Web App" icon="seti:globe" iconColor="#38bdf8" size="sm">
+    **Live today.** Tablet-friendly responsive web app. No install — just open the browser. Real-time updates via WebSockets.
+  </Card>
+  <Card title="Android (Native)" icon="seti:mobile" iconColor="#34d399" size="sm">
+    **In development.** Built for shop floor reliability with **offline support** and **fast cold start**. Designed for rugged tablets and phones.
+  </Card>
+  <Card title="iOS" icon="seti:mobile" iconColor="#a78bfa" size="sm">
+    **In development.** Native iPhone and iPad app for managers and operators on Apple devices.
+  </Card>
+  <Card title="REST · MCP · MQTT" icon="seti:json" iconColor="#fb923c" size="sm">
+    **Live today.** 24 REST endpoints, MCP server, MQTT, and webhooks. Build your own clients and integrations.
+  </Card>
+</Grid>
+</Section>
+
+<Section title="Current <span class='text-primary'>Status</span>" description="v0.5.x is the stable line. Native mobile apps are next.">
 <Grid columns={3}>
   <Card title="Stable Release" icon="seti:tag" iconColor="#38bdf8">
-    v0.5.1 was published on May 6, 2026 as the current maintenance hotfix. v0.5.0 remains the final active-development release.
+    **v0.5.1** is the current stable release, published on May 6, 2026. v0.5.0 introduced planning adapters, MCP HTTP transport, and MQTT reliability hardening.
   </Card>
   <Card title="Hosted Version" icon="seti:globe" iconColor="#34d399">
-    The hosted version remains online as-is. New production deployments should plan around self-hosting or a maintained fork.
+    The hosted version at [app.eryxon.eu](https://app.eryxon.eu) is online and free to try. Self-hosting is fully documented for production deployments.
   </Card>
-  <Card title="Development Hold" icon="seti:lock" iconColor="#fb923c">
-    Active development is currently on hold. You are free to use, fork, and adapt Eryxon Flow under the BSL 1.1 license terms.
+  <Card title="Native Apps Coming" icon="seti:mobile" iconColor="#fb923c">
+    Native **Android** (with offline support and fast cold start) and **iOS** apps are in development. The web app remains the primary surface today.
   </Card>
 </Grid>
 </Section>
@@ -142,13 +172,44 @@ import ThemeDemo from "~/components/ThemeDemo.astro";
 />
 </Section>
 
+<Section title="Native <span class='text-primary'>Mobile Apps</span>" description="Native Android and iOS apps in development for shop floor reliability beyond what a browser can deliver.">
+<Grid columns={2}>
+  <Card title="Android — Native, Offline-Capable" icon="seti:mobile" iconColor="#34d399">
+    Built natively (not a wrapped web view) for **fast cold start** and **offline support** so operators can keep logging time and pulling work even when shop Wi-Fi drops.
+
+    - Native UI tuned for rugged tablets and phones
+    - Offline queue for time entries and status changes, syncs when reconnected
+    - Fast app open — operators won't wait between scans
+    - Camera for issue photos and barcode scanning
+
+    <span class="inline-flex items-center rounded-full bg-emerald-500/10 px-3 py-1 mt-4 text-sm font-medium text-emerald-400 ring-1 ring-inset ring-emerald-500/20">In Development</span>
+  </Card>
+  <Card title="iOS — iPhone & iPad" icon="seti:mobile" iconColor="#a78bfa">
+    Native iOS app for managers, supervisors, and operators on Apple devices. Same real-time data as the web app, optimized for touch.
+
+    - Native iPad and iPhone layouts
+    - Real-time job status and operator activity
+    - Push notifications for issues and approvals
+    - Camera capture for NCRs
+
+    <span class="inline-flex items-center rounded-full bg-sky-500/10 px-3 py-1 mt-4 text-sm font-medium text-sky-400 ring-1 ring-inset ring-sky-500/20">In Development</span>
+  </Card>
+</Grid>
+
+<div class="text-center mt-8">
+  <p class="text-sm" style="color: color-mix(in srgb, var(--sl-color-white) 60%, transparent);">
+    Today, the responsive web app at <a href="https://app.eryxon.eu" class="text-primary hover:underline">app.eryxon.eu</a> works on every browser-capable device. Native apps will land alongside the web app, sharing the same backend and API.
+  </p>
+</div>
+</Section>
+
 <Section title="Why <span class='text-primary'>Eryxon Flow?</span>">
 <Grid columns={2}>
 <Card title="For Job Shops" icon="seti:home" iconColor="#38bdf8">
   High mix, low volume. Thousands of unique parts per year? That's exactly what we built this for.
 </Card>
 <Card title="Developer Friendly" icon="seti:code" iconColor="#34d399">
-  API-first with 22 REST endpoints, webhooks, MQTT, and MCP server. Build integrations your way.
+  API-first with 24 REST endpoints, webhooks, MQTT, MCP server, and pluggable planning adapters (FrePPLe, Odoo). Build integrations your way.
 </Card>
 </Grid>
 

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -27,9 +27,9 @@ import ListCard from "~/components/user-components/ListCard.astro";
 import ThemeDemo from "~/components/ThemeDemo.astro";
 
 <div class="flex flex-wrap items-center justify-center gap-3 -mt-8 mb-4">
-  <span class="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary ring-1 ring-inset ring-primary/20">
-    <span class="inline-block h-2 w-2 rounded-full bg-primary animate-pulse"></span>
-    Native in Browser
+  <span class="inline-flex items-center gap-2 rounded-full bg-amber-500/10 px-3 py-1 text-sm font-medium text-amber-400 ring-1 ring-inset ring-amber-500/20">
+    <span class="inline-block h-2 w-2 rounded-full bg-amber-400 animate-pulse"></span>
+    Web App — Beta
   </span>
   <span class="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-3 py-1 text-sm font-medium text-emerald-400 ring-1 ring-inset ring-emerald-500/20">
     Android (Native) — Coming Soon
@@ -39,33 +39,33 @@ import ThemeDemo from "~/components/ThemeDemo.astro";
   </span>
 </div>
 
-<Section title="One Platform, <span class='text-primary'>Every Screen</span>" description="From the office tablet to the shop floor terminal — Eryxon Flow runs natively where your team works.">
+<Section title="One Platform, <span class='text-primary'>Every Screen</span>" description="From the office tablet to the shop floor terminal — Eryxon Flow runs natively where your team works. Most of the app is in Beta today; the MCP server is the first surface to graduate.">
 <Grid columns={4}>
-  <Card title="Web App" icon="seti:globe" iconColor="#38bdf8" size="sm">
-    **Live today.** Tablet-friendly responsive web app. No install — just open the browser. Real-time updates via WebSockets.
+  <Card title="Web App" icon="seti:globe" iconColor="#fbbf24" size="sm">
+    **Beta.** Tablet-friendly responsive web app. No install — just open the browser. Real-time updates via WebSockets. Hosted version is free to try.
   </Card>
   <Card title="Android (Native)" icon="seti:mobile" iconColor="#34d399" size="sm">
-    **In development.** Built for shop floor reliability with **offline support** and **fast cold start**. Designed for rugged tablets and phones.
+    **Coming Soon.** Native Android app with **offline support** and **fast cold start**. Designed for rugged tablets and phones on the shop floor.
   </Card>
   <Card title="iOS" icon="seti:mobile" iconColor="#a78bfa" size="sm">
-    **In development.** Native iPhone and iPad app for managers and operators on Apple devices.
+    **Coming Soon.** Native iPhone and iPad app for managers and operators on Apple devices.
   </Card>
-  <Card title="REST · MCP · MQTT" icon="seti:json" iconColor="#fb923c" size="sm">
-    **Live today.** 24 REST endpoints, MCP server, MQTT, and webhooks. Build your own clients and integrations.
+  <Card title="MCP · REST · MQTT" icon="seti:json" iconColor="#fb923c" size="sm">
+    **MCP server: Live.** REST API, webhooks, and MQTT are in **Beta** alongside the web app. 24 REST endpoints today.
   </Card>
 </Grid>
 </Section>
 
-<Section title="Current <span class='text-primary'>Status</span>" description="v0.5.x is the stable line. Native mobile apps are next.">
+<Section title="Current <span class='text-primary'>Status</span>" description="v0.5.x is the stable line. Most surfaces are Beta — MCP is live, native mobile apps are next.">
 <Grid columns={3}>
   <Card title="Stable Release" icon="seti:tag" iconColor="#38bdf8">
-    **v0.5.1** is the current stable release, published on May 6, 2026. v0.5.0 introduced planning adapters, MCP HTTP transport, and MQTT reliability hardening.
+    **v0.5.1** is the current stable release, published on May 6, 2026. v0.5.0 introduced planning adapters, MCP HTTP transport, and MQTT reliability hardening. The app itself is still **Beta**.
   </Card>
-  <Card title="Hosted Version" icon="seti:globe" iconColor="#34d399">
-    The hosted version at [app.eryxon.eu](https://app.eryxon.eu) is online and free to try. Self-hosting is fully documented for production deployments.
+  <Card title="Hosted Version (Beta)" icon="seti:globe" iconColor="#fbbf24">
+    The hosted version at [app.eryxon.eu](https://app.eryxon.eu) is online and free to try. Self-hosting is fully documented for production deployments — but expect Beta-level rough edges.
   </Card>
-  <Card title="Native Apps Coming" icon="seti:mobile" iconColor="#fb923c">
-    Native **Android** (with offline support and fast cold start) and **iOS** apps are in development. The web app remains the primary surface today.
+  <Card title="Native Apps Coming" icon="seti:mobile" iconColor="#34d399">
+    Native **Android** (with offline support and fast cold start) and **iOS** apps are coming soon. The web app remains the primary surface today.
   </Card>
 </Grid>
 </Section>
@@ -172,7 +172,7 @@ import ThemeDemo from "~/components/ThemeDemo.astro";
 />
 </Section>
 
-<Section title="Native <span class='text-primary'>Mobile Apps</span>" description="Native Android and iOS apps in development for shop floor reliability beyond what a browser can deliver.">
+<Section title="Native <span class='text-primary'>Mobile Apps</span>" description="Native Android and iOS apps coming soon — built for shop floor reliability beyond what a browser can deliver.">
 <Grid columns={2}>
   <Card title="Android — Native, Offline-Capable" icon="seti:mobile" iconColor="#34d399">
     Built natively (not a wrapped web view) for **fast cold start** and **offline support** so operators can keep logging time and pulling work even when shop Wi-Fi drops.
@@ -182,7 +182,7 @@ import ThemeDemo from "~/components/ThemeDemo.astro";
     - Fast app open — operators won't wait between scans
     - Camera for issue photos and barcode scanning
 
-    <span class="inline-flex items-center rounded-full bg-emerald-500/10 px-3 py-1 mt-4 text-sm font-medium text-emerald-400 ring-1 ring-inset ring-emerald-500/20">In Development</span>
+    <span class="inline-flex items-center rounded-full bg-emerald-500/10 px-3 py-1 mt-4 text-sm font-medium text-emerald-400 ring-1 ring-inset ring-emerald-500/20">Coming Soon</span>
   </Card>
   <Card title="iOS — iPhone & iPad" icon="seti:mobile" iconColor="#a78bfa">
     Native iOS app for managers, supervisors, and operators on Apple devices. Same real-time data as the web app, optimized for touch.
@@ -192,13 +192,13 @@ import ThemeDemo from "~/components/ThemeDemo.astro";
     - Push notifications for issues and approvals
     - Camera capture for NCRs
 
-    <span class="inline-flex items-center rounded-full bg-sky-500/10 px-3 py-1 mt-4 text-sm font-medium text-sky-400 ring-1 ring-inset ring-sky-500/20">In Development</span>
+    <span class="inline-flex items-center rounded-full bg-sky-500/10 px-3 py-1 mt-4 text-sm font-medium text-sky-400 ring-1 ring-inset ring-sky-500/20">Coming Soon</span>
   </Card>
 </Grid>
 
 <div class="text-center mt-8">
   <p class="text-sm" style="color: color-mix(in srgb, var(--sl-color-white) 60%, transparent);">
-    Today, the responsive web app at <a href="https://app.eryxon.eu" class="text-primary hover:underline">app.eryxon.eu</a> works on every browser-capable device. Native apps will land alongside the web app, sharing the same backend and API.
+    Today, the Beta web app at <a href="https://app.eryxon.eu" class="text-primary hover:underline">app.eryxon.eu</a> works on every browser-capable device. Native apps will land alongside the web app, sharing the same backend and API.
   </p>
 </div>
 </Section>

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -1,11 +1,11 @@
 ---
 title: Eryxon Flow - MES for Job Shops
-description: Manufacturing Execution System for Job Shops. Self-hostable, API-first, with native browser, Android, and iOS apps for the shop floor.
+description: Manufacturing Execution System for Job Shops. Self-hostable, API-first browser app today, with native Android and iOS apps coming soon.
 template: splash
 hero:
   title: |
     MES for <span class="text-primary">Job Shops</span>
-  tagline: The shop floor app your operators will actually use. Real-time job tracking on browser, native Android, and iOS — built for custom manufacturing.
+  tagline: The shop floor app your operators will actually use. Real-time job tracking in the browser today — native Android and iOS apps coming soon.
   actions:
     - text: Open Hosted Version
       link: https://app.eryxon.eu

--- a/website/src/content/docs/introduction.md
+++ b/website/src/content/docs/introduction.md
@@ -71,7 +71,7 @@ Track who's on-site and what they're working on in real-time. No guessing, no de
 
 ## Integration-First Architecture
 
-**100% API-driven.** Your ERP pushes jobs, parts, and tasks via [REST API](/architecture/connectivity-rest-api). Eryxon sends completion events back via [webhooks](/architecture/connectivity-mqtt). The [MCP server](/guides/mcp-setup) enables AI/automation integration with Claude Desktop and other AI tools.
+**100% API-driven.** Your ERP pushes jobs, parts, and tasks via 24 [REST API](/architecture/connectivity-rest-api) endpoints. Eryxon sends completion events back via [webhooks or MQTT](/architecture/connectivity-mqtt) — both with retry, circuit breaker, and dead-letter logging in v0.5. The [MCP server](/guides/mcp-setup) enables AI/automation integration with Claude Desktop and other AI tools, with stdio for local clients and Streamable HTTP for trusted self-hosted deployments.
 
 ### File handling
 Request a signed upload URL from the API, upload STEP and PDF files directly to Supabase Storage, then reference the file path when creating jobs or parts. Large files (5-50MB typical) upload directly to storage—no timeouts, no API bottlenecks.
@@ -79,8 +79,8 @@ Request a signed upload URL from the API, upload STEP and PDF files directly to 
 ### Custom metadata
 Include JSON payloads on jobs, parts, and tasks for your specific needs—tooling requirements, mold numbers, machine settings, material specifications, anything your shop needs to track.
 
-### ERP Integrations
-Partners like **Sheet Metal Connect e.U.** build integrations for common ERP systems. Or build your own using our GitHub starter kits with example code and documentation.
+### ERP & Planning Integrations
+Partners like **Sheet Metal Connect e.U.** build integrations for common ERP systems. Or build your own using our GitHub starter kits with example code and documentation. v0.5 also ships pluggable planning adapters for **FrePPLe** (production-ready) and **Odoo MRP** (scaffold) — see the [scheduling feature page](/features/scheduling/) for details.
 
 ### Assembly Tracking
 Parts can have parent-child relationships. Visual grouping shows assemblies with nested components. Non-blocking dependency warnings remind operators when child parts should be complete before starting assembly tasks—but they can override if needed.

--- a/website/src/content/docs/introduction.md
+++ b/website/src/content/docs/introduction.md
@@ -5,7 +5,9 @@ description: Manufacturing execution system for metals fabrication shops.
 
 **Manufacturing execution system for metals fabrication shops.**
 
-> **Try it now:** Open the [hosted version at app.eryxon.eu](https://app.eryxon.eu) - no installation required. It remains online as-is.
+> **Status:** Most of Eryxon Flow is in **Beta** — including the web app, REST API, webhooks, MQTT, and the FrePPLe and Odoo planning adapters. The **MCP server is Live**. Native **Android** and **iOS** apps are coming soon.
+
+> **Try it now:** Open the [hosted version at app.eryxon.eu](https://app.eryxon.eu) — no installation required.
 
 ![Eryxon Flow admin dashboard](../../assets/step-1.png)
 
@@ -80,7 +82,7 @@ Request a signed upload URL from the API, upload STEP and PDF files directly to 
 Include JSON payloads on jobs, parts, and tasks for your specific needs—tooling requirements, mold numbers, machine settings, material specifications, anything your shop needs to track.
 
 ### ERP & Planning Integrations
-Partners like **Sheet Metal Connect e.U.** build integrations for common ERP systems. Or build your own using our GitHub starter kits with example code and documentation. v0.5 also ships pluggable planning adapters for **FrePPLe** (production-ready) and **Odoo MRP** (scaffold) — see the [scheduling feature page](/features/scheduling/) for details.
+Partners like **Sheet Metal Connect e.U.** build integrations for common ERP systems. Or build your own using our GitHub starter kits with example code and documentation. v0.5 also ships pluggable **Beta** planning adapters for **FrePPLe** and **Odoo MRP** — see the [scheduling feature page](/features/scheduling/) for status details.
 
 ### Assembly Tracking
 Parts can have parent-child relationships. Visual grouping shows assemblies with nested components. Non-blocking dependency warnings remind operators when child parts should be complete before starting assembly tasks—but they can override if needed.

--- a/website/src/content/docs/introduction.md
+++ b/website/src/content/docs/introduction.md
@@ -73,7 +73,7 @@ Track who's on-site and what they're working on in real-time. No guessing, no de
 
 ## Integration-First Architecture
 
-**100% API-driven.** Your ERP pushes jobs, parts, and tasks via 24 [REST API](/architecture/connectivity-rest-api) endpoints. Eryxon sends completion events back via [webhooks or MQTT](/architecture/connectivity-mqtt) — both with retry, circuit breaker, and dead-letter logging in v0.5. The [MCP server](/guides/mcp-setup) enables AI/automation integration with Claude Desktop and other AI tools, with stdio for local clients and Streamable HTTP for trusted self-hosted deployments.
+**100% API-driven.** Your ERP pushes jobs, parts, and tasks via 24 [REST API](/architecture/connectivity-rest-api) endpoints (Beta). Eryxon sends completion events back via [webhooks (Beta) or MQTT (Beta)](/architecture/connectivity-mqtt) — the MQTT client adds retry, circuit breaker, and dead-letter logging in v0.5. The [MCP server](/guides/mcp-setup) (Live) enables AI/automation integration with Claude Desktop and other AI tools, with stdio for local clients and Streamable HTTP for trusted self-hosted deployments.
 
 ### File handling
 Request a signed upload URL from the API, upload STEP and PDF files directly to Supabase Storage, then reference the file path when creating jobs or parts. Large files (5-50MB typical) upload directly to storage—no timeouts, no API bottlenecks.

--- a/website/src/content/docs/nl/index.mdx
+++ b/website/src/content/docs/nl/index.mdx
@@ -1,11 +1,11 @@
 ---
 title: Eryxon Flow - MES voor Job Shops
-description: Manufacturing Execution System voor Job Shops. Self-hostable, API-first, en gebouwd voor de werkvloer.
+description: Manufacturing Execution System voor Job Shops. Self-hostable, API-first, met native browser-, Android- en iOS-app voor de werkvloer.
 template: splash
 hero:
   title: |
     MES voor <span class="text-primary">Job Shops</span>
-  tagline: De werkvloer-app die je operators echt gebruiken. Real-time taaktracking, tablet-vriendelijke terminals en ERP-integratie voor maatwerkproductie.
+  tagline: De werkvloer-app die je operators echt gebruiken. Real-time taaktracking in de browser, native Android- en iOS-app — gebouwd voor maatwerkproductie.
   actions:
     - text: Open Hosted Versie
       link: https://app.eryxon.eu
@@ -26,16 +26,46 @@ import LinkButton from "~/components/LinkButton.astro";
 import ListCard from "~/components/user-components/ListCard.astro";
 import ThemeDemo from "~/components/ThemeDemo.astro";
 
-<Section title="Huidige <span class='text-primary'>Status</span>" description="v0.5.1 is de huidige onderhoudshotfix.">
+<div class="flex flex-wrap items-center justify-center gap-3 -mt-8 mb-4">
+  <span class="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary ring-1 ring-inset ring-primary/20">
+    <span class="inline-block h-2 w-2 rounded-full bg-primary animate-pulse"></span>
+    Native in de Browser
+  </span>
+  <span class="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-3 py-1 text-sm font-medium text-emerald-400 ring-1 ring-inset ring-emerald-500/20">
+    Android (Native) — Binnenkort
+  </span>
+  <span class="inline-flex items-center gap-2 rounded-full bg-sky-500/10 px-3 py-1 text-sm font-medium text-sky-400 ring-1 ring-inset ring-sky-500/20">
+    iOS — Binnenkort
+  </span>
+</div>
+
+<Section title="Eén Platform, <span class='text-primary'>Elk Scherm</span>" description="Van het kantoortablet tot het werkvloer-terminal — Eryxon Flow draait native daar waar uw team werkt.">
+<Grid columns={4}>
+  <Card title="Web App" icon="seti:globe" iconColor="#38bdf8" size="sm">
+    **Vandaag live.** Tablet-vriendelijke responsive web-app. Geen installatie — open de browser. Real-time updates via WebSockets.
+  </Card>
+  <Card title="Android (Native)" icon="seti:mobile" iconColor="#34d399" size="sm">
+    **In ontwikkeling.** Gebouwd voor werkvloer-betrouwbaarheid met **offline-ondersteuning** en **snel opstarten**. Voor robuuste tablets en telefoons.
+  </Card>
+  <Card title="iOS" icon="seti:mobile" iconColor="#a78bfa" size="sm">
+    **In ontwikkeling.** Native iPhone- en iPad-app voor managers en operators op Apple-apparaten.
+  </Card>
+  <Card title="REST · MCP · MQTT" icon="seti:json" iconColor="#fb923c" size="sm">
+    **Vandaag live.** 24 REST-endpoints, MCP-server, MQTT en webhooks. Bouw je eigen clients en integraties.
+  </Card>
+</Grid>
+</Section>
+
+<Section title="Huidige <span class='text-primary'>Status</span>" description="v0.5.x is de stabiele lijn. Native mobile apps zijn de volgende stap.">
 <Grid columns={3}>
   <Card title="Stabiele Release" icon="seti:tag" iconColor="#38bdf8">
-    v0.5.1 is op 6 mei 2026 gepubliceerd als huidige onderhoudshotfix. v0.5.0 blijft de laatste release met actieve ontwikkeling.
+    **v0.5.1** is de huidige stabiele release, gepubliceerd op 6 mei 2026. v0.5.0 introduceerde planning-adapters, MCP-HTTP-transport en MQTT-versterking.
   </Card>
   <Card title="Hosted Versie" icon="seti:globe" iconColor="#34d399">
-    De hosted versie blijft online zoals hij nu is. Nieuwe productie-installaties kunnen het beste self-hosting of een onderhouden fork gebruiken.
+    De hosted versie op [app.eryxon.eu](https://app.eryxon.eu) is online en gratis te proberen. Self-hosting is volledig gedocumenteerd voor productie-deployments.
   </Card>
-  <Card title="Ontwikkeling Stil" icon="seti:lock" iconColor="#fb923c">
-    Actieve ontwikkeling staat momenteel stil. U bent vrij om Eryxon Flow te gebruiken, forken en aanpassen onder de BSL 1.1 licentievoorwaarden.
+  <Card title="Native Apps Komen" icon="seti:mobile" iconColor="#fb923c">
+    Native **Android**-app (met offline-ondersteuning en snel opstarten) en **iOS**-app zijn in ontwikkeling. De web-app blijft vandaag het primaire oppervlak.
   </Card>
 </Grid>
 </Section>
@@ -143,13 +173,44 @@ import ThemeDemo from "~/components/ThemeDemo.astro";
 />
 </Section>
 
+<Section title="Native <span class='text-primary'>Mobile Apps</span>" description="Native Android- en iOS-apps in ontwikkeling — voor werkvloer-betrouwbaarheid die een browser alleen niet kan leveren.">
+<Grid columns={2}>
+  <Card title="Android — Native, Offline" icon="seti:mobile" iconColor="#34d399">
+    Native gebouwd (geen web-wrapper) voor **snel opstarten** en **offline-ondersteuning**, zodat operators kunnen blijven tijd schrijven en werk oppakken ook als de werkvloer-WiFi uitvalt.
+
+    - Native UI voor robuuste tablets en telefoons
+    - Offline-wachtrij voor tijdregistraties en statuswijzigingen, synchroniseert bij herverbinding
+    - Snel openen — operators wachten niet tussen scans
+    - Camera voor probleemfoto's en barcode scannen
+
+    <span class="inline-flex items-center rounded-full bg-emerald-500/10 px-3 py-1 mt-4 text-sm font-medium text-emerald-400 ring-1 ring-inset ring-emerald-500/20">In Ontwikkeling</span>
+  </Card>
+  <Card title="iOS — iPhone & iPad" icon="seti:mobile" iconColor="#a78bfa">
+    Native iOS-app voor managers, leidinggevenden en operators op Apple-apparaten. Dezelfde real-time data als de web-app, geoptimaliseerd voor touch.
+
+    - Native iPad- en iPhone-layouts
+    - Real-time orderstatus en operator-activiteit
+    - Push-notificaties voor problemen en goedkeuringen
+    - Camera-opnames voor NCR's
+
+    <span class="inline-flex items-center rounded-full bg-sky-500/10 px-3 py-1 mt-4 text-sm font-medium text-sky-400 ring-1 ring-inset ring-sky-500/20">In Ontwikkeling</span>
+  </Card>
+</Grid>
+
+<div class="text-center mt-8">
+  <p class="text-sm" style="color: color-mix(in srgb, var(--sl-color-white) 60%, transparent);">
+    Vandaag werkt de responsive web-app op <a href="https://app.eryxon.eu" class="text-primary hover:underline">app.eryxon.eu</a> op elk apparaat met een browser. Native apps verschijnen naast de web-app — zelfde backend, zelfde API.
+  </p>
+</div>
+</Section>
+
 <Section title="Waarom <span class='text-primary'>Eryxon Flow?</span>">
 <Grid columns={2}>
 <Card title="Voor Job Shops" icon="seti:home" iconColor="#38bdf8">
   High mix, low volume. Beheert u duizenden unieke onderdelen? Daarvoor hebben we Eryxon gebouwd.
 </Card>
 <Card title="Ontwikkelaar Vriendelijk" icon="seti:code" iconColor="#34d399">
-  API-first met 22 REST-endpoints, webhooks, MQTT en MCP-server. Bouw integraties op uw manier.
+  API-first met 24 REST-endpoints, webhooks, MQTT, MCP-server en pluggable planning-adapters (FrePPLe, Odoo). Bouw integraties op uw manier.
 </Card>
 </Grid>
 

--- a/website/src/content/docs/nl/index.mdx
+++ b/website/src/content/docs/nl/index.mdx
@@ -27,9 +27,9 @@ import ListCard from "~/components/user-components/ListCard.astro";
 import ThemeDemo from "~/components/ThemeDemo.astro";
 
 <div class="flex flex-wrap items-center justify-center gap-3 -mt-8 mb-4">
-  <span class="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary ring-1 ring-inset ring-primary/20">
-    <span class="inline-block h-2 w-2 rounded-full bg-primary animate-pulse"></span>
-    Native in de Browser
+  <span class="inline-flex items-center gap-2 rounded-full bg-amber-500/10 px-3 py-1 text-sm font-medium text-amber-400 ring-1 ring-inset ring-amber-500/20">
+    <span class="inline-block h-2 w-2 rounded-full bg-amber-400 animate-pulse"></span>
+    Web App — Beta
   </span>
   <span class="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-3 py-1 text-sm font-medium text-emerald-400 ring-1 ring-inset ring-emerald-500/20">
     Android (Native) — Binnenkort
@@ -39,33 +39,33 @@ import ThemeDemo from "~/components/ThemeDemo.astro";
   </span>
 </div>
 
-<Section title="Eén Platform, <span class='text-primary'>Elk Scherm</span>" description="Van het kantoortablet tot het werkvloer-terminal — Eryxon Flow draait native daar waar uw team werkt.">
+<Section title="Eén Platform, <span class='text-primary'>Elk Scherm</span>" description="Van het kantoortablet tot het werkvloer-terminal — Eryxon Flow draait native daar waar uw team werkt. De meeste onderdelen zijn vandaag Beta; de MCP-server is het eerste oppervlak dat die status heeft verlaten.">
 <Grid columns={4}>
-  <Card title="Web App" icon="seti:globe" iconColor="#38bdf8" size="sm">
-    **Vandaag live.** Tablet-vriendelijke responsive web-app. Geen installatie — open de browser. Real-time updates via WebSockets.
+  <Card title="Web App" icon="seti:globe" iconColor="#fbbf24" size="sm">
+    **Beta.** Tablet-vriendelijke responsive web-app. Geen installatie — open de browser. Real-time updates via WebSockets. Hosted versie gratis te proberen.
   </Card>
   <Card title="Android (Native)" icon="seti:mobile" iconColor="#34d399" size="sm">
-    **In ontwikkeling.** Gebouwd voor werkvloer-betrouwbaarheid met **offline-ondersteuning** en **snel opstarten**. Voor robuuste tablets en telefoons.
+    **Binnenkort.** Native Android-app met **offline-ondersteuning** en **snel opstarten**. Voor robuuste tablets en telefoons op de werkvloer.
   </Card>
   <Card title="iOS" icon="seti:mobile" iconColor="#a78bfa" size="sm">
-    **In ontwikkeling.** Native iPhone- en iPad-app voor managers en operators op Apple-apparaten.
+    **Binnenkort.** Native iPhone- en iPad-app voor managers en operators op Apple-apparaten.
   </Card>
-  <Card title="REST · MCP · MQTT" icon="seti:json" iconColor="#fb923c" size="sm">
-    **Vandaag live.** 24 REST-endpoints, MCP-server, MQTT en webhooks. Bouw je eigen clients en integraties.
+  <Card title="MCP · REST · MQTT" icon="seti:json" iconColor="#fb923c" size="sm">
+    **MCP-server: Live.** REST-API, webhooks en MQTT zijn in **Beta** samen met de web-app. Vandaag 24 REST-endpoints.
   </Card>
 </Grid>
 </Section>
 
-<Section title="Huidige <span class='text-primary'>Status</span>" description="v0.5.x is de stabiele lijn. Native mobile apps zijn de volgende stap.">
+<Section title="Huidige <span class='text-primary'>Status</span>" description="v0.5.x is de stabiele lijn. De meeste oppervlakken zijn Beta — MCP is live, native mobile apps zijn de volgende stap.">
 <Grid columns={3}>
   <Card title="Stabiele Release" icon="seti:tag" iconColor="#38bdf8">
-    **v0.5.1** is de huidige stabiele release, gepubliceerd op 6 mei 2026. v0.5.0 introduceerde planning-adapters, MCP-HTTP-transport en MQTT-versterking.
+    **v0.5.1** is de huidige stabiele release, gepubliceerd op 6 mei 2026. v0.5.0 introduceerde planning-adapters, MCP-HTTP-transport en MQTT-versterking. De app zelf blijft **Beta**.
   </Card>
-  <Card title="Hosted Versie" icon="seti:globe" iconColor="#34d399">
-    De hosted versie op [app.eryxon.eu](https://app.eryxon.eu) is online en gratis te proberen. Self-hosting is volledig gedocumenteerd voor productie-deployments.
+  <Card title="Hosted Versie (Beta)" icon="seti:globe" iconColor="#fbbf24">
+    De hosted versie op [app.eryxon.eu](https://app.eryxon.eu) is online en gratis te proberen. Self-hosting is gedocumenteerd voor productie-deployments — verwacht Beta-niveau scherpe randjes.
   </Card>
-  <Card title="Native Apps Komen" icon="seti:mobile" iconColor="#fb923c">
-    Native **Android**-app (met offline-ondersteuning en snel opstarten) en **iOS**-app zijn in ontwikkeling. De web-app blijft vandaag het primaire oppervlak.
+  <Card title="Native Apps Komen" icon="seti:mobile" iconColor="#34d399">
+    Native **Android**-app (met offline-ondersteuning en snel opstarten) en **iOS**-app komen binnenkort. De web-app blijft vandaag het primaire oppervlak.
   </Card>
 </Grid>
 </Section>
@@ -173,7 +173,7 @@ import ThemeDemo from "~/components/ThemeDemo.astro";
 />
 </Section>
 
-<Section title="Native <span class='text-primary'>Mobile Apps</span>" description="Native Android- en iOS-apps in ontwikkeling — voor werkvloer-betrouwbaarheid die een browser alleen niet kan leveren.">
+<Section title="Native <span class='text-primary'>Mobile Apps</span>" description="Native Android- en iOS-apps komen binnenkort — voor werkvloer-betrouwbaarheid die een browser alleen niet kan leveren.">
 <Grid columns={2}>
   <Card title="Android — Native, Offline" icon="seti:mobile" iconColor="#34d399">
     Native gebouwd (geen web-wrapper) voor **snel opstarten** en **offline-ondersteuning**, zodat operators kunnen blijven tijd schrijven en werk oppakken ook als de werkvloer-WiFi uitvalt.
@@ -183,7 +183,7 @@ import ThemeDemo from "~/components/ThemeDemo.astro";
     - Snel openen — operators wachten niet tussen scans
     - Camera voor probleemfoto's en barcode scannen
 
-    <span class="inline-flex items-center rounded-full bg-emerald-500/10 px-3 py-1 mt-4 text-sm font-medium text-emerald-400 ring-1 ring-inset ring-emerald-500/20">In Ontwikkeling</span>
+    <span class="inline-flex items-center rounded-full bg-emerald-500/10 px-3 py-1 mt-4 text-sm font-medium text-emerald-400 ring-1 ring-inset ring-emerald-500/20">Binnenkort</span>
   </Card>
   <Card title="iOS — iPhone & iPad" icon="seti:mobile" iconColor="#a78bfa">
     Native iOS-app voor managers, leidinggevenden en operators op Apple-apparaten. Dezelfde real-time data als de web-app, geoptimaliseerd voor touch.
@@ -193,13 +193,13 @@ import ThemeDemo from "~/components/ThemeDemo.astro";
     - Push-notificaties voor problemen en goedkeuringen
     - Camera-opnames voor NCR's
 
-    <span class="inline-flex items-center rounded-full bg-sky-500/10 px-3 py-1 mt-4 text-sm font-medium text-sky-400 ring-1 ring-inset ring-sky-500/20">In Ontwikkeling</span>
+    <span class="inline-flex items-center rounded-full bg-sky-500/10 px-3 py-1 mt-4 text-sm font-medium text-sky-400 ring-1 ring-inset ring-sky-500/20">Binnenkort</span>
   </Card>
 </Grid>
 
 <div class="text-center mt-8">
   <p class="text-sm" style="color: color-mix(in srgb, var(--sl-color-white) 60%, transparent);">
-    Vandaag werkt de responsive web-app op <a href="https://app.eryxon.eu" class="text-primary hover:underline">app.eryxon.eu</a> op elk apparaat met een browser. Native apps verschijnen naast de web-app — zelfde backend, zelfde API.
+    Vandaag werkt de Beta web-app op <a href="https://app.eryxon.eu" class="text-primary hover:underline">app.eryxon.eu</a> op elk apparaat met een browser. Native apps verschijnen naast de web-app — zelfde backend, zelfde API.
   </p>
 </div>
 </Section>

--- a/website/src/content/docs/nl/index.mdx
+++ b/website/src/content/docs/nl/index.mdx
@@ -1,11 +1,11 @@
 ---
 title: Eryxon Flow - MES voor Job Shops
-description: Manufacturing Execution System voor Job Shops. Self-hostable, API-first, met native browser-, Android- en iOS-app voor de werkvloer.
+description: Manufacturing Execution System voor Job Shops. Self-hostable, API-first browser-app vandaag — native Android- en iOS-apps binnenkort.
 template: splash
 hero:
   title: |
     MES voor <span class="text-primary">Job Shops</span>
-  tagline: De werkvloer-app die je operators echt gebruiken. Real-time taaktracking in de browser, native Android- en iOS-app — gebouwd voor maatwerkproductie.
+  tagline: De werkvloer-app die je operators echt gebruiken. Vandaag real-time taaktracking in de browser — native Android- en iOS-apps binnenkort.
   actions:
     - text: Open Hosted Versie
       link: https://app.eryxon.eu
@@ -176,7 +176,7 @@ import ThemeDemo from "~/components/ThemeDemo.astro";
 <Section title="Native <span class='text-primary'>Mobile Apps</span>" description="Native Android- en iOS-apps komen binnenkort — voor werkvloer-betrouwbaarheid die een browser alleen niet kan leveren.">
 <Grid columns={2}>
   <Card title="Android — Native, Offline" icon="seti:mobile" iconColor="#34d399">
-    Native gebouwd (geen web-wrapper) voor **snel opstarten** en **offline-ondersteuning**, zodat operators kunnen blijven tijd schrijven en werk oppakken ook als de werkvloer-WiFi uitvalt.
+    Native gebouwd (geen web-wrapper) voor **snel opstarten** en **offline-ondersteuning**, zodat operators tijd kunnen blijven registreren en werk oppakken — ook als de werkvloer-WiFi uitvalt.
 
     - Native UI voor robuuste tablets en telefoons
     - Offline-wachtrij voor tijdregistraties en statuswijzigingen, synchroniseert bij herverbinding

--- a/website/src/content/docs/nl/introduction.md
+++ b/website/src/content/docs/nl/introduction.md
@@ -67,7 +67,7 @@ Volg in realtime wie er aanwezig is en waaraan zij werken. Geen gegis, geen vert
 
 ## Integratie-Eerste Architectuur
 
-**100% API-gedreven.** Uw ERP stuurt orders, onderdelen en taken via 24 REST-API-endpoints. Eryxon stuurt voltooiingsgebeurtenissen terug via webhooks of MQTT — beide in v0.5 versterkt met retry, circuit breaker en dead-letter logging. De MCP-server maakt AI/automatisering-integratie mogelijk met stdio voor lokale clients en Streamable HTTP voor vertrouwde zelfgehoste deployments.
+**100% API-gedreven.** Uw ERP stuurt orders, onderdelen en taken via 24 REST-API-endpoints (Beta). Eryxon stuurt voltooiingsgebeurtenissen terug via webhooks (Beta) of MQTT (Beta) — de MQTT-client krijgt in v0.5 retry, circuit breaker en dead-letter logging. De MCP-server (Live) maakt AI/automatisering-integratie mogelijk met stdio voor lokale clients en Streamable HTTP voor vertrouwde zelfgehoste deployments.
 
 ### Bestandsafhandeling
 Vraag een ondertekende upload-URL aan via de API, upload STEP- en PDF-bestanden rechtstreeks naar Supabase Storage en verwijs vervolgens naar het bestandspad bij het maken van orders of onderdelen. Grote bestanden (typisch 5-50MB) worden rechtstreeks naar de storage geüpload—geen timeouts, geen API-knelpunten.

--- a/website/src/content/docs/nl/introduction.md
+++ b/website/src/content/docs/nl/introduction.md
@@ -5,6 +5,10 @@ description: Het eenvoudige, elegante en krachtige manufacturing execution syste
 
 **Het eenvoudige, elegante en krachtige manufacturing execution system waar uw mensen graag mee zullen werken. Gemaakt voor de metaalbewerking.**
 
+> **Status:** Het grootste deel van Eryxon Flow is in **Beta** — web-app, REST-API, webhooks, MQTT en de planning-adapters voor FrePPLe en Odoo. De **MCP-server is Live**. Native **Android**- en **iOS**-apps komen binnenkort.
+
+> **Probeer het nu:** Open de [hosted versie op app.eryxon.eu](https://app.eryxon.eu) — geen installatie vereist.
+
 ## Wat Het Doet
 
 Eryxon volgt orders, onderdelen en taken door de productie met een mobiele en tablet-vriendelijke interface. Gegevens komen via een API uit uw ERP.
@@ -72,7 +76,7 @@ Vraag een ondertekende upload-URL aan via de API, upload STEP- en PDF-bestanden 
 Voeg JSON-payloads toe aan orders, onderdelen en taken voor uw specifieke behoeften—gereedschapsvereisten, malnummers, machine-instellingen, materiaalspecificaties, alles wat uw werkplaats moet bijhouden.
 
 ### ERP- & Planning-Integraties
-Partners zoals **Sheet Metal Connect e.U.** bouwen integraties voor gangbare ERP-systemen. Of bouw uw eigen integratie met onze GitHub starter kits met voorbeeldcode en documentatie. v0.5 levert ook pluggable planning-adapters voor **FrePPLe** (productiegereed) en **Odoo MRP** (scaffold).
+Partners zoals **Sheet Metal Connect e.U.** bouwen integraties voor gangbare ERP-systemen. Of bouw uw eigen integratie met onze GitHub starter kits met voorbeeldcode en documentatie. v0.5 levert ook pluggable planning-adapters in **Beta**-status voor **FrePPLe** en **Odoo MRP**.
 
 ### Assemblage Volgen
 Onderdelen kunnen ouder-kind relaties hebben. Visuele groepering toont assemblages met geneste componenten. Niet-blokkerende afhankelijkheidswaarschuwingen herinneren operators eraan wanneer onderdelen voltooid moeten zijn voordat assemblage-taken worden gestart—maar ze kunnen dit overschrijven indien nodig.

--- a/website/src/content/docs/nl/introduction.md
+++ b/website/src/content/docs/nl/introduction.md
@@ -63,7 +63,7 @@ Volg in realtime wie er aanwezig is en waaraan zij werken. Geen gegis, geen vert
 
 ## Integratie-Eerste Architectuur
 
-**100% API-gedreven.** Uw ERP stuurt orders, onderdelen en taken via de REST API. Eryxon stuurt voltooiingsgebeurtenissen terug via webhooks. MCP-server maakt AI/automatisering-integratie mogelijk.
+**100% API-gedreven.** Uw ERP stuurt orders, onderdelen en taken via 24 REST-API-endpoints. Eryxon stuurt voltooiingsgebeurtenissen terug via webhooks of MQTT — beide in v0.5 versterkt met retry, circuit breaker en dead-letter logging. De MCP-server maakt AI/automatisering-integratie mogelijk met stdio voor lokale clients en Streamable HTTP voor vertrouwde zelfgehoste deployments.
 
 ### Bestandsafhandeling
 Vraag een ondertekende upload-URL aan via de API, upload STEP- en PDF-bestanden rechtstreeks naar Supabase Storage en verwijs vervolgens naar het bestandspad bij het maken van orders of onderdelen. Grote bestanden (typisch 5-50MB) worden rechtstreeks naar de storage geüpload—geen timeouts, geen API-knelpunten.
@@ -71,8 +71,8 @@ Vraag een ondertekende upload-URL aan via de API, upload STEP- en PDF-bestanden 
 ### Aangepaste metadata
 Voeg JSON-payloads toe aan orders, onderdelen en taken voor uw specifieke behoeften—gereedschapsvereisten, malnummers, machine-instellingen, materiaalspecificaties, alles wat uw werkplaats moet bijhouden.
 
-### ERP-Integraties
-Partners zoals **Sheet Metal Connect e.U.** bouwen integraties voor gangbare ERP-systemen. Of bouw uw eigen integratie met onze GitHub starter kits met voorbeeldcode en documentatie.
+### ERP- & Planning-Integraties
+Partners zoals **Sheet Metal Connect e.U.** bouwen integraties voor gangbare ERP-systemen. Of bouw uw eigen integratie met onze GitHub starter kits met voorbeeldcode en documentatie. v0.5 levert ook pluggable planning-adapters voor **FrePPLe** (productiegereed) en **Odoo MRP** (scaffold).
 
 ### Assemblage Volgen
 Onderdelen kunnen ouder-kind relaties hebben. Visuele groepering toont assemblages met geneste componenten. Niet-blokkerende afhankelijkheidswaarschuwingen herinneren operators eraan wanneer onderdelen voltooid moeten zijn voordat assemblage-taken worden gestart—maar ze kunnen dit overschrijven indien nodig.

--- a/website/src/content/docs/roadmap.md
+++ b/website/src/content/docs/roadmap.md
@@ -3,7 +3,7 @@ title: Roadmap
 description: Feature considerations and future direction for Eryxon Flow
 ---
 
-> **May 2026 status:** v0.5.x is the current stable line and v0.5.1 is the latest hotfix. The web app is in maintenance mode while focus shifts to native mobile apps. This page lists what is in active development and possible future work for forks and maintainers.
+> **May 2026 status:** v0.5.x is the current stable line and v0.5.1 is the latest hotfix. Most surfaces — the web app, REST API, webhooks, MQTT, and the FrePPLe/Odoo planning adapters — are still **Beta**. The **MCP server is Live**. The web app is in maintenance mode while focus shifts to native mobile apps. This page lists what is in active development and possible future work for forks and maintainers.
 
 Track progress and vote on features via [GitHub Issues](https://github.com/SheetMetalConnect/eryxon-flow/issues).
 

--- a/website/src/content/docs/roadmap.md
+++ b/website/src/content/docs/roadmap.md
@@ -3,15 +3,26 @@ title: Roadmap
 description: Feature considerations and future direction for Eryxon Flow
 ---
 
-> **May 2026 status:** Active development is currently on hold after the v0.5.0 final active-development release. v0.5.1 is the current maintenance hotfix. This page lists possible future work for forks, maintainers, or a later restart.
-
-Features we're **considering** - nothing planned, promised, or guaranteed.
+> **May 2026 status:** v0.5.x is the current stable line and v0.5.1 is the latest hotfix. The web app is in maintenance mode while focus shifts to native mobile apps. This page lists what is in active development and possible future work for forks and maintainers.
 
 Track progress and vote on features via [GitHub Issues](https://github.com/SheetMetalConnect/eryxon-flow/issues).
 
 ---
 
+## In Development
+
+| Initiative | Why | Notes |
+|------------|-----|-------|
+| **Android (Native) app** | Shop floor reliability needs offline support and fast cold start that a browser can't deliver. | Built natively (not a wrapped web view). Offline queue for time entries and status changes, sync on reconnect, native camera for issue photos and barcodes. |
+| **iOS app** | Managers, supervisors, and operators on Apple devices need first-class native UX. | Native iPad and iPhone layouts, push notifications, real-time job status. |
+
+Both apps share the same backend and REST/MCP/MQTT API as the web app, so existing integrations carry over.
+
+---
+
 ## Under Consideration
+
+Features we're **considering** - nothing planned, promised, or guaranteed.
 
 | Feature | Why | Issue |
 |---------|-----|-------|


### PR DESCRIPTION
## Summary

- Refresh the docs site for the v0.5 line, with corrected Beta/Live status across the web app, REST API, webhooks, MQTT, MCP server, and the FrePPLe/Odoo planning adapters.
- Announce native Android (offline support, fast cold start) and iOS apps as Coming Soon on the landing pages and roadmap.
- Self-audit pass for accuracy, i18n parity, and review feedback (codex P2 on the MQTT log query, CodeRabbit description-template).

## Changes

**Status framing — Beta vs Live vs Coming Soon (EN/DE/NL):**
- Web app, REST API (24 endpoints), webhooks, MQTT, FrePPLe adapter, Odoo adapter → Beta
- MCP server → Live (only fully-graduated surface)
- Android (native, offline, fast cold start), iOS → Coming Soon
- Hero pill strip, platform 4-card row, Current Status cards, intro page status callout, changelog Current Status, and roadmap May 2026 status all reflect this consistently.

**Landing pages (EN/DE/NL):**
- New SaaS-style platform availability strip below the hero
- New "One Platform, Every Screen" 4-card row (Web · Android · iOS · MCP/REST/MQTT)
- New "Native Mobile Apps" section with Android/iOS feature cards and Coming Soon badges
- Hero tagline and frontmatter description rewritten so Android/iOS aren't implied to exist today

**Feature pages:**
- `features/scheduling.md` — new "Planning Adapters (v0.5)" section with FrePPLe (Beta, 21 tests) and Odoo MRP (Beta, 2 tests) and the `createPlanningAdapter` factory
- `features/erp-integration.md` — new "Planning Adapters" integration option, 22 → 24 endpoints
- `architecture/connectivity-mqtt.md` — new "Reliability (v0.5)" section (retry, per-attempt timeout, circuit breaker, dead-letter logging, injectable transport) with a corrected SQL example using `mqtt_publisher_id` and `success` (codex P2 fix)

**Intro pages (EN/DE/NL):**
- New status callout near the top with Beta/Live/Coming Soon breakdown
- "Integration-First Architecture" rewritten to show inline status tags and to scope retry/circuit-breaker/dead-letter to MQTT only (webhooks have HMAC signatures, no retry hardening)

**Changelog + roadmap:**
- "Development on hold" framing replaced with "web app in maintenance, native apps in development"
- Roadmap gains an "In Development" section for the Android/iOS apps
- Historical v0.5.0/v0.5.1 entries reframed (no longer "final active-development release")

**Localization polish:**
- DE: "gleiches Backend" agreement fix
- NL: smoother phrasing for the offline-support claim

## Checklist

- [x] Astro `npm run build` passes (106 pages built)
- [ ] `npm run test:run` — N/A (docs-only change, no app code touched)
- [ ] New tables have RLS policies — N/A (docs-only)
- [x] New UI text uses i18n keys (EN + NL + DE) — landing/intro/feature copy is mirrored across all three locales
- [ ] Edge functions have `deno.json` with import map — N/A (docs-only)
- [x] Column names verified against actual DB schema — `mqtt_logs.mqtt_publisher_id`, `mqtt_logs.success`, `mqtt_publishers.tenant_id` confirmed against `supabase/migrations/20260121175020_remote_schema.sql:5457`
