### PR TITLE
fix(api): validate webhook fields so missing secret_key returns 422 not 500

### DIFF
--- a/src/test/edge-functions/webhook-validator.test.ts
+++ b/src/test/edge-functions/webhook-validator.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Regression test for issue #909.
+ *
+ * POST /api-webhooks used to 500 with a NOT NULL violation when secret_key
+ * (or url / events) was missing, because the handler had no validator. The
+ * WebhookValidator now turns those into a clean 422, matching the other CRUD
+ * validators (e.g. IssueValidator).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { WebhookValidator } from '../../../supabase/functions/_shared/validation/validators/WebhookValidator.ts';
+
+const ctx = {} as never; // WebhookValidator does not use ValidationContext
+
+describe('WebhookValidator (issue #909)', () => {
+  it('rejects a missing secret_key with a 422 (not a 500 pass-through)', () => {
+    const result = new WebhookValidator().validate(
+      { url: 'https://example.com/hook', events: ['job.created'] } as never,
+      ctx,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.httpStatus).toBe(422);
+    const fields = result.errors.map((e) => e.field);
+    expect(fields).toContain('secret_key');
+    const secretErr = result.errors.find((e) => e.field === 'secret_key');
+    expect(secretErr?.constraint).toBe('NOT_NULL');
+  });
+
+  it('rejects a missing url and missing events too', () => {
+    const result = new WebhookValidator().validate(
+      { secret_key: 'whsec_abc123' } as never,
+      ctx,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.httpStatus).toBe(422);
+    const fields = result.errors.map((e) => e.field);
+    expect(fields).toContain('url');
+    expect(fields).toContain('events');
+  });
+
+  it('rejects a non-http url', () => {
+    const result = new WebhookValidator().validate(
+      { url: 'ftp://example.com', events: ['job.created'], secret_key: 'whsec_abc123' } as never,
+      ctx,
+    );
+    expect(result.valid).toBe(false);
+    const urlErr = result.errors.find((e) => e.field === 'url');
+    expect(urlErr?.constraint).toBe('PATTERN_MISMATCH');
+  });
+
+  it('rejects an empty events array', () => {
+    const result = new WebhookValidator().validate(
+      { url: 'https://example.com/hook', events: [], secret_key: 'whsec_abc123' } as never,
+      ctx,
+    );
+    expect(result.valid).toBe(false);
+    const eventsErr = result.errors.find((e) => e.field === 'events');
+    expect(eventsErr?.constraint).toBe('MIN_LENGTH');
+  });
+
+  it('accepts a complete, valid webhook payload', () => {
+    const result = new WebhookValidator().validate(
+      {
+        url: 'https://example.com/hook',
+        events: ['job.created', 'batch.completed'],
+        secret_key: 'whsec_abc123',
+        active: true,
+      } as never,
+      ctx,
+    );
+    expect(result.valid).toBe(true);
+    expect(result.httpStatus).toBe(200);
+    expect(result.errors).toHaveLength(0);
+  });
+});

--- a/supabase/functions/_shared/validation/validators/WebhookValidator.ts
+++ b/supabase/functions/_shared/validation/validators/WebhookValidator.ts
@@ -1,0 +1,61 @@
+/**
+ * Webhook Validator
+ * Validates webhook subscription creation/update.
+ *
+ * The webhooks table has NOT NULL columns url, events and secret_key. Without
+ * validation, a POST missing any of these reached the DB and surfaced as a
+ * 500 NOT NULL violation (issue #909). This validator turns those into a clean
+ * 422 with field-level detail, matching the other CRUD validators.
+ */
+
+import { BaseValidator } from "../BaseValidator.ts";
+import { ValidationContext, ValidationError } from "../types.ts";
+
+// http(s) URL, since webhooks are delivered over HTTP.
+const URL_PATTERN = /^https?:\/\/.+/i;
+
+export interface WebhookData {
+  url: string;
+  events: string[];
+  secret_key: string;
+  active?: boolean;
+}
+
+export class WebhookValidator extends BaseValidator<WebhookData> {
+  constructor() {
+    super("webhook");
+  }
+
+  validateEntity(
+    entity: WebhookData,
+    index: number,
+    _context: ValidationContext,
+  ): ValidationError[] {
+    const errors: ValidationError[] = [];
+
+    // Required: url (must be an http(s) URL)
+    const urlError = this.validateString(entity, "url", index, {
+      required: true,
+      minLength: 1,
+      maxLength: 2048,
+      pattern: URL_PATTERN,
+    });
+    if (urlError) errors.push(urlError);
+
+    // Required: events (non-empty array)
+    const eventsError = this.validateArray(entity, "events", index, {
+      required: true,
+      minLength: 1,
+    });
+    if (eventsError) errors.push(eventsError);
+
+    // Required: secret_key (NOT NULL in DB; used to sign webhook payloads)
+    const secretError = this.validateString(entity, "secret_key", index, {
+      required: true,
+      minLength: 1,
+    });
+    if (secretError) errors.push(secretError);
+
+    return errors;
+  }
+}

--- a/supabase/functions/api-webhooks/index.ts
+++ b/supabase/functions/api-webhooks/index.ts
@@ -1,5 +1,6 @@
 import { serveApi } from "@shared/handler.ts";
 import { createCrudHandler } from "@shared/crud-builder.ts";
+import { WebhookValidator } from "@shared/validation/validators/WebhookValidator.ts";
 
 // Configure CRUD handler for webhooks
 serveApi(
@@ -11,5 +12,8 @@ serveApi(
     sortableFields: ['created_at', 'events', 'url'],
     defaultSort: { field: 'created_at', direction: 'desc' },
     softDelete: false,
+    // url, events and secret_key are NOT NULL. Validate up front so a missing
+    // field returns a 422 instead of a 500 NOT NULL violation (issue #909).
+    validator: WebhookValidator,
   })
 );


### PR DESCRIPTION
## Problem
`POST /api-webhooks` returned `HTTP 500 / INTERNAL_ERROR` (NOT NULL violation) when a required field was missing, instead of a clean validation error.

```
POST /functions/v1/api-webhooks
{"url":"https://example.com/hook","events":["job.created"],"active":false}

HTTP 500
{"error":{"code":"INTERNAL_ERROR","message":"Failed to create webhooks: null value in column \"secret_key\" of relation \"webhooks\" violates not-null constraint"}}
```

## Root cause
`api-webhooks` used the generic CRUD builder with no `validator`, so the body was inserted as-is. The `webhooks` table has `url`, `events` and `secret_key` as NOT NULL columns, so a missing field hit the DB constraint and raised a 500.

## Fix
Add `WebhookValidator` (same `BaseValidator` pattern as `IssueValidator`) and wire it into the handler:
- `url` — required, http(s) pattern
- `events` — required, non-empty array
- `secret_key` — required, non-empty string

Missing/invalid fields now return `422` with field-level detail (matching `api-issues`). PATCH stays partial — the validator has no `validatePartial`, so the CRUD builder skips required-field enforcement on update.

## Tests
New `src/test/edge-functions/webhook-validator.test.ts` (5 cases): missing secret_key, missing url+events, non-http url, empty events array, and a valid payload. Verified red->green by temporarily relaxing the `secret_key` rule (test fails) and restoring it (test passes).

All 129 edge-function tests pass locally; `npm run build` green.

Closes #909