### PR TITLE
chore: finish Apache 2.0 sweep lockfile metadata

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "eryxon-flow-mcp-server",
       "version": "2.4.0",
-      "license": "BSL-1.1",
+      "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",
         "@supabase/supabase-js": "^2.100.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "eryxon-flow",
       "version": "0.5.2",
-      "license": "BSL-1.1",
+      "license": "Apache-2.0",
       "dependencies": {
         "@capacitor-mlkit/barcode-scanning": "^7.5.0",
         "@capacitor/android": "^7.6.4",


### PR DESCRIPTION
## Summary
- finish the remaining ERY-89 Apache 2.0 sweep gap on `main`
- align the root app and MCP server lockfile package metadata from `BSL-1.1` to `Apache-2.0`
- avoid re-publishing the old workflow-bearing branch lineage that requires extra GitHub token scope

## Context
Most of the original `7a3d746` Apache 2.0 sweep is already present on `main`. The residual inconsistency was the lockfile root package metadata still declaring `BSL-1.1`.

## Validation
- `git diff --check`
- verified both lockfiles now match the Apache 2.0 package manifests

## Links
- Closes ERY-248
- Related ERY-89
