### PR TITLE
fix(operator): stabilize terminal load + mobile admin access (batch/location)

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -3252,6 +3252,93 @@ export type Database = {
           },
         ]
       }
+      storage_locations: {
+        Row: {
+          id: string
+          tenant_id: string
+          cell_id: string | null
+          code: string
+          label: string | null
+          row_index: number | null
+          col_index: number | null
+          capacity: number
+          sort_order: number
+          active: boolean
+          metadata: Json
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          tenant_id: string
+          cell_id?: string | null
+          code: string
+          label?: string | null
+          row_index?: number | null
+          col_index?: number | null
+          capacity?: number
+          sort_order?: number
+          active?: boolean
+          metadata?: Json
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          tenant_id?: string
+          cell_id?: string | null
+          code?: string
+          label?: string | null
+          row_index?: number | null
+          col_index?: number | null
+          capacity?: number
+          sort_order?: number
+          active?: boolean
+          metadata?: Json
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      part_placements: {
+        Row: {
+          id: string
+          tenant_id: string
+          part_id: string
+          location_id: string
+          operation_id: string | null
+          placed_by: string | null
+          placed_by_operator_id: string | null
+          placed_at: string
+          removed_at: string | null
+          metadata: Json
+        }
+        Insert: {
+          id?: string
+          tenant_id: string
+          part_id: string
+          location_id: string
+          operation_id?: string | null
+          placed_by?: string | null
+          placed_by_operator_id?: string | null
+          placed_at?: string
+          removed_at?: string | null
+          metadata?: Json
+        }
+        Update: {
+          id?: string
+          tenant_id?: string
+          part_id?: string
+          location_id?: string
+          operation_id?: string | null
+          placed_by?: string | null
+          placed_by_operator_id?: string | null
+          placed_at?: string
+          removed_at?: string | null
+          metadata?: Json
+        }
+        Relationships: []
+      }
       tenants: {
         Row: {
           abbreviation: string | null
@@ -3277,6 +3364,7 @@ export type Database = {
           grace_period_ends_at: string | null
           id: string
           last_parts_reset_date: string | null
+          location_tracking_enabled: boolean
           max_jobs: number | null
           max_parts_per_month: number | null
           max_storage_gb: number | null
@@ -3330,6 +3418,7 @@ export type Database = {
           grace_period_ends_at?: string | null
           id?: string
           last_parts_reset_date?: string | null
+          location_tracking_enabled?: boolean
           max_jobs?: number | null
           max_parts_per_month?: number | null
           max_storage_gb?: number | null
@@ -3383,6 +3472,7 @@ export type Database = {
           grace_period_ends_at?: string | null
           id?: string
           last_parts_reset_date?: string | null
+          location_tracking_enabled?: boolean
           max_jobs?: number | null
           max_parts_per_month?: number | null
           max_storage_gb?: number | null

--- a/src/lib/db/operations.ts
+++ b/src/lib/db/operations.ts
@@ -299,9 +299,13 @@ async function fetchOperationsWithDetailsInternal(
   const batchContextsByOperation = new Map<string, OperationBatchContext>();
 
   if (operationIds.length > 0) {
-    let modeHistory: OperationModeHistoryResult[];
+    // Operator-mode history and batch context enrich each operation, but they must
+    // never block the terminal. If any of these queries fail (a half-migrated batch
+    // table, an oversized `.in()`, a missing FK embed) we log and load operations
+    // WITHOUT batch context rather than blanking the whole view — operators can
+    // still see and clock on their work.
     try {
-      modeHistory = await fetchInChunks<OperationModeHistoryResult>(operationIds, (chunk) =>
+      const modeHistory = await fetchInChunks<OperationModeHistoryResult>(operationIds, (chunk) =>
         supabase
           .from("time_entries")
           .select("operation_id, notes")
@@ -309,20 +313,14 @@ async function fetchOperationsWithDetailsInternal(
           .in("operation_id", chunk)
           .like("notes", "operator-mode:%"),
       );
-    } catch (modeHistoryError) {
-      logger.error("Database", "Error fetching operator mode history", modeHistoryError);
-      throw modeHistoryError;
-    }
 
-    for (const entry of modeHistory) {
-      if (parseOperatorTerminalModeNote(entry.notes) === "setup") {
-        setupHistoryByOperation.add(entry.operation_id);
+      for (const entry of modeHistory) {
+        if (parseOperatorTerminalModeNote(entry.notes) === "setup") {
+          setupHistoryByOperation.add(entry.operation_id);
+        }
       }
-    }
 
-    let batchLinks: BatchLinkResult[];
-    try {
-      batchLinks = await fetchInChunks<BatchLinkResult>(operationIds, (chunk) =>
+      const batchLinks = await fetchInChunks<BatchLinkResult>(operationIds, (chunk) =>
         supabase
           .from("batch_operations")
           .select(`
@@ -348,94 +346,98 @@ async function fetchOperationsWithDetailsInternal(
           .in("operation_id", chunk)
           .eq("tenant_id", tenantId),
       );
-    } catch (batchLinksError) {
-      logger.error("Database", "Error fetching batch links for operations", batchLinksError);
-      throw batchLinksError;
-    }
 
-    const batchIds = Array.from(
-      new Set(batchLinks.map((link) => link.batch_id)),
-    );
+      const batchIds = Array.from(
+        new Set(batchLinks.map((link) => link.batch_id)),
+      );
 
-    const membersByBatchId = new Map<string, OperationBatchMember[]>();
+      const membersByBatchId = new Map<string, OperationBatchMember[]>();
 
-    if (batchIds.length > 0) {
-      const { data: batchMembers, error: batchMembersError } = await supabase
-        .from("batch_operations")
-        .select(`
-          batch_id,
-          operation_id,
-          sequence_in_batch,
-          operation:operations!batch_operations_operation_id_fkey(
-            id,
-            status,
-            operation_name,
-            part_id
-          )
-        `)
-        .in("batch_id", batchIds)
-        .eq("tenant_id", tenantId)
-        .order("sequence_in_batch", { ascending: true });
+      if (batchIds.length > 0) {
+        // Chunk by batch_id too — a tenant can accumulate enough batches to blow
+        // the PostgREST URL limit on a single `.in()`.
+        const batchMembers = await fetchInChunks<BatchMemberResult>(batchIds, (chunk) =>
+          supabase
+            .from("batch_operations")
+            .select(`
+              batch_id,
+              operation_id,
+              sequence_in_batch,
+              operation:operations!batch_operations_operation_id_fkey(
+                id,
+                status,
+                operation_name,
+                part_id
+              )
+            `)
+            .in("batch_id", chunk)
+            .eq("tenant_id", tenantId)
+            .order("sequence_in_batch", { ascending: true }),
+        );
 
-      if (batchMembersError) {
-        logger.error("Database", "Error fetching batch members for operations", batchMembersError);
-        throw batchMembersError;
+        for (const member of batchMembers) {
+          const operation = Array.isArray(member.operation)
+            ? member.operation[0]
+            : member.operation;
+
+          if (!operation) continue;
+
+          const safeEntry = activeEntriesByOperation.get(member.operation_id);
+          const existingMembers = membersByBatchId.get(member.batch_id) ?? [];
+          existingMembers.push({
+            operation_id: member.operation_id,
+            operation_name: operation.operation_name,
+            part_id: operation.part_id,
+            status: operation.status,
+            sequence_in_batch: member.sequence_in_batch,
+            active_time_entry: safeEntry
+              ? {
+                  operator_id: safeEntry.operator_id,
+                  operator_name: safeEntry.operator.full_name,
+                  notes: safeEntry.notes ?? null,
+                }
+              : undefined,
+          });
+          membersByBatchId.set(member.batch_id, existingMembers);
+        }
       }
 
-      for (const member of (batchMembers ?? []) as BatchMemberResult[]) {
-        const operation = Array.isArray(member.operation)
-          ? member.operation[0]
-          : member.operation;
+      for (const link of batchLinks) {
+        const batch = Array.isArray(link.batch) ? link.batch[0] : link.batch;
+        if (!batch) continue;
 
-        if (!operation) continue;
+        const parentBatch = Array.isArray(batch.parent_batch)
+          ? batch.parent_batch[0]
+          : batch.parent_batch;
 
-        const safeEntry = activeEntriesByOperation.get(member.operation_id);
-        const existingMembers = membersByBatchId.get(member.batch_id) ?? [];
-        existingMembers.push({
-          operation_id: member.operation_id,
-          operation_name: operation.operation_name,
-          part_id: operation.part_id,
-          status: operation.status,
-          sequence_in_batch: member.sequence_in_batch,
-          active_time_entry: safeEntry
+        batchContextsByOperation.set(link.operation_id, {
+          batch_id: batch.id,
+          batch_number: batch.batch_number,
+          batch_type: batch.batch_type,
+          status: batch.status,
+          operations_count: batch.operations_count,
+          material: batch.material,
+          nesting_metadata: batch.nesting_metadata,
+          sequence_in_batch: link.sequence_in_batch,
+          parent_batch: parentBatch
             ? {
-                operator_id: safeEntry.operator_id,
-                operator_name: safeEntry.operator.full_name,
-                notes: safeEntry.notes ?? null,
+                id: parentBatch.id,
+                batch_number: parentBatch.batch_number,
+                batch_type: parentBatch.batch_type,
+                status: parentBatch.status,
               }
-            : undefined,
+            : null,
+          members: membersByBatchId.get(batch.id) ?? [],
         });
-        membersByBatchId.set(member.batch_id, existingMembers);
       }
-    }
-
-    for (const link of batchLinks) {
-      const batch = Array.isArray(link.batch) ? link.batch[0] : link.batch;
-      if (!batch) continue;
-
-      const parentBatch = Array.isArray(batch.parent_batch)
-        ? batch.parent_batch[0]
-        : batch.parent_batch;
-
-      batchContextsByOperation.set(link.operation_id, {
-        batch_id: batch.id,
-        batch_number: batch.batch_number,
-        batch_type: batch.batch_type,
-        status: batch.status,
-        operations_count: batch.operations_count,
-        material: batch.material,
-        nesting_metadata: batch.nesting_metadata,
-        sequence_in_batch: link.sequence_in_batch,
-        parent_batch: parentBatch
-          ? {
-              id: parentBatch.id,
-              batch_number: parentBatch.batch_number,
-              batch_type: parentBatch.batch_type,
-              status: parentBatch.status,
-            }
-          : null,
-        members: membersByBatchId.get(batch.id) ?? [],
-      });
+    } catch (enrichmentError) {
+      logger.error(
+        "Database",
+        "Operation batch/mode enrichment failed; loading operations without batch context",
+        enrichmentError,
+      );
+      setupHistoryByOperation.clear();
+      batchContextsByOperation.clear();
     }
   }
 

--- a/src/pages/operator/OperatorView.tsx
+++ b/src/pages/operator/OperatorView.tsx
@@ -272,15 +272,21 @@ export default function OperatorView() {
         />
       </div>
 
-      <PlacementPickerModal
-        open={placementTarget !== null}
-        onOpenChange={(open) => {
-          if (!open) setPlacementTarget(null);
-        }}
-        cellId={placementTarget?.cellId ?? null}
-        isRecording={isRecording}
-        onConfirm={handleConfirmPlacement}
-      />
+      {/* Only mount the placement picker when location tracking is on. The module
+          is off by default, and the modal eagerly queries storage_locations /
+          part_placements on mount — keep it out of the tree so a terminal with
+          tracking disabled never touches the location queries. */}
+      {locationTrackingEnabled ? (
+        <PlacementPickerModal
+          open={placementTarget !== null}
+          onOpenChange={(open) => {
+            if (!open) setPlacementTarget(null);
+          }}
+          cellId={placementTarget?.cellId ?? null}
+          isRecording={isRecording}
+          onConfirm={handleConfirmPlacement}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/routes/guards.operator-gate.test.tsx
+++ b/src/routes/guards.operator-gate.test.tsx
@@ -1,10 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 
 // The guards module pulls in auth hooks at import time; stub them so this
 // test stays focused on the operator gate and never touches Supabase.
-vi.mock("@/hooks/useProfile", () => ({ useProfile: (): null => null }));
+const useProfileMock = vi.fn();
+vi.mock("@/hooks/useProfile", () => ({ useProfile: () => useProfileMock() }));
 vi.mock("@/hooks/useSession", () => ({
   useSession: (): { user: null } => ({ user: null }),
 }));
@@ -22,19 +23,25 @@ import { RequireActiveOperator, resolveOperatorGate } from "./guards";
 describe("resolveOperatorGate", () => {
   it("waits while the operator context is hydrating", () => {
     expect(
-      resolveOperatorGate({ isLoading: true, hasActiveOperator: false }),
+      resolveOperatorGate({ isLoading: true, hasActiveOperator: false, isAdmin: false }),
     ).toBe("loading");
   });
 
   it("redirects a shared account with no active operator", () => {
     expect(
-      resolveOperatorGate({ isLoading: false, hasActiveOperator: false }),
+      resolveOperatorGate({ isLoading: false, hasActiveOperator: false, isAdmin: false }),
     ).toBe("redirect");
   });
 
   it("allows a verified active operator through", () => {
     expect(
-      resolveOperatorGate({ isLoading: false, hasActiveOperator: true }),
+      resolveOperatorGate({ isLoading: false, hasActiveOperator: true, isAdmin: false }),
+    ).toBe("allow");
+  });
+
+  it("allows an admin through for oversight without a PIN'd operator", () => {
+    expect(
+      resolveOperatorGate({ isLoading: false, hasActiveOperator: false, isAdmin: true }),
     ).toBe("allow");
   });
 });
@@ -58,11 +65,25 @@ function renderGate() {
 }
 
 describe("RequireActiveOperator", () => {
+  beforeEach(() => {
+    // Default: a non-admin shared account (no PIN'd operator).
+    useProfileMock.mockReturnValue(null);
+  });
+
   it("redirects to the PIN login when no operator is signed in", () => {
     useOperatorMock.mockReturnValue({ activeOperator: null, isLoading: false });
     renderGate();
     expect(screen.getByText("PIN login")).toBeInTheDocument();
     expect(screen.queryByText("Operator queue")).toBeNull();
+  });
+
+  it("lets an admin into the mobile shell without forcing the PIN login", () => {
+    // Admins get oversight access without badging in as a shop-floor operator.
+    useProfileMock.mockReturnValue({ role: "admin" });
+    useOperatorMock.mockReturnValue({ activeOperator: null, isLoading: false });
+    renderGate();
+    expect(screen.getByText("Operator queue")).toBeInTheDocument();
+    expect(screen.queryByText("PIN login")).toBeNull();
   });
 
   it("renders the operator surface when an operator is active", () => {

--- a/src/routes/guards.tsx
+++ b/src/routes/guards.tsx
@@ -82,11 +82,18 @@ type OperatorGateOutcome = "loading" | "redirect" | "allow";
 export function resolveOperatorGate({
   isLoading,
   hasActiveOperator,
+  isAdmin,
 }: {
   isLoading: boolean;
   hasActiveOperator: boolean;
+  isAdmin: boolean;
 }): OperatorGateOutcome {
   if (isLoading) return "loading";
+  // Admins/shift-leaders get oversight access to the mobile shell WITHOUT badging
+  // in as a shop-floor operator — same as the desktop terminal (ProtectedRoute).
+  // They are never recorded as an operator: mobile write actions guard on
+  // activeOperator?.id, which stays null for an admin who didn't PIN in.
+  if (isAdmin) return "allow";
   if (!hasActiveOperator) return "redirect";
   return "allow";
 }
@@ -96,11 +103,13 @@ export function RequireActiveOperator({
 }: {
   children: React.ReactNode;
 }) {
+  const profile = useProfile();
   const { activeOperator, isLoading } = useOperator();
   const location = useLocation();
   const outcome = resolveOperatorGate({
     isLoading,
     hasActiveOperator: Boolean(activeOperator),
+    isAdmin: profile?.role === "admin",
   });
 
   if (outcome === "loading") {


### PR DESCRIPTION
## Summary
- Operator terminal no longer "fails to load" when a batch/nesting or location query errors at production scale — it degrades instead of blanking.
- Admins can open the mobile app without being forced through the operator badge/PIN login.
- Hardens the half-finished location module (off-by-default now truly inert on the terminal; generated types fixed).

## Release Path
- [x] Critical hotfix exception

Planned train date (`YYYY-MM-DD`) or hotfix issue: critical prod regression — operator terminal blocked + admins locked out of mobile.

## Changes
**Terminal load won't blank on a failing enrichment query** (`src/lib/db/operations.ts`)
- Batch + operator-mode enrichment in `fetchOperationsWithDetailsInternal` previously rethrew on any error, so one failing enrichment query (oversized PostgREST `.in()`, half-migrated batch table) blanked the whole terminal — no operations, no clock-on. It is now non-fatal: on error it logs and loads operations **without** batch context.
- The batch-members query used the last remaining unchunked `.in("batch_id", …)` on the hot path; it now goes through `fetchInChunks` like the operation-id queries (chunked in `86e292e`).

**Mobile admin access** (`src/routes/guards.tsx`)
- `RequireActiveOperator` redirected to the operator PIN login whenever no PIN'd operator was present, regardless of role — locking admins out of the `/m` shell. `resolveOperatorGate` now takes `isAdmin` and allows admins through (parity with the desktop `ProtectedRoute`). Admins are never recorded as an operator — mobile write/attribution paths already guard on `activeOperator?.id`, which stays null.

**Location module hardening**
- `PlacementPickerModal` was mounted unconditionally and eagerly queried `storage_locations` / `part_placements` on every terminal load even with tracking off; it is now only mounted when location tracking is enabled (`src/pages/operator/OperatorView.tsx`).
- The location tables + `tenants.location_tracking_enabled` existed only in the modular types tree, not the generated `types.ts` the client resolves — so the module was untyped (build/vitest skip type-checking). Added to `types.ts` (`src/integrations/supabase/types.ts`).

## Checklist
- [x] Change was prepared on a non-`main` branch; no direct push to `main` was used
- [x] `npm run build` passes
- [x] `npm run test:run` passes (97 files, 997 tests)
- [x] New tables have RLS policies (existing `storage_locations` / `part_placements` migration; no new tables here)
- [x] New UI text uses i18n keys (EN + NL + DE) — no new user-facing strings
- [ ] Edge functions have `deno.json` with import map — N/A
- [x] Column names verified against actual DB schema (checked location/batch tables + FKs against prod)
- [x] No customer-identifying, credential, or commercial details were added

## Notes for reviewers
- Root cause of "terminal won't load" is the enrichment-query-blanks-everything path at prod scale (7,315 operations). The fix makes the terminal resilient regardless of which enrichment query fails.
- Follow-ups worth tracking (out of scope here): prod migration history is two migrations behind HEAD (`location_placement_module`, `issues_simple_cell_fkeys`); `storage_locations.row_index/col_index` are write-only dead config (grid UI never built); `nesting_metadata` is fetched in the terminal but unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVuRrje2icP7bPNvnz1iF8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for tracking storage locations and part placements in the app.
  - Enabled a location-tracking setting for tenants.

- **Bug Fixes**
  - Improved operator screen behavior so placement tools only appear when location tracking is enabled.
  - Made operator workflows more resilient when background details can’t be loaded.
  - Allowed admins to access the operator area without being blocked by active-operator checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->