### PR TITLE
[reference] ci(drill): scope seed-drill assertion to real ErrorResponse (ERY-107)

### DIFF
--- a/.github/workflows/seed-provisioning-drill.yml
+++ b/.github/workflows/seed-provisioning-drill.yml
@@ -60,18 +60,25 @@ jobs:
         run: |
           set -euo pipefail
           log=artifacts/db-reset.log
-          echo "Scanning $log for 42501 / insufficient_privilege / ownership failures..."
-          # These are the exact ERY-47 failure signatures the b2ba76a fix targets.
-          if grep -nE "42501|insufficient_privilege|must be owner of (table|relation) objects" "$log"; then
-            echo "::error::Seed phase still hit a storage-policy privilege/ownership failure"
+          echo "Scanning $log for real 42501 / ownership ErrorResponse messages..."
+          # IMPORTANT: --debug echoes the seed SQL itself (which now literally contains
+          # the strings "42501" and "insufficient_privilege" in the b2ba76a fix's comment
+          # and EXCEPTION clauses), so a naive grep over the whole log false-matches the
+          # query being SENT. The only signal that matters is a server ERROR RESPONSE.
+          # Match Postgres ErrorResponse lines (severity ERROR) carrying the ERY-47
+          # signature: SQLSTATE 42501 or "must be owner of ... objects".
+          if grep -E '"Type":"ErrorResponse"' "$log" \
+               | grep -E '"Severity":"ERROR"' \
+               | grep -E '"Code":"42501"|must be owner of (table|relation) objects'; then
+            echo "::error::Seed phase still hit a storage-policy privilege/ownership ERROR response"
             exit 1
           fi
           # Reset must have actually run the seed; guard against a silently skipped seed.
-          if ! grep -qiE "seed|Seeding|Applying migration|Finished supabase db reset" "$log"; then
+          if ! grep -qiE "Seeding|Applying migration|Finished supabase db reset" "$log"; then
             echo "::error::db reset log does not show a migration/seed phase — drill inconclusive"
             exit 1
           fi
-          echo "PASS: seed phase completed with no 42501 / insufficient_privilege / ownership failure."
+          echo "PASS: seed phase completed with no 42501 / ownership ERROR response."
 
       - name: Upload drill artifacts
         if: always()


### PR DESCRIPTION
Fixes the seed-provisioning-drill assertion that false-matched the echoed `--debug` seed SQL (which now literally contains the strings `42501`/`insufficient_privilege` from the b2ba76a fix). Scopes the check to Postgres `ErrorResponse` (severity ERROR) lines carrying SQLSTATE `42501` or "must be owner of objects".

Verified green on the validation branch: run 26370856436.

ERY-107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal testing workflow validation logic for database provisioning checks with improved error detection accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SheetMetalConnect/eryxon-flow/pull/601?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->