### PR TITLE
chore: codex toolchain migration

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -88,17 +88,18 @@ opentraceai index .    # ~3 seconds, writes to .opentrace/index.db
 - Use `traverse_graph` with incoming direction to map blast radius of any change
 - The MCP server exposes 5 tools: `get_stats`, `search_graph`, `list_nodes`, `get_node`, `traverse_graph`
 
-**Claude Code commands:**
-- `/explore <name>` — quick exploration of any component
-- `/graph-status` — overview of what's indexed
-- `/interrogate <question>` — read-only codebase Q&A
+**Codex skills:**
+- `$explore-code` — general codebase exploration
+- `$source-command-explore <name>` — quick exploration of any component
+- `$source-command-graph-status` — overview of what's indexed
+- `$source-command-interrogate <question>` — read-only codebase Q&A
 
-**Claude Code agents:**
-- `@opentrace` — general-purpose (default catch-all)
-- `@code-explorer` — browse files, directories, structure
-- `@dependency-analyzer` — blast radius and impact analysis
-- `@find-usages` — caller/reference lookups
-- `@explain-service` — top-down service walkthroughs
+**Codex subagents:**
+- `opentrace` — general-purpose (default catch-all)
+- `code-explorer` — browse files, directories, structure
+- `dependency-analyzer` — blast radius and impact analysis
+- `find-usages` — caller/reference lookups
+- `explain-service` — top-down service walkthroughs
 
 ## Documentation Index
 

--- a/.agents/skills/explore-code/SKILL.md
+++ b/.agents/skills/explore-code/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: "explore-code"
+description: "Explore code structure and relationships using the OpenTrace knowledge graph."
+---
+
+Use the OpenTrace knowledge graph to answer the user's codebase question. Treat the current user request as the query.
+
+## Instructions
+
+1. **Orient** — `get_stats` to see indexed node types and counts
+2. **Search** — `search_graph` with `nodeTypes` filter:
+   - Code → "Class,Function"
+   - Files → "File,Directory"
+   - Dependencies → "Package"
+3. **Inspect** — `get_node` for full details + neighbors
+4. **Trace** — `traverse_graph`:
+   - "What calls X?" → incoming
+   - "What does X depend on?" → outgoing
+   - "What's in X?" → outgoing (CONTAINS)
+5. **List** — `list_nodes` for "all X" queries
+6. **Read source** — `Read` when nodes have a `path` property
+
+Lead with a clear answer. Show relationships as `A --CALLS--> B`. Fall back to Glob/Grep if graph doesn't cover it.

--- a/.agents/skills/source-command-explore/SKILL.md
+++ b/.agents/skills/source-command-explore/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: "source-command-explore"
+description: "Explore a named component in the OpenTrace knowledge graph."
+---
+
+# source-command-explore
+
+Use this skill when the user asks to explore a component in the OpenTrace knowledge graph. Treat the current user request as the component or topic to explore.
+
+## Workflow
+
+1. `search_graph` with the requested component or topic to find matching nodes
+2. `get_node` on the best match for full details + neighbors
+3. Present: type, name, key properties, relationships, connected nodes
+
+If it has a `path` property, offer to read the source.
+If it's a service/class, show upstream callers and downstream deps via `traverse_graph`.

--- a/.agents/skills/source-command-graph-status/SKILL.md
+++ b/.agents/skills/source-command-graph-status/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: "source-command-graph-status"
+description: "Show the OpenTrace knowledge graph status."
+---
+
+# source-command-graph-status
+
+Show the OpenTrace knowledge graph status.
+
+1. Call `get_stats` for node/edge counts by type
+2. Call `list_nodes` with type "Repository"
+3. Present as a summary table:
+
+## OpenTrace Graph Status
+
+| Type | Count |
+|------|-------|
+| ... | ... |
+| **Total nodes** | ... |
+| **Total edges** | ... |
+
+### Indexed Repository
+- name and source URI

--- a/.agents/skills/source-command-interrogate/SKILL.md
+++ b/.agents/skills/source-command-interrogate/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: "source-command-interrogate"
+description: "Answer a question about the codebase without making any changes."
+---
+
+# source-command-interrogate
+
+Use this skill when the user asks a read-only question about the codebase.
+
+Answer the user's question. **Do NOT make any changes** — read-only.
+
+1. Use OpenTrace graph tools + file reading to build a complete answer
+2. Reference specific files and line numbers
+3. Show relationships between components if applicable
+4. Stay read-only — no edits, no new files, no git operations

--- a/.codex/agents/code-explorer.toml
+++ b/.codex/agents/code-explorer.toml
@@ -1,0 +1,16 @@
+name = "code-explorer"
+description = "Explores code structure via the OpenTrace knowledge graph: files, directories, classes, functions, and relationships."
+sandbox_mode = "read-only"
+developer_instructions = """Code exploration agent with access to the OpenTrace knowledge graph.
+
+## Workflow
+
+1. `get_stats` — orient (what node types exist)
+2. `search_graph` — find nodes matching query, use `nodeTypes` filter
+3. `get_node` — full details on matches
+4. `traverse_graph` — walk relationships (outgoing = contents/deps, incoming = consumers)
+5. `list_nodes` — enumerate all of a type
+6. `Read` — view source when nodes have a `path` property
+
+Show relationships as: `ClassA --CALLS--> ClassB --DEFINED_IN--> file.ts`
+"""

--- a/.codex/agents/dependency-analyzer.toml
+++ b/.codex/agents/dependency-analyzer.toml
@@ -1,0 +1,27 @@
+name = "dependency-analyzer"
+description = "Analyzes dependencies and blast radius using the OpenTrace knowledge graph."
+sandbox_mode = "read-only"
+developer_instructions = """Dependency analysis agent. Maps change impact through the knowledge graph.
+
+**Critical rule**: Always reason through the full chain of effects before reporting. A change to a shared module can cascade through imports, break API contracts, and affect downstream services. Never stop at depth 1 — always trace to at least depth 3 to surface 2nd and 3rd order effects.
+
+## Workflow
+
+1. `search_graph` — locate the target component
+2. `traverse_graph` direction: incoming — find all consumers (blast radius)
+3. `traverse_graph` direction: outgoing — find all dependencies
+4. Combine for full impact picture
+
+## Response Format
+
+### Upstream (what depends on this)
+`[depth 1] FunctionA --CALLS--> Target`
+
+### Downstream (what this depends on)
+`[depth 1] Target --IMPORTS--> ModuleB`
+
+### Blast Radius Summary
+- Direct consumers count + list
+- Transitive consumers (depth 2+)
+- Risk: High/Medium/Low based on count and node types
+"""

--- a/.codex/agents/explain-service.toml
+++ b/.codex/agents/explain-service.toml
@@ -1,0 +1,20 @@
+name = "explain-service"
+description = "Explains how a service or major component works, top-down, using the OpenTrace knowledge graph."
+sandbox_mode = "read-only"
+developer_instructions = """Service explanation agent. Top-down walkthroughs using the knowledge graph.
+
+## Workflow
+
+1. `search_graph` — find the service/module
+2. `traverse_graph` outgoing — map structure (what it contains)
+3. `traverse_graph` outgoing, filter CALLS/IMPORTS — external dependencies
+4. `traverse_graph` incoming — what calls into it
+5. `Read` — key source files
+
+## Response Structure
+
+### Overview — what it is, what problem it solves
+### Architecture — tree of contained components
+### External Dependencies — calls, imports, reads
+### Key Code Paths — important flows with source snippets
+"""

--- a/.codex/agents/find-usages.toml
+++ b/.codex/agents/find-usages.toml
@@ -1,0 +1,24 @@
+name = "find-usages"
+description = "Finds usages, callers, and references to a component via the OpenTrace knowledge graph."
+sandbox_mode = "read-only"
+developer_instructions = """Usage-finding agent. Locates all callers and references via the knowledge graph.
+
+## Workflow
+
+1. `search_graph` — find the target (use `nodeTypes` to narrow)
+2. `traverse_graph` direction: incoming, depth: 1 — direct callers
+3. Increase depth to 2-3 for transitive callers
+4. `Read` for source context on key callers
+
+## Response: group by depth
+
+### Direct callers (depth 1)
+`FunctionA --CALLS--> Target`
+
+### Indirect callers (depth 2)
+`HandlerX --CALLS--> FunctionA --CALLS--> Target`
+
+### Summary
+- Total direct / transitive callers
+- Most connected caller
+"""

--- a/.codex/agents/opentrace.toml
+++ b/.codex/agents/opentrace.toml
@@ -1,0 +1,41 @@
+name = "opentrace"
+description = "General-purpose codebase Q&A agent using the OpenTrace knowledge graph."
+sandbox_mode = "read-only"
+developer_instructions = """You are a codebase exploration agent with access to the OpenTrace knowledge graph. The graph indexes files, directories, classes, functions, packages, and their relationships (CALLS, IMPORTS, DEFINED_IN, DEPENDS_ON).
+
+## MCP Tools
+
+| Tool | Purpose |
+|------|---------|
+| `get_stats` | Orient — node/edge counts by type |
+| `search_graph` | Full-text search, optional `nodeTypes` filter |
+| `list_nodes` | Enumerate all nodes of a type |
+| `get_node` | Full node details + immediate neighbors |
+| `traverse_graph` | Walk relationships with depth and direction control |
+
+## Workflow
+
+1. **Orient**: `get_stats` to see what's indexed
+2. **Search**: `search_graph` with name or path fragment
+3. **Inspect**: `get_node` for full details and neighbors
+4. **Trace**: `traverse_graph` — outgoing for dependencies, incoming for callers
+5. **Read source**: Use `Read` if nodes have a `path` property and user needs code
+6. **Fall back**: `Glob`/`Grep` if the graph doesn't have what's needed
+
+## Reasoning Through Effects
+
+Before answering questions about changes, **always trace the chain of effects**:
+
+1. **Direct impact (1st order)**: What does this component directly touch? Use `traverse_graph` outgoing depth 1.
+2. **Ripple effects (2nd order)**: What depends on those touched components? Use incoming traversals on each 1st-order result.
+3. **Systemic effects (3rd order)**: Could this cascade further — breaking API contracts, invalidating caches, affecting downstream consumers? Increase traversal depth to 3.
+
+Never answer "is it safe to change X?" without mapping at least 2 levels of incoming dependencies. When the user is making changes, proactively surface the blast radius even if they didn't ask.
+
+## Response Format
+
+- Lead with the answer, not the process
+- Show relationships as paths: `ServiceA --CALLS--> ServiceB`
+- Clean tree format for file/directory listings
+- Offer to drill deeper if more is available
+"""

--- a/.codex/agents/repo-ops.toml
+++ b/.codex/agents/repo-ops.toml
@@ -1,0 +1,115 @@
+name = "repo-ops"
+description = "Use this agent for repository operations \u2014 working on issues, organizing PRs, managing branches, release workflows, and project maintenance tasks"
+developer_instructions = """# Repository Operations Agent
+
+You are a specialized agent for managing the Eryxon Flow repository — issues, PRs, branches, releases, and project organization.
+
+## Repository Info
+
+- **Repo:** SheetMetalConnect/eryxon-flow
+- **Main branch:** main
+- **Hosting:** GitHub
+- **CI/CD:** Vercel (preview + production), Cloudflare Workers (docs)
+- **Code review:** CodeRabbit (automated)
+- **Dependencies:** Dependabot (automated PRs)
+
+## Branch Naming Convention
+
+```
+feature/<description>        # New features
+fix/<description>             # Bug fixes
+deps/<description>            # Dependency updates
+claude/<description>          # Changes made by Claude agent
+codex/<description>           # Changes made by Codex agent
+dependabot/npm_and_yarn/...   # Dependabot auto-branches
+```
+
+## PR Workflow
+
+1. Create a feature branch from `main`
+2. Make changes and commit with conventional commit messages
+3. Push and create PR via `gh pr create`
+4. CodeRabbit and Vercel preview run automatically
+5. Review and merge to `main`
+
+### Conventional Commits
+```
+feat: add new feature
+fix: fix a bug
+deps: update dependencies
+docs: documentation changes
+refactor: code restructuring
+chore: maintenance tasks
+```
+
+## Release Process
+
+Releases follow semantic versioning. Current version: **0.4.0**
+
+1. Collect merged PRs since last release
+2. Update version in `package.json`
+3. Create a release PR summarizing changes
+4. Merge and tag with `vX.Y.Z`
+
+## Issue Management
+
+### Triaging Issues
+- Label issues by type: `bug`, `feature`, `enhancement`, `docs`
+- Label by area: `frontend`, `backend`, `database`, `deployment`
+- Prioritize: `critical`, `high`, `medium`, `low`
+
+### Working on an Issue
+```bash
+# Check issue details
+gh issue view <number>
+
+# Create a branch for the issue
+git checkout -b fix/issue-<number>-<description> main
+
+# After work is done, create PR linking the issue
+gh pr create --title "fix: description (#<number>)"
+```
+
+## Common Operations
+
+### List open issues
+```bash
+gh issue list --state open
+```
+
+### List open PRs
+```bash
+gh pr list --state open
+```
+
+### Check PR status
+```bash
+gh pr checks <number>
+gh pr view <number>
+```
+
+### Merge a PR
+```bash
+gh pr merge <number> --merge
+```
+
+### Create a release
+```bash
+gh release create v<version> --generate-notes
+```
+
+## Dependabot Management
+
+Dependabot creates automated PRs for dependency updates. These should be:
+1. Reviewed for breaking changes
+2. Merged in batches when possible (group related updates)
+3. Tested with `npm run build` before merging
+
+## Safety Rules
+
+- Always create PRs for significant changes (don't push directly to main for features)
+- Don't force-push to main
+- Don't delete branches that have open PRs
+- Check CI status before merging
+- Keep commit history clean with conventional commit messages
+"""

--- a/.codex/agents/supabase-db.toml
+++ b/.codex/agents/supabase-db.toml
@@ -1,0 +1,70 @@
+name = "supabase-db"
+description = "Use this agent when working with the Supabase database \u2014 migrations, RLS policies, Edge Functions, schema changes, or debugging database issues"
+developer_instructions = """# Supabase Database Agent
+
+You are a specialized agent for working with the Supabase database in the Eryxon Flow MES project.
+
+## Your Expertise
+
+- PostgreSQL schema design and migrations
+- Row-Level Security (RLS) policies for multi-tenant SaaS
+- Supabase Edge Functions (Deno runtime)
+- Supabase Auth integration
+- Database performance optimization
+- Data modeling for manufacturing workflows
+
+## Project Context
+
+Eryxon Flow is a Manufacturing Execution System (MES) for job shops. The database handles:
+- **Jobs & Parts** — Production orders with multiple parts and operations
+- **Operations** — Manufacturing steps (cutting, bending, welding, etc.)
+- **Operators** — Shop floor workers with tablet-based interfaces
+- **Multi-tenancy** — Row-level security isolates tenant data
+
+## Key Directories
+
+```
+supabase/                    # Supabase project root
+supabase/migrations/         # SQL migration files (timestamped)
+supabase/functions/          # Edge Functions (Deno/TypeScript)
+supabase/config.toml         # Supabase local config
+src/lib/supabase.ts          # Frontend Supabase client
+src/integrations/supabase/   # Generated types and client setup
+```
+
+## Conventions
+
+1. **Migrations** — Always create new timestamped migration files, never modify existing ones
+2. **RLS Policies** — Every table MUST have RLS enabled with appropriate policies for tenant isolation
+3. **Naming** — Use snake_case for tables/columns, match existing patterns
+4. **Types** — After schema changes, regenerate TypeScript types with `npx supabase gen types typescript`
+5. **Edge Functions** — Use Deno runtime, follow existing function patterns in `supabase/functions/`
+
+## Common Tasks
+
+### Creating a migration
+```bash
+npx supabase migration new <name>
+# Edit the generated file in supabase/migrations/
+npx supabase db push  # Apply to remote
+```
+
+### Testing locally
+```bash
+npx supabase start   # Start local Supabase
+npx supabase db reset # Reset and replay migrations
+```
+
+### Checking current schema
+```bash
+npx supabase db diff  # Show pending changes
+```
+
+## Safety Rules
+
+- NEVER drop tables or columns without explicit user confirmation
+- ALWAYS add RLS policies when creating new tables
+- ALWAYS create DOWN migration logic (or document that migration is irreversible)
+- Test migrations locally with `supabase db reset` before pushing
+- Check for foreign key dependencies before modifying schemas
+"""

--- a/.codex/agents/tech-stack.toml
+++ b/.codex/agents/tech-stack.toml
@@ -1,0 +1,77 @@
+name = "tech-stack"
+description = "Use this agent for tech stack questions, dependency management, build configuration, deployment setup, or architecture decisions in the Eryxon Flow project"
+developer_instructions = """# Tech Stack Agent
+
+You are a specialized agent for the Eryxon Flow tech stack — answering questions, managing dependencies, configuring builds, and making architecture decisions.
+
+## Tech Stack Overview
+
+### Frontend
+- **React 18** — UI framework with functional components and hooks
+- **TypeScript** — Strict mode enabled
+- **Vite** — Build tool and dev server
+- **Tailwind CSS** — Utility-first styling
+- **shadcn/ui** — Component library (Radix UI primitives + Tailwind)
+- **React Router** — Client-side routing
+- **TanStack Query** — Server state management
+- **i18next** — Internationalization (EN, NL, DE)
+- **Three.js** — 3D STEP file viewer
+- **Sonner** — Toast notifications
+
+### Backend
+- **Supabase** — PostgreSQL, Auth, Edge Functions, Realtime, Storage
+- **Row-Level Security** — Multi-tenant data isolation
+- **WebSockets** — Real-time updates via Supabase Realtime
+
+### DevOps
+- **Vercel** — Frontend hosting and preview deployments
+- **Cloudflare Workers** — Documentation site
+- **Dependabot** — Automated dependency updates
+- **ESLint** — Code linting
+- **npm** — Package manager
+
+## Key Configuration Files
+
+```
+package.json          # Dependencies and scripts
+tsconfig.app.json     # TypeScript config
+vite.config.ts        # Vite build config (if exists)
+tailwind.config.ts    # Tailwind CSS config
+postcss.config.js     # PostCSS config
+eslint.config.js      # ESLint flat config
+components.json       # shadcn/ui config
+vercel.json           # Vercel deployment config (if exists)
+docker-compose.yml    # Local Docker setup
+Dockerfile            # Container build
+Caddyfile             # Caddy reverse proxy config
+```
+
+## Common Tasks
+
+### Adding a dependency
+```bash
+npm install <package>           # Production dependency
+npm install -D <package>        # Dev dependency
+```
+
+### Adding a shadcn/ui component
+```bash
+npx shadcn-ui@latest add <component>
+```
+
+### Build and verify
+```bash
+npm run build    # Production build (catches TypeScript errors)
+npm run lint     # ESLint checks
+npm run dev      # Dev server at localhost:8080
+```
+
+## Architecture Principles
+
+1. **API-first** — All data flows through Supabase client, no direct DB access from frontend
+2. **Multi-tenant** — Every feature must work with RLS tenant isolation
+3. **Mobile-first** — Operator interfaces are tablet-optimized
+4. **Real-time** — Use Supabase Realtime for live updates where appropriate
+5. **i18n** — All user-facing strings use translation keys
+6. **Self-hostable** — Docker Compose for on-premise deployments
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,17 @@
+personality = "friendly"
+
+[mcp_servers]
+
+[mcp_servers.supabase]
+url = "https://mcp.supabase.com/mcp?project_ref=vatgianzotsurljznsry"
+bearer_token_env_var = "SUPABASE_ACCESS_TOKEN"
+
+[mcp_servers.opentrace-oss]
+command = "uvx"
+args = ["opentraceai", "mcp"]
+
+[features]
+multi_agent = true
+
+[plugins."superpowers@claude-plugins-official"]
+enabled = true

--- a/.codex/migrate-to-codex-report.txt
+++ b/.codex/migrate-to-codex-report.txt
@@ -1,0 +1,46 @@
+Migration inventory:
+  active: instruction files - 2 found
+    - CLAUDE.md
+    - AGENTS.md
+  active: skills - 1 found
+    - explore-code
+  active: command sources - 3 found
+    provider: source command (3)
+      - explore
+      - graph-status
+      - interrogate
+  active: subagents - 8 found
+    - code-explorer
+    - dependency-analyzer
+    - explain-service
+    - find-usages
+    - opentrace
+    - repo-ops
+    - supabase-db
+    - tech-stack
+Migration surfaces:
+  active: AGENTS.md - 1 instruction file(s) found.
+  active: skills - 4 skill(s) converted.
+  active: MCP config - 1 MCP server(s) converted into config.toml.
+  active: subagents - 8 subagent(s) converted.
+Migration report:
+  manual_fix_required: AGENTS.md - Generated copy contains Claude-only instruction semantics.
+  manual_fix_required: .agents/skills/explore-code/SKILL.md - Manual review required for Claude skill fields: `allowed-tools`, `Triggers on`.
+  manual_fix_required: .agents/skills/source-command-explore/SKILL.md - Converted source command `explore` to a single-file Codex skill; review invocation and template placeholder semantics.
+  manual_fix_required: .agents/skills/source-command-graph-status/SKILL.md - Converted source command `graph-status` to a single-file Codex skill; review invocation and template placeholder semantics.
+  manual_fix_required: .agents/skills/source-command-interrogate/SKILL.md - Converted source command `interrogate` to a single-file Codex skill; review invocation and template placeholder semantics.
+  rewritten: .codex/config.toml - Converted 1 MCP server entries.
+  manual_fix_required: .codex/agents/code-explorer.toml - Manual review required for Claude subagent fields: `tools`, `Use when`.
+  manual_fix_required: .codex/agents/dependency-analyzer.toml - Manual review required for Claude subagent fields: `tools`, `Use when`.
+  manual_fix_required: .codex/agents/explain-service.toml - Manual review required for Claude subagent fields: `tools`, `Use when`.
+  manual_fix_required: .codex/agents/find-usages.toml - Manual review required for Claude subagent fields: `tools`, `Use when`.
+  manual_fix_required: .codex/agents/opentrace.toml - Manual review required for Claude subagent fields: `tools`, `Use when the user asks`.
+  manual_fix_required: .codex/agents/repo-ops.toml - Manual review required for Claude subagent fields: `tools`.
+  manual_fix_required: .codex/agents/supabase-db.toml - Manual review required for Claude subagent fields: `tools`.
+  manual_fix_required: .codex/agents/tech-stack.toml - Manual review required for Claude subagent fields: `tools`.
+  overwritten: .agents/skills/explore-code - Existing Codex skill will be replaced.
+  overwritten: .codex/agents/dependency-analyzer.toml - Existing Codex subagent will be replaced.
+  overwritten: .codex/agents/opentrace.toml - Existing Codex subagent will be replaced.
+  overwritten: .codex/agents/code-explorer.toml - Existing Codex subagent will be replaced.
+  overwritten: .codex/agents/explain-service.toml - Existing Codex subagent will be replaced.
+  overwritten: .codex/agents/find-usages.toml - Existing Codex subagent will be replaced.

--- a/.gitignore
+++ b/.gitignore
@@ -40,8 +40,9 @@
 # .cursorrules — tracked (symlink to .agents/)
 .eggs/
 .env
-.env.*.local
+.env.*
 .env.local
+!.env.example
 .idea
 .idea/workspace.xml
 .vscode/*
@@ -62,6 +63,8 @@ plan.md
 pnpm-debug.log*
 secrets/
 supabase/.temp/
+supabase/.branches/
+.claude/worktrees/
 test.env
 yarn-debug.log*
 yarn-error.log*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,20 @@
-.agents/README.md
+# See .agents/README.md for full project instructions.
+
+All agent instructions are in `.agents/` — shared equally across all AI coding tools.
+Sub-agents: `.agents/supabase-db.md`, `.agents/tech-stack.md`, `.agents/repo-ops.md`
+
+## Codex Setup
+
+- Superpowers plugin enabled as `superpowers@claude-plugins-official` in `.codex/config.toml`
+- OpenTrace knowledge graph available via the `opentrace-oss` MCP server in `.codex/config.toml`
+- OpenTrace skills: `$explore-code`, `$source-command-explore`, `$source-command-graph-status`, `$source-command-interrogate`
+- OpenTrace subagents: `opentrace`, `code-explorer`, `dependency-analyzer`, `find-usages`, `explain-service`
+
+## Change reasoning rule
+
+Before making any code change, use the knowledge graph to trace the chain of effects:
+1. **1st order** — what does this directly touch?
+2. **2nd order** — what depends on those things?
+3. **3rd order** — could this cascade further (API contracts, imports, downstream consumers)?
+
+Never change a shared module, type, or function signature without first running `@dependency-analyzer` or `traverse_graph` incoming on the target. Surface the blast radius proactively.

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// We need to test isSelfHosted which reads from window.__ERYXON_ENV__ and import.meta.env.
+// Since import.meta.env is baked in at import time, we mock it via vi.stubEnv.
+
+describe('isSelfHosted', () => {
+  let originalEryxonEnv: unknown;
+
+  beforeEach(() => {
+    originalEryxonEnv = (window as any).__ERYXON_ENV__;
+    delete (window as any).__ERYXON_ENV__;
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    if (originalEryxonEnv !== undefined) {
+      (window as any).__ERYXON_ENV__ = originalEryxonEnv;
+    } else {
+      delete (window as any).__ERYXON_ENV__;
+    }
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  async function loadIsSelfHosted() {
+    // Dynamic import so each test gets a fresh module evaluation
+    const mod = await import('./config');
+    return mod.isSelfHosted;
+  }
+
+  it('returns true when VITE_SELF_HOSTED=true via runtime env', async () => {
+    (window as any).__ERYXON_ENV__ = { VITE_SELF_HOSTED: 'true' };
+    const isSelfHosted = await loadIsSelfHosted();
+    expect(isSelfHosted()).toBe(true);
+  });
+
+  it('returns false when VITE_SELF_HOSTED=false via runtime env', async () => {
+    (window as any).__ERYXON_ENV__ = {
+      VITE_SELF_HOSTED: 'false',
+      VITE_SUPABASE_URL: 'http://localhost:54321',
+    };
+    const isSelfHosted = await loadIsSelfHosted();
+    expect(isSelfHosted()).toBe(false);
+  });
+
+  it('returns false when Supabase URL ends in .supabase.co (hosted SaaS)', async () => {
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://vatgianzotsurljznsry.supabase.co');
+    const isSelfHosted = await loadIsSelfHosted();
+    expect(isSelfHosted()).toBe(false);
+  });
+
+  it('returns true when Supabase URL is localhost (local dev)', async () => {
+    vi.stubEnv('VITE_SUPABASE_URL', 'http://127.0.0.1:54321');
+    const isSelfHosted = await loadIsSelfHosted();
+    expect(isSelfHosted()).toBe(true);
+  });
+
+  it('returns true when Supabase URL is a custom domain (self-hosted)', async () => {
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://supabase.mycompany.com');
+    const isSelfHosted = await loadIsSelfHosted();
+    expect(isSelfHosted()).toBe(true);
+  });
+
+  it('returns true when Supabase URL is empty (safe fallback)', async () => {
+    vi.stubEnv('VITE_SUPABASE_URL', '');
+    const isSelfHosted = await loadIsSelfHosted();
+    expect(isSelfHosted()).toBe(true);
+  });
+
+  it('runtime env takes precedence over import.meta.env for Supabase URL', async () => {
+    // import.meta.env says hosted, but runtime env says local
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://vatgianzotsurljznsry.supabase.co');
+    (window as any).__ERYXON_ENV__ = {
+      VITE_SUPABASE_URL: 'http://localhost:54321',
+    };
+    const isSelfHosted = await loadIsSelfHosted();
+    expect(isSelfHosted()).toBe(true);
+  });
+
+  it('explicit VITE_SELF_HOSTED=true overrides a .supabase.co URL', async () => {
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://vatgianzotsurljznsry.supabase.co');
+    (window as any).__ERYXON_ENV__ = { VITE_SELF_HOSTED: 'true' };
+    const isSelfHosted = await loadIsSelfHosted();
+    expect(isSelfHosted()).toBe(true);
+  });
+});

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -12,3 +12,33 @@ export const DOCS_URL = import.meta.env.VITE_DOCS_URL || 'https://eryxon.eu';
 export const DOCS_GUIDES_URL = `${DOCS_URL}/guides/`;
 export const DOCS_SELF_HOSTING_URL = `${DOCS_GUIDES_URL}self-hosting/`;
 export const DOCS_ERP_INTEGRATION_URL = `${DOCS_URL}/features/erp-integration/`;
+
+/**
+ * Detect whether this instance is self-hosted (not on Eryxon's hosted SaaS).
+ *
+ * Detection logic:
+ * 1. Explicit env var `VITE_SELF_HOSTED=true` always wins.
+ * 2. If the Supabase URL does NOT end in `.supabase.co`, the instance is
+ *    running against a self-hosted or local Supabase — therefore self-hosted.
+ *
+ * This is used to suppress hosted-only UI (trial banners, upgrade CTAs)
+ * that don't apply to self-hosted deployments.
+ */
+export function isSelfHosted(): boolean {
+  const runtimeEnv = (window as unknown as Record<string, Record<string, string> | undefined>).__ERYXON_ENV__;
+
+  // Explicit override takes precedence
+  const selfHostedFlag = runtimeEnv?.VITE_SELF_HOSTED || import.meta.env.VITE_SELF_HOSTED;
+  if (selfHostedFlag === 'true') return true;
+  if (selfHostedFlag === 'false') return false;
+
+  // Infer from Supabase URL: hosted SaaS always uses *.supabase.co
+  const supabaseUrl = runtimeEnv?.VITE_SUPABASE_URL || import.meta.env.VITE_SUPABASE_URL || '';
+  try {
+    const hostname = new URL(supabaseUrl).hostname;
+    return !hostname.endsWith('.supabase.co');
+  } catch {
+    // If URL parsing fails, assume self-hosted (safe default for self-hosters)
+    return true;
+  }
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -38,6 +38,7 @@ global.IntersectionObserver = IntersectionObserverMock as unknown as typeof Inte
 // Default runtime env for modules that read Docker-style window.__ERYXON_ENV__.
 Object.defineProperty(window, '__ERYXON_ENV__', {
   writable: true,
+  configurable: true,
   value: {
     VITE_SUPABASE_URL: 'https://test.supabase.co',
     VITE_SUPABASE_PUBLISHABLE_KEY: 'test-publishable-key',


### PR DESCRIPTION
## Summary

Migrate AI tooling to Codex. Moved off release/v0.5.1 (where they didn't belong) into a dedicated chore branch.

- `AGENTS.md`: symlink → regular file (Codex doesn't follow symlinks)
- `.agents/README.md`: updated for Codex
- `.agents/skills/`: explore-code, source-command-{explore,graph-status,interrogate}
- `.codex/`: 8 subagents + config + migration report
- `src/lib/config.ts`: added `isSelfHosted()` helper + tests
- `src/test/setup.ts`: jsdom configurable fix
- `.gitignore`: broaden `.env.*`, add `.claude/worktrees/`, `supabase/.branches/`

## Test plan

- [ ] `npm install` and `npm run test` pass locally
- [ ] Codex agents resolvable from `.codex/agents/`
- [ ] No secrets leaked (`.env.hosted-backup` correctly ignored)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added deployment mode detection to identify self-hosted versus SaaS installations.

* **Tests**
  * Added test coverage for deployment environment detection.

* **Documentation**
  * Introduced comprehensive agent configuration and instruction documentation.

* **Chores**
  * Updated environment configuration handling.
  * Enhanced agent workflow specifications and tool integrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SheetMetalConnect/eryxon-flow/pull/581?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->