### PR TITLE
feat(pwa): auto-apply UI updates so the terminal never runs a stale bundle

### DIFF
--- a/src/components/PwaUpdatePrompt.test.tsx
+++ b/src/components/PwaUpdatePrompt.test.tsx
@@ -2,22 +2,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "@testing-library/react";
 import { PwaUpdatePrompt } from "./PwaUpdatePrompt";
 
-interface ToastOptions {
-  duration: number;
-  action: { label: string; onClick: () => void };
-  cancel: { label: string; onClick: () => void };
-}
-
 const mocks = vi.hoisted(() => ({
   isNativeApp: vi.fn(() => false),
   useRegisterSW: vi.fn(),
-  toast: Object.assign(
-    vi.fn<(message: string, options: ToastOptions) => string>(() => "toast-id"),
-    {
-      success: vi.fn(),
-      dismiss: vi.fn(),
-    },
-  ),
+  toast: Object.assign(vi.fn(() => "toast-id"), {
+    success: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+  }),
 }));
 
 vi.mock("@/native", () => ({ isNativeApp: mocks.isNativeApp }));
@@ -70,37 +62,20 @@ describe("PwaUpdatePrompt", () => {
     expect(setOfflineReady).toHaveBeenCalledWith(false);
   });
 
-  it("shows a persistent update toast whose action activates the new SW", () => {
+  it("auto-applies the update and shows an updating toast when a new version is ready", () => {
     const { updateServiceWorker } = mockRegisterSW({ needRefresh: true });
     render(<PwaUpdatePrompt />);
 
-    expect(mocks.toast).toHaveBeenCalledTimes(1);
-    const [message, options] = mocks.toast.mock.calls[0];
-    expect(message).toBe("pwa.updateAvailable");
-    // Infinity duration: the prompt must survive until the operator decides.
-    expect(options.duration).toBe(Infinity);
-
-    options.action.onClick();
-    // `true` posts SKIP_WAITING so the waiting SW activates and reloads.
+    // No manual tap: `true` posts SKIP_WAITING so the waiting SW activates and reloads.
     expect(updateServiceWorker).toHaveBeenCalledWith(true);
+    expect(mocks.toast.loading).toHaveBeenCalledWith("pwa.updating", expect.anything());
   });
 
-  it("lets the operator defer the update without activating it", () => {
-    const { setNeedRefresh, updateServiceWorker } = mockRegisterSW({
-      needRefresh: true,
-    });
+  it("does not toast or update when there is nothing to announce", () => {
+    const { updateServiceWorker } = mockRegisterSW();
     render(<PwaUpdatePrompt />);
-
-    const [, options] = mocks.toast.mock.calls[0];
-    options.cancel.onClick();
-    expect(setNeedRefresh).toHaveBeenCalledWith(false);
-    expect(updateServiceWorker).not.toHaveBeenCalled();
-  });
-
-  it("does not toast when there is nothing to announce", () => {
-    mockRegisterSW();
-    render(<PwaUpdatePrompt />);
-    expect(mocks.toast).not.toHaveBeenCalled();
+    expect(mocks.toast.loading).not.toHaveBeenCalled();
     expect(mocks.toast.success).not.toHaveBeenCalled();
+    expect(updateServiceWorker).not.toHaveBeenCalled();
   });
 });

--- a/src/components/PwaUpdatePrompt.tsx
+++ b/src/components/PwaUpdatePrompt.tsx
@@ -23,13 +23,24 @@ export function PwaUpdatePrompt(): null {
   return <PwaUpdatePromptInner />;
 }
 
+// How often to ask the browser to check for a newer service worker. Shop-floor
+// terminals stay open for hours, so without a poll they'd never see an update.
+const UPDATE_CHECK_INTERVAL_MS = 20 * 60 * 1000;
+
 function PwaUpdatePromptInner(): null {
   const { t } = useTranslation("common");
   const {
     offlineReady: [offlineReady, setOfflineReady],
-    needRefresh: [needRefresh, setNeedRefresh],
+    needRefresh: [needRefresh],
     updateServiceWorker,
-  } = useRegisterSW();
+  } = useRegisterSW({
+    onRegisteredSW(_swUrl, registration) {
+      if (!registration) return;
+      setInterval(() => {
+        void registration.update();
+      }, UPDATE_CHECK_INTERVAL_MS);
+    },
+  });
 
   useEffect(() => {
     if (offlineReady) {
@@ -38,26 +49,13 @@ function PwaUpdatePromptInner(): null {
     }
   }, [offlineReady, setOfflineReady, t]);
 
+  // Auto-apply updates: when a new version is ready, activate it and reload so
+  // the UI is always current — no manual "Reload" tap, no stale cached bundle.
   useEffect(() => {
     if (!needRefresh) return;
-    const id = toast(t("pwa.updateAvailable"), {
-      description: t("pwa.updateDescription"),
-      duration: Infinity,
-      action: {
-        label: t("pwa.reload"),
-        onClick: () => {
-          void updateServiceWorker(true);
-        },
-      },
-      cancel: {
-        label: t("pwa.later"),
-        onClick: () => setNeedRefresh(false),
-      },
-    });
-    return () => {
-      toast.dismiss(id);
-    };
-  }, [needRefresh, setNeedRefresh, updateServiceWorker, t]);
+    toast.loading(t("pwa.updating"), { id: "pwa-update", duration: Infinity });
+    void updateServiceWorker(true);
+  }, [needRefresh, updateServiceWorker, t]);
 
   return null;
 }

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -248,6 +248,7 @@
     "updateDescription": "Neu laden, um das Update anzuwenden.",
     "reload": "Neu laden",
     "later": "Später",
+    "updating": "Aktualisierung auf die neueste Version…",
     "offlineReady": "Eryxon Flow ist bereit für die Offline-Nutzung"
   }
 }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -248,6 +248,7 @@
     "updateDescription": "Reload to apply the update.",
     "reload": "Reload",
     "later": "Later",
+    "updating": "Updating to the latest version…",
     "offlineReady": "Eryxon Flow is ready to work offline"
   }
 }

--- a/src/i18n/locales/nl/common.json
+++ b/src/i18n/locales/nl/common.json
@@ -248,6 +248,7 @@
     "updateDescription": "Herlaad om de update toe te passen.",
     "reload": "Herladen",
     "later": "Later",
+    "updating": "Bezig met bijwerken naar de nieuwste versie…",
     "offlineReady": "Eryxon Flow is klaar om offline te werken"
   }
 }


### PR DESCRIPTION
## Summary
- The PWA now **auto-applies** new versions instead of showing a manual "Reload" toast, so operators stop running a stale cached bundle (the exact friction that recurred during the terminal incident — "hard-reload / unregister the service worker").
- Adds a periodic update check so long-lived shop-floor terminals pick up new versions without a navigation.

## Release Path
- [x] Critical hotfix exception

Follow-up to the v0.7.2 terminal fixes — removes the manual-reload step that hid the fix from users on the cached bundle.

## Changes
- `src/components/PwaUpdatePrompt.tsx` — on `needRefresh`, activate the waiting SW + reload automatically with a brief "Updating…" toast (no action button). Registers a 20-minute `registration.update()` poll via `onRegisteredSW`. Native shells still bail before registering a SW.
- `src/components/PwaUpdatePrompt.test.tsx` — updated to assert auto-apply (no defer path).
- `src/i18n/locales/{en,nl,de}/common.json` — add `pwa.updating`.

## Checklist
- [x] Change was prepared on a non-`main` branch; no direct push to `main` was used
- [x] `npm run build` passes
- [x] `npm run test:run` passes (PwaUpdatePrompt: 5 tests)
- [x] New tables have RLS policies — N/A
- [x] New UI text uses i18n keys (EN + NL + DE)
- [x] Edge functions have `deno.json` with import map — N/A
- [x] Column names verified against actual DB schema — N/A
- [x] No customer-identifying, credential, or commercial details were added

## Note
The previous `prompt` mode was a deliberate choice to avoid reloading shop-floor terminals mid-task. Auto-apply trades that for always-current UI; operator work state lives server-side (time entries), so a reload resumes cleanly. If mid-task reloads prove disruptive, a follow-up can gate the reload on an idle/navigation boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVuRrje2icP7bPNvnz1iF8)_