### PR TITLE
docs: finish Apache 2.0 copy sweep publication (ERY-89)

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "eryxon-flow-mcp-server",
       "version": "2.4.0",
-      "license": "BSL-1.1",
+      "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",
         "@supabase/supabase-js": "^2.100.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "eryxon-flow",
       "version": "0.5.2",
-      "license": "BSL-1.1",
+      "license": "Apache-2.0",
       "dependencies": {
         "@capacitor-mlkit/barcode-scanning": "^7.5.0",
         "@capacitor/android": "^7.6.4",

--- a/website/src/content/docs/articles/why-eryxon-flow-moved-to-apache-2-0.md
+++ b/website/src/content/docs/articles/why-eryxon-flow-moved-to-apache-2-0.md
@@ -1,6 +1,6 @@
 ---
 title: Why Eryxon Flow moved to Apache 2.0
-description: Eryxon Flow is now source-available under Apache 2.0 so job shops can use, fork, modify, and deploy it freely, while Eryxon continues to offer hosted, managed, and rollout support as services.
+description: Eryxon Flow is now open source under Apache 2.0 so job shops can use, fork, modify, and deploy it freely, while Eryxon continues to offer hosted, managed, and rollout support as services.
 head:
   - tag: link
     attrs:


### PR DESCRIPTION
## Summary
- align the remaining root and MCP lockfile `license` metadata with Apache 2.0
- correct the public Apache 2.0 article description so it says `open source`, not `source-available`
- publish the final review artifact for the Apache 2.0 copy sweep

## Changed Surfaces
- `package-lock.json`
- `mcp-server/package-lock.json`
- `website/src/content/docs/articles/why-eryxon-flow-moved-to-apache-2-0.md`

## Verification
- `main` already contained the broader Apache 2.0 relicensing sweep across README, docs landing pages, website footer/config, package metadata, and admin license copy.
- This PR now captures the remaining drift in the scoped public/package surfaces.
- Verified the PR branch no longer contains the incorrect phrase `source-available under Apache 2.0` in `website/`.

## Intentionally Left Unchanged
- Historical and internal planning references that discuss the prior BSL/source-available positioning as past state or planning context, including older strategy briefs and the historical explainer article that explicitly describes the move from BSL to Apache 2.0.
- Binary QA screenshots that happen to match search terms; they are archived evidence, not live copy surfaces.

## Issue Links
- ERY-89


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified licensing terminology in the Apache 2.0 adoption article to reflect "open source" phrasing, providing improved clarity about how users can fork, modify, and deploy the software.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->