### PR TITLE
[reference] fix(onboarding): hydrate onboarding state and stamp tenant completion (ERY-34)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,11 @@ function AppRoutes() {
     );
   }
 
+  // The wizard is an admin-only first-run flow (team setup, plan, mock data),
+  // so only incomplete admins are routed into it. Operators are never gated.
+  const needsOnboarding =
+    profile?.role === "admin" && profile?.onboarding_completed === false;
+
   return (
     <Routes>
       {/* Auth routes */}
@@ -59,7 +64,7 @@ function AppRoutes() {
         element={
           <Navigate
             to={
-              (profile as { onboarding_completed?: boolean })?.onboarding_completed === false
+              needsOnboarding
                 ? "/onboarding"
                 : profile?.role === "admin"
                   ? "/admin/dashboard"

--- a/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/components/onboarding/OnboardingWizard.tsx
@@ -6,6 +6,7 @@ import { PlanSelection, PlanType } from './PlanSelection';
 import { MockDataImport } from './MockDataImport';
 import { TeamSetup } from './TeamSetup';
 import { useProfile } from '@/hooks/useProfile';
+import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
 import { useSubscription } from '@/hooks/useSubscription';
@@ -19,6 +20,7 @@ type TenantPlan = Exclude<PlanType, 'self_hosted'>;
 export function OnboardingWizard() {
   const navigate = useNavigate();
   const profile = useProfile();
+  const { refreshProfile } = useAuth();
   const { subscription } = useSubscription();
   const { t } = useTranslation();
   const [currentStep, setCurrentStep] = useState(1);
@@ -33,9 +35,7 @@ export function OnboardingWizard() {
   ];
 
   useEffect(() => {
-    // onboarding_step exists in DB profiles table but isn't exposed in the Profile interface
-    const profileWithStep = profile as (typeof profile & { onboarding_step?: number }) | null;
-    const persistedStep = profileWithStep?.onboarding_step;
+    const persistedStep = profile?.onboarding_step;
     if (
       typeof persistedStep === 'number' &&
       Number.isInteger(persistedStep) &&
@@ -116,7 +116,7 @@ export function OnboardingWizard() {
       mock_data_imported: true,
       onboarding_completed: true,
     });
-    completeOnboarding();
+    await completeOnboarding();
   };
 
   const handleMockDataSkip = async () => {
@@ -124,10 +124,28 @@ export function OnboardingWizard() {
       mock_data_imported: false,
       onboarding_completed: true,
     });
-    completeOnboarding();
+    await completeOnboarding();
   };
 
-  const completeOnboarding = () => {
+  const completeOnboarding = async () => {
+    // Stamp tenant-level completion so the tenant record carries a durable
+    // onboarding-finished timestamp (used for analytics / re-onboarding logic),
+    // not just the per-profile boolean.
+    if (profile?.tenant_id) {
+      const { error } = await supabase
+        .from('tenants')
+        .update({ onboarding_completed_at: new Date().toISOString() })
+        .eq('id', profile.tenant_id);
+
+      if (error) {
+        logger.error('OnboardingWizard', 'Error stamping tenant onboarding completion', error);
+      }
+    }
+
+    // Re-hydrate the auth profile so the router no longer gates this admin into
+    // the wizard after we navigate away.
+    await refreshProfile();
+
     toast.success(t('onboarding.onboardingComplete'));
 
     if (profile?.role === 'admin') {

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -352,6 +352,67 @@ describe('AuthContext', () => {
     });
   });
 
+  describe('onboarding state hydration', () => {
+    const buildProfileSource = (profileData: unknown) => ({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          maybeSingle: vi.fn().mockResolvedValue({ data: profileData, error: null }),
+        }),
+      }),
+    });
+
+    it('hydrates onboarding_completed and onboarding_step from the profile row', async () => {
+      mockGetSession.mockResolvedValue({ data: { session: mockSession }, error: null });
+      mockFrom.mockReturnValue(
+        buildProfileSource({ ...mockProfile, onboarding_completed: true, onboarding_step: 3 }),
+      );
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.profile?.onboarding_completed).toBe(true);
+      expect(result.current.profile?.onboarding_step).toBe(3);
+    });
+
+    it('coerces null onboarding fields to deterministic defaults', async () => {
+      mockGetSession.mockResolvedValue({ data: { session: mockSession }, error: null });
+      mockFrom.mockReturnValue(
+        buildProfileSource({ ...mockProfile, onboarding_completed: null, onboarding_step: null }),
+      );
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.profile?.onboarding_completed).toBe(false);
+      expect(result.current.profile?.onboarding_step).toBe(0);
+    });
+
+    it('refreshProfile re-fetches the profile so completion state updates', async () => {
+      mockGetSession.mockResolvedValue({ data: { session: mockSession }, error: null });
+      mockFrom.mockReturnValue(
+        buildProfileSource({ ...mockProfile, onboarding_completed: false, onboarding_step: 4 }),
+      );
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.profile?.onboarding_completed).toBe(false);
+
+      // Simulate the wizard finishing: next read returns completed state.
+      mockFrom.mockReturnValue(
+        buildProfileSource({ ...mockProfile, onboarding_completed: true, onboarding_step: 4 }),
+      );
+
+      await act(async () => {
+        await result.current.refreshProfile();
+      });
+
+      expect(result.current.profile?.onboarding_completed).toBe(true);
+    });
+  });
+
   describe('useAuth hook', () => {
     it('throws error when used outside AuthProvider', () => {
       // Suppress console.error for this test

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -19,6 +19,10 @@ interface Profile {
   active: boolean;
   is_machine: boolean;
   is_root_admin: boolean;
+  // First-run onboarding state. The router (src/App.tsx) and the wizard
+  // (OnboardingWizard) gate on these, so they must be hydrated here.
+  onboarding_completed: boolean;
+  onboarding_step: number;
 }
 
 interface TenantInfo {
@@ -48,6 +52,7 @@ interface AuthContextType {
   signOut: () => Promise<void>;
   switchTenant: (tenantId: string) => Promise<void>;
   refreshTenant: () => Promise<void>;
+  refreshProfile: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -121,7 +126,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     try {
       const { data, error } = await supabase
         .from("profiles")
-        .select("id, tenant_id, username, full_name, email, role, active, is_machine, is_root_admin")
+        .select("id, tenant_id, username, full_name, email, role, active, is_machine, is_root_admin, onboarding_completed, onboarding_step")
         .eq("id", userId)
         .maybeSingle();
 
@@ -133,7 +138,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         return;
       }
 
-      setProfile(data as Profile);
+      // Columns are nullable in the DB (defaults applied on insert); coerce to
+      // concrete values so the router/wizard gates are deterministic.
+      setProfile({
+        ...(data as Profile),
+        onboarding_completed: data.onboarding_completed ?? false,
+        onboarding_step: data.onboarding_step ?? 0,
+      });
       await fetchTenant();
       prefetchCommonData(queryClient, data.tenant_id, {
         fetchCells: () => Promise.resolve(supabase.from('cells').select('*').eq('tenant_id', data.tenant_id).eq('active', true).then(r => r.data)),
@@ -197,6 +208,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const refreshTenant = async () => {
     await fetchTenant();
+  };
+
+  // Re-hydrate the profile after a mutation that changes durable profile state
+  // (e.g. completing onboarding) so router gates reflect the new state without
+  // requiring a full reload.
+  const refreshProfile = async () => {
+    if (user?.id) {
+      await fetchProfile(user.id);
+    }
   };
 
   const signIn = async (email: string, password: string, captchaToken?: string | null) => {
@@ -264,7 +284,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         signUp,
         signOut,
         switchTenant,
-        refreshTenant
+        refreshTenant,
+        refreshProfile
       }}
     >
       {children}


### PR DESCRIPTION
## ERY-34 — Onboarding state hydration & completion tracking (clean restack)

Replaces #594, which carried 24 commits / 176 files of unrelated mobile/docs/tooling work due to a contaminated branch base. This branch is cut fresh from `main` and contains **only** the onboarding fix.

### What changed (4 files, +115/-10)
- **`AuthContext.tsx`** — `fetchProfile` now selects `onboarding_completed` + `onboarding_step`, coerces the nullable columns to `false`/`0`, and exposes `refreshProfile()` for re-hydration.
- **`App.tsx`** — onboarding routing is gated to incomplete **admins only** (`role === "admin" && onboarding_completed === false`); operators are never routed into the admin-only wizard. (Adapted to main's inline `<Route path="/">` ternary — the original commit's `homeTarget`/mobile-shell block does not exist on `main`.)
- **`OnboardingWizard.tsx`** — on complete and skip, stamps `tenants.onboarding_completed_at = now()` and calls `refreshProfile()` before navigating away.
- **`AuthContext.test.tsx`** — +61 lines of coverage for the hydration/coercion behavior.

### Verification
- `tsc --noEmit`: clean.
- `vitest run src/contexts/AuthContext.test.tsx`: 19 passed.

### Note
The fix logic is unchanged from board-approved commit `1d753b0` (approval `dde8da46`), cherry-picked onto a clean base. App.tsx required a small adaptation because `main` uses an inline ternary rather than the mobile-shell `homeTarget` variable.

Closes #594 once this is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
