### PR TITLE
fix(api): map auth failures to 401 instead of 500

### DIFF
--- a/src/test/edge-functions/auth-error-mapping.test.ts
+++ b/src/test/edge-functions/auth-error-mapping.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Regression test for issue #908.
+ *
+ * Auth failures must map to HTTP 401, not 500. The bug was that auth.ts
+ * defined its own UnauthorizedError/ForbiddenError classes, which mapError()
+ * in validation/errorHandler.ts did not recognize via instanceof — so they
+ * fell through to the generic `instanceof Error -> 500` branch.
+ *
+ * This test asserts the error THROWN by the auth module is the SAME class
+ * mapError() checks, and therefore maps to the correct status code.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// cors.ts calls Deno.env.get() at module-eval time (top-level), so Deno must
+// exist before the import graph below evaluates. vi.hoisted runs first.
+vi.hoisted(() => {
+  (globalThis as unknown as { Deno: unknown }).Deno = {
+    env: { get: (_key: string) => undefined },
+  };
+});
+
+// auth.ts pulls in cache + rate-limiter; stub them so the import is side-effect free
+vi.mock('../../../supabase/functions/_shared/cache-utils.ts', () => ({
+  cacheOrFetch: vi.fn(),
+  invalidateCache: vi.fn(),
+}));
+vi.mock('../../../supabase/functions/_shared/cache.ts', () => ({
+  CacheKeys: { rateLimit: (a: string, b: string) => `${a}:${b}` },
+  CacheTTL: { SHORT: 60, MEDIUM: 300, LONG: 3600 },
+  getCache: vi.fn(() => ({
+    get: vi.fn(),
+    set: vi.fn(),
+    del: vi.fn(),
+    mget: vi.fn(),
+    mset: vi.fn(),
+    incr: vi.fn(),
+    getType: () => 'memory',
+  })),
+  getCachedJson: vi.fn(),
+  setCachedJson: vi.fn(),
+}));
+vi.mock('../../../supabase/functions/_shared/rate-limiter.ts', () => ({
+  checkRateLimit: vi.fn(),
+  getRateLimitHeaders: vi.fn(() => ({})),
+}));
+
+import { UnauthorizedError as AuthUnauthorizedError, ForbiddenError as AuthForbiddenError } from '../../../supabase/functions/_shared/auth.ts';
+import { mapError } from '../../../supabase/functions/_shared/validation/errorHandler.ts';
+
+describe('auth error -> HTTP status mapping (issue #908)', () => {
+  it('maps an UnauthorizedError thrown by the auth module to 401', () => {
+    const mapped = mapError(new AuthUnauthorizedError('Invalid API key'));
+    expect(mapped.status).toBe(401);
+    expect(mapped.code).toBe('UNAUTHORIZED');
+  });
+
+  it('maps a ForbiddenError thrown by the auth module to 403', () => {
+    const mapped = mapError(new AuthForbiddenError('Access denied'));
+    expect(mapped.status).toBe(403);
+    expect(mapped.code).toBe('FORBIDDEN');
+  });
+
+  it('does not fall through to the generic 500 branch for auth errors', () => {
+    const mapped = mapError(new AuthUnauthorizedError('Invalid API key'));
+    expect(mapped.status).not.toBe(500);
+    expect(mapped.code).not.toBe('INTERNAL_ERROR');
+  });
+});

--- a/src/test/edge-functions/auth.test.ts
+++ b/src/test/edge-functions/auth.test.ts
@@ -13,11 +13,13 @@
 
 import { describe, it, expect, vi } from 'vitest';
 
-// Mock Deno.env (required by transitive imports through cors.ts)
-vi.stubGlobal('Deno', {
-  env: {
-    get: (key: string) => undefined,
-  },
+// Deno.env is read at module-eval time by cors.ts (pulled in transitively now
+// that auth.ts re-exports from validation/errorHandler.ts). vi.hoisted runs
+// before the import graph evaluates, so Deno exists in time.
+vi.hoisted(() => {
+  (globalThis as unknown as { Deno: unknown }).Deno = {
+    env: { get: (_key: string) => undefined },
+  };
 });
 
 // Mock the cache/rate-limiter dependencies that auth.ts imports

--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -13,7 +13,10 @@ import { checkRateLimit, RateLimitResult } from "./rate-limiter.ts";
 import { getRateLimitConfig } from "./plan-limits.ts";
 import { constantTimeCompare } from "./security.ts";
 
-// Custom error classes
+// Custom error classes. These are the canonical Unauthorized/Forbidden classes;
+// validation/errorHandler.ts imports them so mapError() recognizes them via
+// instanceof and maps them to 401/403 (issue #908). They must live here (not be
+// duplicated in errorHandler.ts) so the class thrown is the class checked.
 export class UnauthorizedError extends Error {
   constructor(message: string) {
     super(message);

--- a/supabase/functions/_shared/validation/errorHandler.ts
+++ b/supabase/functions/_shared/validation/errorHandler.ts
@@ -8,8 +8,13 @@ import {
   ApiSuccessResponse,
   ValidationResult,
 } from "./types.ts";
-import { RateLimitError } from "../auth.ts";
+import { RateLimitError, UnauthorizedError, ForbiddenError } from "../auth.ts";
 import { getRateLimitHeaders } from "../rate-limiter.ts";
+
+// Re-export so existing importers of these from errorHandler.ts keep working.
+// auth.ts is the single source of truth for these classes, so mapError() below
+// checks the exact class that auth throws (issue #908).
+export { UnauthorizedError, ForbiddenError };
 
 /**
  * Custom error classes
@@ -41,20 +46,6 @@ export class ConflictError extends Error {
   ) {
     super(`${resource} with ${field} "${value}" already exists`);
     this.name = "ConflictError";
-  }
-}
-
-export class UnauthorizedError extends Error {
-  constructor(message: string = "Invalid or missing API key") {
-    super(message);
-    this.name = "UnauthorizedError";
-  }
-}
-
-export class ForbiddenError extends Error {
-  constructor(message: string = "Access denied") {
-    super(message);
-    this.name = "ForbiddenError";
   }
 }
 


### PR DESCRIPTION
## Problem
Every API endpoint returned `HTTP 500 / INTERNAL_ERROR` for an invalid or missing API key, instead of `401 / UNAUTHORIZED`.

## Root cause
`auth.ts` defined its own `UnauthorizedError`/`ForbiddenError` classes, separate from the identically-named classes in `validation/errorHandler.ts` that `mapError()` checks via `instanceof`. The thrown class was not the checked class, so auth errors fell through to the generic `instanceof Error -> 500` branch.

## Fix
Make `auth.ts` the single source of truth for `UnauthorizedError`/`ForbiddenError`, and have `errorHandler.ts` import and re-export them. Now the class thrown is the class `mapError()` recognizes, so auth failures map to 401/403. The dependency direction stays `errorHandler.ts -> auth.ts` (no new import cycle; the reverse re-export approach was rejected because the cycle left the binding undefined at throw-time).

## Tests
- New `src/test/edge-functions/auth-error-mapping.test.ts`: asserts `mapError(new UnauthorizedError()).status === 401` and `ForbiddenError -> 403`, and that auth errors never map to 500. Verified red before the fix, green after.
- Updated `auth.test.ts` to stub `Deno` via `vi.hoisted` (cors.ts reads `Deno.env` at module-eval time, now pulled in transitively).
- All 127 edge-function tests pass locally; `npm run build` green.

## Verification
```
GET /functions/v1/api-cells   Authorization: Bearer <invalid>
before: HTTP 500 INTERNAL_ERROR
after:  HTTP 401 UNAUTHORIZED   (after deploy of _shared/auth.ts consumers)
```

Closes #908