### PR TITLE
feat(terminal): declutter operator panel into deduped tabs + finish location flow

### DIFF
--- a/src/components/locations/PlacementPickerModal.tsx
+++ b/src/components/locations/PlacementPickerModal.tsx
@@ -9,7 +9,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
-import { Loader2, MapPin, PackageCheck } from 'lucide-react'
+import { ArrowRight, Loader2, MapPin, PackageCheck } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useStorageLocations } from '@/hooks/locations/useStorageLocations'
 import { suggestLocation, type LocationOccupancy } from '@/lib/locations/placement'
@@ -17,8 +17,10 @@ import { suggestLocation, type LocationOccupancy } from '@/lib/locations/placeme
 interface PlacementPickerModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
-  /** Cell the operation belongs to — scopes the suggestion to nearby slots. */
+  /** Cell to scope the slot suggestion to — the cell the part is heading to. */
   cellId?: string | null
+  /** Name of the next cell, shown so the operator drops it in the right lane. */
+  nextCellName?: string | null
   isRecording?: boolean
   onConfirm: (locationId: string) => void
 }
@@ -32,6 +34,7 @@ export function PlacementPickerModal({
   open,
   onOpenChange,
   cellId,
+  nextCellName,
   isRecording = false,
   onConfirm,
 }: PlacementPickerModalProps) {
@@ -124,6 +127,15 @@ export function PlacementPickerModal({
             {t('locations.placement.title')}
           </DialogTitle>
           <DialogDescription>{t('locations.placement.description')}</DialogDescription>
+          {nextCellName ? (
+            <div className="mt-1 flex items-center gap-1.5 text-sm">
+              <ArrowRight className="h-4 w-4 text-muted-foreground" />
+              <span className="text-muted-foreground">
+                {t('locations.placement.nextCell', 'Heading to')}
+              </span>
+              <span className="font-semibold text-foreground">{nextCellName}</span>
+            </div>
+          ) : null}
         </DialogHeader>
 
         <div className="max-h-[55vh] overflow-y-auto py-2">

--- a/src/components/operator/OperatorDetailSidebar.tsx
+++ b/src/components/operator/OperatorDetailSidebar.tsx
@@ -26,6 +26,7 @@ interface OperatorDetailSidebarProps {
   serverGeometry: GeometryData | null;
   operations: OperationWithDetails[];
   onDataRefresh: () => void;
+  locationTrackingEnabled?: boolean;
 }
 
 export function OperatorDetailSidebar({
@@ -46,6 +47,7 @@ export function OperatorDetailSidebar({
   serverGeometry,
   operations,
   onDataRefresh,
+  locationTrackingEnabled = false,
 }: OperatorDetailSidebarProps) {
   const { t } = useTranslation();
 
@@ -95,6 +97,7 @@ export function OperatorDetailSidebar({
             serverGeometry={serverGeometry}
             operations={operations}
             onDataRefresh={onDataRefresh}
+            locationTrackingEnabled={locationTrackingEnabled}
           />
         </div>
       ) : (

--- a/src/components/terminal/DetailPanel.test.tsx
+++ b/src/components/terminal/DetailPanel.test.tsx
@@ -147,7 +147,7 @@ describe("DetailPanel", () => {
     });
   });
 
-  it("expands routing steps from the instruction card", async () => {
+  it("expands routing substeps from the Steps tab", async () => {
     substepRows.splice(0, substepRows.length, {
       id: "sub-1",
       operation_id: "op-1",
@@ -159,13 +159,15 @@ describe("DetailPanel", () => {
 
     render(<DetailPanel job={baseJob} operations={operations as any} />);
 
+    // The routing operation is visible in the default Steps tab; its substeps
+    // stay collapsed until the operator taps the operation row.
     await waitFor(() => {
-      expect(screen.getByText(/terminal\.instructions\.viewSteps/)).toBeInTheDocument();
+      expect(screen.getByText("Laser cutting")).toBeInTheDocument();
     });
 
     expect(screen.queryByText("Clamp fixture")).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByText(/terminal\.instructions\.viewSteps/));
+    fireEvent.click(screen.getByText("Laser cutting"));
 
     await waitFor(() => {
       expect(screen.getByText("Clamp fixture")).toBeInTheDocument();

--- a/src/components/terminal/DetailPanel.tsx
+++ b/src/components/terminal/DetailPanel.tsx
@@ -15,12 +15,15 @@ import {
   CheckCircle2,
   Clock3,
   Circle,
+  Info,
   Maximize2,
   X,
   ChevronDown,
   ChevronRight,
   PackageCheck,
   Layers3,
+  Boxes,
+  MapPin,
 } from "lucide-react";
 import { CncProgramQrCode } from "./CncProgramQrCode";
 import { STEPViewer } from "@/components/STEPViewerLazy";
@@ -32,7 +35,6 @@ import { OperationWithDetails } from "@/lib/database";
 import { cn } from "@/lib/utils";
 import IssueForm from "@/components/operator/IssueForm";
 import ProductionQuantityModal from "@/components/operator/ProductionQuantityModal";
-import { JobFlowProgress } from "./JobFlowProgress";
 import { useCellQRMMetrics } from "@/hooks/useQRMMetrics";
 import { useProfile } from "@/hooks/useProfile";
 import { supabase } from "@/integrations/supabase/client";
@@ -40,10 +42,11 @@ import { IconDisplay } from "@/components/ui/icon-picker";
 import { useTranslation } from "react-i18next";
 import { logger } from "@/lib/logger";
 import {
-  getTerminalOperationType,
   TerminalEncodingBadges,
   TerminalInstructionFallback,
 } from "./terminalEncoding";
+import { OperationBatchTab } from "./OperationBatchTab";
+import { OperationLocationTab } from "./OperationLocationTab";
 
 interface Substep {
   id: string;
@@ -69,9 +72,11 @@ interface DetailPanelProps {
   serverGeometry?: GeometryData | null;
   operations?: OperationWithDetails[];
   onDataRefresh?: () => void;
+  /** When true, surface the Location tab (drop-off placement) in the panel. */
+  locationTrackingEnabled?: boolean;
 }
 
-type ViewerTab = "3d" | "pdf" | "ops";
+type ViewerTab = "3d" | "pdf" | "steps" | "batch" | "location" | "info";
 
 export function DetailPanel({
   job,
@@ -87,6 +92,7 @@ export function DetailPanel({
   serverGeometry,
   operations = [],
   onDataRefresh,
+  locationTrackingEnabled = false,
 }: DetailPanelProps) {
   const { t } = useTranslation();
   const [isIssueModalOpen, setIsIssueModalOpen] = useState(false);
@@ -105,7 +111,7 @@ export function DetailPanel({
     new Set(),
   );
   const profile = useProfile();
-  const defaultTab: ViewerTab = job.hasModel ? "3d" : job.hasPdf ? "pdf" : "ops";
+  const defaultTab: ViewerTab = job.hasModel ? "3d" : job.hasPdf ? "pdf" : "steps";
   const [activeTab, setActiveTab] = useState<ViewerTab>(defaultTab);
 
   useEffect(() => {
@@ -193,42 +199,6 @@ export function DetailPanel({
     return nextCellMetrics.current_wip >= nextCellMetrics.wip_limit;
   }, [nextOperation, nextCellMetrics]);
 
-  const statusBadge = useMemo(() => {
-    if (job.isCurrentUserClocked) {
-      return {
-        label: t("terminal.inProcess"),
-        className:
-          "border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400",
-      };
-    }
-
-    switch (job.status) {
-      case "in_progress":
-        return {
-          label: t("terminal.inProcess"),
-          className:
-            "border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400",
-        };
-      case "in_buffer":
-        return {
-          label: t("terminal.inBuffer"),
-          className:
-            "border-sky-500/30 bg-sky-500/10 text-sky-600 dark:text-sky-400",
-        };
-      case "on_hold":
-        return {
-          label: t("terminal.onHold", "On hold"),
-          className:
-            "border-orange-500/30 bg-orange-500/10 text-orange-600 dark:text-orange-400",
-        };
-      default:
-        return {
-          label: t("terminal.expected"),
-          className: "border-border bg-muted text-foreground",
-        };
-    }
-  }, [job.isCurrentUserClocked, job.status, t]);
-
   const showCompleteAction =
     showCompleteActionOverride ??
     (job.status === "in_progress" || job.isCurrentUserClocked);
@@ -250,13 +220,9 @@ export function DetailPanel({
   const currentOperationInstructionSteps = currentOperationSubsteps.filter((substep) =>
     Boolean(substep.notes?.trim()),
   );
-  const instructionPreview = job.notes?.trim() || currentOperationInstructionSteps[0]?.notes?.trim() || null;
-  const hasInstructionFallback = !instructionPreview && currentOperationInstructionSteps.length === 0;
-  const operationType = getTerminalOperationType(job);
-  const viewSteps = () => {
-    setActiveTab("ops");
-    setExpandedOperations((prev) => new Set(prev).add(job.operationId));
-  };
+  const instructionPreview = job.notes?.trim() || null;
+  const hasInstructions =
+    Boolean(instructionPreview) || currentOperationInstructionSteps.length > 0;
 
   const renderOperations = () => {
     if (operations.length === 0) {
@@ -385,145 +351,57 @@ export function DetailPanel({
     );
   };
 
+  const nextCellName = nextOperation?.cell?.name ?? null;
+  const nextCellId = nextOperation?.cell_id ?? null;
+  const tabs = (
+    [
+      job.hasModel && { value: "3d", label: "3D", icon: Box },
+      job.hasPdf && { value: "pdf", label: "PDF", icon: FileText },
+      { value: "steps", label: t("terminal.tabs.steps", "Steps"), icon: Layers3 },
+      job.batchContext && {
+        value: "batch",
+        label: t("terminal.tabs.batch", "Batch"),
+        icon: Boxes,
+      },
+      locationTrackingEnabled && {
+        value: "location",
+        label: t("terminal.tabs.location", "Location"),
+        icon: MapPin,
+      },
+      { value: "info", label: t("terminal.tabs.info", "Info"), icon: Info },
+    ] as Array<{ value: ViewerTab; label: string; icon: typeof Box } | false>
+  ).filter(Boolean) as Array<{ value: ViewerTab; label: string; icon: typeof Box }>;
+
   return (
     <div className="flex h-full flex-col overflow-hidden bg-card text-card-foreground">
-      {/* ── Minimal header: just identity + status (table already shows the rest) ── */}
-      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border px-3 py-2">
-        <div className="flex min-w-0 items-center gap-2">
-          <h2 className="truncate font-mono text-sm font-semibold text-foreground">
+      {/* ── Identity strip: one calm row, status/type/rush via the shared badges only ── */}
+      <div className="shrink-0 space-y-2 border-b border-border px-4 py-3">
+        <div className="min-w-0">
+          <h2 className="truncate font-mono text-base font-semibold text-foreground">
             {String(job.jobCode ?? "")}
           </h2>
-          <span className="truncate text-sm text-muted-foreground">
+          <p className="truncate text-sm text-muted-foreground">
             {String(job.description ?? "")}
-          </span>
+          </p>
         </div>
-        <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="inline-flex items-center gap-1.5 text-sm font-medium text-foreground">
+            <span
+              className="inline-flex h-2.5 w-2.5 rounded-full border border-white/20"
+              style={{ backgroundColor: job.cellColor || undefined }}
+            />
+            {job.cellName || t("terminal.columns.cell")}
+          </span>
+          <TerminalEncodingBadges job={job} t={t} />
           {job.modeSummary ? (
             <Badge variant="outline" className="rounded-full text-[10px]">
               {t(`terminal.workModes.readiness.${job.modeSummary.readiness}`)}
             </Badge>
           ) : null}
-          <Badge
-            variant="outline"
-            className={cn("shrink-0 rounded-full text-[10px]", statusBadge.className)}
-          >
-            {statusBadge.label}
-          </Badge>
         </div>
       </div>
 
-      <div className="shrink-0 border-b border-border px-3 py-2">
-        <div className="rounded-xl border border-border bg-muted/20 p-3">
-          <div className="flex flex-wrap items-start justify-between gap-2">
-            <div className="space-y-1">
-              <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
-                {t("terminal.instructions.title", "Cell instructions")}
-              </div>
-              <div className="flex items-center gap-2 text-sm font-medium text-foreground">
-                <span>{job.cellName || t("terminal.columns.cell")}</span>
-                <span
-                  className="inline-flex h-2.5 w-2.5 rounded-full border border-white/20"
-                  style={{ backgroundColor: job.cellColor || undefined }}
-                />
-              </div>
-            </div>
-            <TerminalEncodingBadges job={job} t={t} />
-          </div>
-
-          <div className="mt-3 space-y-2">
-            {instructionPreview ? (
-              <div className="rounded-lg border border-border bg-background/70 px-3 py-2 text-sm leading-5 text-foreground">
-                {instructionPreview}
-              </div>
-            ) : (
-              <TerminalInstructionFallback t={t} />
-            )}
-
-            {currentOperationInstructionSteps.length > 0 ? (
-              <div className="rounded-lg border border-border/70 bg-background/40 px-3 py-2">
-                <div className="mb-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
-                  {t("terminal.instructions.stepHighlights", "Step highlights")}
-                </div>
-                <div className="space-y-1">
-                  {currentOperationInstructionSteps.slice(0, 2).map((substep) => (
-                    <div key={substep.id} className="text-xs text-muted-foreground">
-                      <span className="font-medium text-foreground">{substep.name}:</span>{" "}
-                      {substep.notes}
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ) : null}
-
-            <div className="flex flex-wrap items-center gap-2">
-              <Badge
-                variant="outline"
-                className={cn(
-                  "rounded-full px-2 py-0 text-[10px] uppercase tracking-wide",
-                  operationType.chipClassName,
-                )}
-              >
-                {t(operationType.label.key, operationType.label.fallback)}
-              </Badge>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={viewSteps}
-                className="min-h-9 rounded-full px-3 text-xs"
-              >
-                {t("terminal.instructions.viewSteps", "View steps")}
-              </Button>
-              {hasInstructionFallback ? (
-                <span className="text-xs text-muted-foreground">
-                  {t("terminal.instructions.fallbackHint", "Use routing steps as the fallback operator guide.")}
-                </span>
-              ) : null}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* ── Routing progress (compact) ── */}
-      {job.jobId ? (
-        <div className="shrink-0 border-b border-border px-3 py-2">
-          <JobFlowProgress
-            jobId={job.jobId}
-            currentCellId={job.cellId}
-            nextCellName={nextOperation?.cell?.name}
-            nextCellMetrics={nextCellMetrics}
-          />
-        </div>
-      ) : null}
-
-      {/* ── Resources + Dependencies (inline, compact) ── */}
-      <div className="shrink-0 border-b border-border px-3 py-2">
-        <div className="grid gap-2 lg:grid-cols-2">
-          <OperationResources operationId={job.operationId} />
-          <AssemblyDependencies partId={job.partId} />
-        </div>
-      </div>
-
-      {/* ── CNC Program QR (compact inline) ── */}
-      {job.cncProgramName ? (
-        <div className="shrink-0 border-b border-border px-3 py-2">
-          <div className="flex items-center gap-2">
-            <div className="rounded border border-border bg-white p-1">
-              <CncProgramQrCode programName={job.cncProgramName} size={40} />
-            </div>
-            <div className="min-w-0">
-              <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                {t("parts.cncProgramName")}
-              </div>
-              <div className="truncate font-mono text-sm font-semibold text-foreground">
-                {job.cncProgramName}
-              </div>
-            </div>
-          </div>
-        </div>
-      ) : null}
-
-      {/* ── 3D / PDF / Routing viewer — takes all remaining space ── */}
+      {/* ── Everything reference lives behind tabs and fills the screen ── */}
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         <Tabs
           key={`${job.id}-${defaultTab}`}
@@ -531,35 +409,28 @@ export function DetailPanel({
           onValueChange={(value) => setActiveTab(value as ViewerTab)}
           className="flex h-full flex-col"
         >
-          <div className="shrink-0 border-b border-border px-3 py-2">
-            <TabsList className="grid h-auto w-full grid-cols-3 gap-1 rounded-lg bg-muted/30 p-0.5">
-              <TabsTrigger
-                value="3d"
-                disabled={!job.hasModel}
-                className="min-h-8 rounded-md text-xs data-[state=active]:bg-background"
-              >
-                <Box className="mr-1.5 h-3.5 w-3.5" />
-                3D
-              </TabsTrigger>
-              <TabsTrigger
-                value="pdf"
-                disabled={!job.hasPdf}
-                className="min-h-8 rounded-md text-xs data-[state=active]:bg-background"
-              >
-                <FileText className="mr-1.5 h-3.5 w-3.5" />
-                PDF
-              </TabsTrigger>
-              <TabsTrigger
-                value="ops"
-                className="min-h-8 rounded-md text-xs data-[state=active]:bg-background"
-              >
-                <Layers3 className="mr-1.5 h-3.5 w-3.5" />
-                {t("terminal.routing", "Routing")}
-              </TabsTrigger>
+          <div className="shrink-0 px-4 pt-3">
+            <TabsList
+              className="grid h-auto w-full gap-1 rounded-lg bg-muted/30 p-0.5"
+              style={{ gridTemplateColumns: `repeat(${tabs.length}, minmax(0, 1fr))` }}
+            >
+              {tabs.map((tab) => {
+                const Icon = tab.icon;
+                return (
+                  <TabsTrigger
+                    key={tab.value}
+                    value={tab.value}
+                    className="min-h-9 rounded-md text-xs data-[state=active]:bg-background"
+                  >
+                    <Icon className="mr-1.5 h-3.5 w-3.5" />
+                    {tab.label}
+                  </TabsTrigger>
+                );
+              })}
             </TabsList>
           </div>
 
-          <div className="min-h-0 flex-1 overflow-hidden p-3">
+          <div className="min-h-0 flex-1 overflow-hidden p-4">
             {job.hasModel ? (
               <TabsContent
                 value="3d"
@@ -602,8 +473,77 @@ export function DetailPanel({
               </TabsContent>
             ) : null}
 
-            <TabsContent value="ops" className="m-0 h-full overflow-auto">
-              {renderOperations()}
+            {/* Steps: instructions for this cell, then the full routing ── flat, no nested boxes */}
+            <TabsContent value="steps" className="m-0 h-full space-y-5 overflow-auto">
+              <div className="space-y-2">
+                {hasInstructions ? (
+                  <>
+                    {instructionPreview ? (
+                      <p className="whitespace-pre-wrap text-sm leading-6 text-foreground">
+                        {instructionPreview}
+                      </p>
+                    ) : null}
+                    {currentOperationInstructionSteps.map((substep) => (
+                      <p key={substep.id} className="text-sm leading-6 text-muted-foreground">
+                        <span className="font-medium text-foreground">{substep.name}:</span>{" "}
+                        {substep.notes}
+                      </p>
+                    ))}
+                  </>
+                ) : (
+                  <TerminalInstructionFallback t={t} />
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                  {t("terminal.routing", "Routing")}
+                </div>
+                {renderOperations()}
+              </div>
+            </TabsContent>
+
+            {job.batchContext ? (
+              <TabsContent value="batch" className="m-0 h-full overflow-auto">
+                <OperationBatchTab batch={job.batchContext} />
+              </TabsContent>
+            ) : null}
+
+            {locationTrackingEnabled ? (
+              <TabsContent value="location" className="m-0 h-full overflow-auto">
+                {activeTab === "location" ? (
+                  <OperationLocationTab
+                    partId={job.partId}
+                    operationId={job.operationId}
+                    nextCellId={nextCellId}
+                    nextCellName={nextCellName}
+                  />
+                ) : null}
+              </TabsContent>
+            ) : null}
+
+            {/* Info: resources + dependencies + CNC, the operator reference desk */}
+            <TabsContent value="info" className="m-0 h-full space-y-4 overflow-auto">
+              <div className="grid gap-3 lg:grid-cols-2">
+                <OperationResources operationId={job.operationId} />
+                <AssemblyDependencies partId={job.partId} />
+              </div>
+
+              {job.cncProgramName ? (
+                <div className="flex items-center gap-3 rounded-lg border border-border bg-muted/20 p-3">
+                  <div className="rounded border border-border bg-white p-1">
+                    <CncProgramQrCode programName={job.cncProgramName} size={48} />
+                  </div>
+                  <div className="min-w-0">
+                    <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                      {t("parts.cncProgramName")}
+                    </div>
+                    <div className="truncate font-mono text-sm font-semibold text-foreground">
+                      {job.cncProgramName}
+                    </div>
+                  </div>
+                </div>
+              ) : null}
             </TabsContent>
           </div>
         </Tabs>
@@ -611,7 +551,7 @@ export function DetailPanel({
 
       {/* ── Warnings ── */}
       {job.warnings?.length ? (
-        <div className="shrink-0 border-t border-border bg-amber-500/10 px-3 py-2 text-xs text-amber-600 dark:text-amber-400">
+        <div className="shrink-0 border-t border-border bg-amber-500/10 px-4 py-2 text-xs text-amber-600 dark:text-amber-400">
           <div className="flex items-center gap-1.5">
             <AlertTriangle className="h-3.5 w-3.5" />
             {job.warnings.join(", ")}

--- a/src/components/terminal/OperationBatchTab.tsx
+++ b/src/components/terminal/OperationBatchTab.tsx
@@ -1,0 +1,59 @@
+import { useTranslation } from "react-i18next";
+import { Boxes } from "lucide-react";
+import type { TerminalJob } from "@/types/terminal";
+
+type BatchContext = NonNullable<TerminalJob["batchContext"]>;
+
+/**
+ * Read-only summary of the batch/nest this operation belongs to. The batch is
+ * already on the job payload, so this stays a pure presentation component —
+ * no queries, no duplication of the routing or flow shown elsewhere.
+ */
+export function OperationBatchTab({ batch }: { batch: BatchContext }) {
+  const { t } = useTranslation();
+  const isNest = batch.batchType?.toLowerCase().includes("nest");
+
+  const rows: Array<{ label: string; value: string }> = [
+    { label: t("terminal.batchPanel.type", "Type"), value: isNest ? "Nest" : "Batch" },
+    { label: t("terminal.batchPanel.status", "Status"), value: batch.status },
+    {
+      label: t("terminal.batchPanel.operations", "Operations"),
+      value: String(batch.operationsCount),
+    },
+  ];
+  if (batch.parentBatchNumber) {
+    rows.push({
+      label: t("terminal.batchPanel.parent", "Parent batch"),
+      value: batch.parentBatchNumber,
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Boxes className="h-5 w-5 text-primary" />
+        <span className="font-mono text-lg font-semibold text-foreground">
+          {batch.batchNumber}
+        </span>
+      </div>
+
+      <p className="text-sm leading-6 text-muted-foreground">
+        {t(
+          "terminal.batchPanel.intro",
+          "This operation runs as part of a batch — it moves through production together with the other parts on it.",
+        )}
+      </p>
+
+      <dl className="divide-y divide-border overflow-hidden rounded-lg border border-border">
+        {rows.map((row) => (
+          <div key={row.label} className="flex items-center justify-between gap-3 px-3 py-2">
+            <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+              {row.label}
+            </dt>
+            <dd className="text-sm font-medium text-foreground">{row.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}

--- a/src/components/terminal/OperationLocationTab.tsx
+++ b/src/components/terminal/OperationLocationTab.tsx
@@ -1,0 +1,136 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import { ArrowRight, MapPin } from "lucide-react";
+import { supabase } from "@/integrations/supabase/client";
+import { useProfile } from "@/hooks/useProfile";
+import { useOperator } from "@/contexts/OperatorContext";
+import { useRecordPlacement } from "@/hooks/locations/useRecordPlacement";
+import { useStorageLocations } from "@/hooks/locations/useStorageLocations";
+import { PlacementPickerModal } from "@/components/locations/PlacementPickerModal";
+import { Button } from "@/components/ui/button";
+
+interface OperationLocationTabProps {
+  partId: string;
+  operationId: string;
+  /** Cell the part heads to next — scopes the slot suggestion and is shown to the operator. */
+  nextCellId: string | null;
+  nextCellName: string | null;
+}
+
+/**
+ * "Where is this part?" — reads the part's one active placement and lets the
+ * operator (re)record it from the same slot picker used on completion. Mounted
+ * only when location tracking is enabled and the operator opens the tab, so the
+ * storage-location queries never run on terminals that don't use the module.
+ */
+export function OperationLocationTab({
+  partId,
+  operationId,
+  nextCellId,
+  nextCellName,
+}: OperationLocationTabProps) {
+  const { t } = useTranslation();
+  const profile = useProfile();
+  const { activeOperator } = useOperator();
+  const { recordPlacement, isRecording } = useRecordPlacement();
+  const { locations } = useStorageLocations();
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const tenantId = profile?.tenant_id ?? "";
+
+  // Read only the active placement's location id, then resolve its code/label
+  // from the slot list. Avoids a PostgREST FK embed (the kind that broke the
+  // terminal in prod) and reuses the slots already fetched for the picker.
+  const { data: placement, refetch } = useQuery({
+    queryKey: ["part-placement", tenantId, partId],
+    enabled: Boolean(tenantId && partId),
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("part_placements")
+        .select("location_id")
+        .eq("tenant_id", tenantId)
+        .eq("part_id", partId)
+        .is("removed_at", null)
+        .maybeSingle();
+      if (error) throw error;
+      return data;
+    },
+  });
+
+  const location = placement?.location_id
+    ? locations.find((slot) => slot.id === placement.location_id) ?? null
+    : null;
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-border bg-muted/20 p-4">
+        <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          {location
+            ? t("locations.panel.currentlyAt", "Currently at")
+            : t("locations.panel.notPlaced", "Not placed yet")}
+        </div>
+        {location ? (
+          <div className="mt-1 flex items-center gap-2 text-base font-semibold text-foreground">
+            <MapPin className="h-4 w-4 text-primary" />
+            <span className="font-mono">{location.code}</span>
+            {location.label ? (
+              <span className="text-sm font-normal text-muted-foreground">
+                {location.label}
+              </span>
+            ) : null}
+          </div>
+        ) : (
+          <p className="mt-1 text-sm text-muted-foreground">
+            {t(
+              "locations.panel.notPlacedHint",
+              "Record where you put this part so the next operator can find it.",
+            )}
+          </p>
+        )}
+      </div>
+
+      {nextCellName ? (
+        <div className="flex items-center gap-1.5 px-1 text-sm text-muted-foreground">
+          <ArrowRight className="h-4 w-4" />
+          <span>{t("locations.placement.nextCell", "Heading to")}</span>
+          <span className="font-semibold text-foreground">{nextCellName}</span>
+        </div>
+      ) : null}
+
+      <Button
+        variant="outline"
+        onClick={() => setPickerOpen(true)}
+        className="min-h-11 w-full rounded-lg"
+      >
+        <MapPin className="mr-1.5 h-4 w-4" />
+        {location
+          ? t("locations.panel.move", "Move to another slot")
+          : t("locations.panel.record", "Record location")}
+      </Button>
+
+      <PlacementPickerModal
+        open={pickerOpen}
+        onOpenChange={setPickerOpen}
+        cellId={nextCellId}
+        nextCellName={nextCellName}
+        isRecording={isRecording}
+        onConfirm={(locationId) =>
+          recordPlacement(
+            {
+              partId,
+              locationId,
+              operationId,
+              operatorId: activeOperator?.id ?? null,
+            },
+            {
+              onSuccess: () => {
+                setPickerOpen(false);
+                void refetch();
+              },
+            },
+          )
+        }
+      />
+    </div>
+  );
+}

--- a/src/i18n/locales/de/admin.json
+++ b/src/i18n/locales/de/admin.json
@@ -705,7 +705,15 @@
       "confirm": "Ablage bestätigen",
       "skip": "Überspringen",
       "recorded": "Ablage erfasst",
-      "failed": "Ablage konnte nicht erfasst werden"
+      "failed": "Ablage konnte nicht erfasst werden",
+      "nextCell": "Unterwegs zu"
+    },
+    "panel": {
+      "currentlyAt": "Aktueller Ort",
+      "notPlaced": "Noch nicht abgelegt",
+      "notPlacedHint": "Erfassen Sie, wo Sie dieses Teil abgelegt haben, damit der nächste Bediener es findet.",
+      "record": "Ort erfassen",
+      "move": "In anderen Platz verschieben"
     }
   },
   "timeTracking": {

--- a/src/i18n/locales/de/operator.json
+++ b/src/i18n/locales/de/operator.json
@@ -218,7 +218,20 @@
     "noOperationsFound": "Keine Routingschritte für dieses Teil gefunden.",
     "onHold": "Pausiert",
     "routing": "Routing",
+    "tabs": {
+      "steps": "Schritte",
+      "batch": "Batch",
+      "location": "Standort",
+      "info": "Info"
+    },
     "selectCell": "Zelle auswählen",
+    "batchPanel": {
+      "intro": "Dieser Arbeitsgang läuft als Teil eines Batches — er durchläuft die Produktion zusammen mit den anderen Teilen darin.",
+      "type": "Typ",
+      "status": "Status",
+      "parent": "Übergeordneter Batch",
+      "operations": "Arbeitsgänge"
+    },
     "status": {
       "longRunning": "lange aktiv",
       "notClockedOn": "nicht eingestempelt"

--- a/src/i18n/locales/en/admin.json
+++ b/src/i18n/locales/en/admin.json
@@ -705,7 +705,15 @@
       "confirm": "Confirm placement",
       "skip": "Skip",
       "recorded": "Placement recorded",
-      "failed": "Could not record placement"
+      "failed": "Could not record placement",
+      "nextCell": "Heading to"
+    },
+    "panel": {
+      "currentlyAt": "Currently at",
+      "notPlaced": "Not placed yet",
+      "notPlacedHint": "Record where you put this part so the next operator can find it.",
+      "record": "Record location",
+      "move": "Move to another slot"
     }
   },
   "timeTracking": {

--- a/src/i18n/locales/en/operator.json
+++ b/src/i18n/locales/en/operator.json
@@ -218,7 +218,20 @@
     "noOperationsFound": "No routing steps found for this part.",
     "onHold": "On hold",
     "routing": "Routing",
+    "tabs": {
+      "steps": "Steps",
+      "batch": "Batch",
+      "location": "Location",
+      "info": "Info"
+    },
     "selectCell": "Select Cell",
+    "batchPanel": {
+      "intro": "This operation runs as part of a batch — it moves through production together with the other parts on it.",
+      "type": "Type",
+      "status": "Status",
+      "parent": "Parent batch",
+      "operations": "Operations"
+    },
     "status": {
       "longRunning": "lang actief",
       "notClockedOn": "niet ingeklokt"

--- a/src/i18n/locales/nl/admin.json
+++ b/src/i18n/locales/nl/admin.json
@@ -861,7 +861,15 @@
       "confirm": "Plaatsing bevestigen",
       "skip": "Overslaan",
       "recorded": "Plaatsing vastgelegd",
-      "failed": "Plaatsing kon niet worden vastgelegd"
+      "failed": "Plaatsing kon niet worden vastgelegd",
+      "nextCell": "Op weg naar"
+    },
+    "panel": {
+      "currentlyAt": "Huidige locatie",
+      "notPlaced": "Nog niet neergelegd",
+      "notPlacedHint": "Leg vast waar je dit onderdeel hebt neergelegd zodat de volgende operator het terugvindt.",
+      "record": "Locatie vastleggen",
+      "move": "Naar ander vak verplaatsen"
     }
   },
   "timeTracking": {

--- a/src/i18n/locales/nl/operator.json
+++ b/src/i18n/locales/nl/operator.json
@@ -218,7 +218,20 @@
     "noOperationsFound": "Geen routingstappen gevonden voor dit onderdeel.",
     "onHold": "In de wacht",
     "routing": "Routing",
+    "tabs": {
+      "steps": "Stappen",
+      "batch": "Batch",
+      "location": "Locatie",
+      "info": "Info"
+    },
     "selectCell": "Cel selecteren",
+    "batchPanel": {
+      "intro": "Deze bewerking loopt als onderdeel van een batch — hij gaat samen met de andere onderdelen door productie.",
+      "type": "Type",
+      "status": "Status",
+      "parent": "Bovenliggende batch",
+      "operations": "Bewerkingen"
+    },
     "status": {
       "longRunning": "lang actief",
       "notClockedOn": "niet ingeklokt"

--- a/src/pages/operator/OperatorView.tsx
+++ b/src/pages/operator/OperatorView.tsx
@@ -85,19 +85,31 @@ export default function OperatorView() {
     partId: string;
     operationId: string;
     cellId: string | null;
+    nextCellName: string | null;
   } | null>(null);
 
   const handleCompleteWithPlacement = useCallback(async () => {
     const job = selectedJob;
     await handleComplete();
     if (locationTrackingEnabled && job) {
+      // The drop-off slot belongs to the cell the part heads to next, so the
+      // next operator finds it — scope the picker to that cell, not this one.
+      const sorted = [...selectedPartOperations].sort(
+        (a, b) => a.sequence - b.sequence,
+      );
+      const currentIndex = sorted.findIndex((op) => op.id === job.operationId);
+      const nextOp =
+        currentIndex >= 0 && currentIndex < sorted.length - 1
+          ? sorted[currentIndex + 1]
+          : null;
       setPlacementTarget({
         partId: job.partId,
         operationId: job.operationId,
-        cellId: job.cellId ?? null,
+        cellId: nextOp?.cell_id ?? job.cellId ?? null,
+        nextCellName: nextOp?.cell?.name ?? null,
       });
     }
-  }, [selectedJob, handleComplete, locationTrackingEnabled]);
+  }, [selectedJob, selectedPartOperations, handleComplete, locationTrackingEnabled]);
 
   const handleConfirmPlacement = useCallback(
     (locationId: string) => {
@@ -290,6 +302,7 @@ export default function OperatorView() {
           serverGeometry={geometryData}
           operations={selectedPartOperations}
           onDataRefresh={() => void loadData()}
+          locationTrackingEnabled={locationTrackingEnabled}
         />
       </div>
       ) : null}
@@ -305,6 +318,7 @@ export default function OperatorView() {
             if (!open) setPlacementTarget(null);
           }}
           cellId={placementTarget?.cellId ?? null}
+          nextCellName={placementTarget?.nextCellName ?? null}
           isRecording={isRecording}
           onConfirm={handleConfirmPlacement}
         />


### PR DESCRIPTION
## Summary
- Replace the cluttered, ~8-stacked-section operator detail panel with one calm identity strip + data-driven tabs that fill the screen.
- Remove duplicated UI (status badge, op-type chip, and the routing/flow shown twice) — nothing in the side panel is shown twice.
- Finish the location/placement flow: a Location tab + the completion picker now show where the part goes and indicate the next cell.

## Release Path
- [x] Next biweekly train
- [ ] Critical hotfix exception

Planned train date (`YYYY-MM-DD`) or hotfix issue: next train

## Changes
**Decluttered detail panel (`DetailPanel.tsx`)** — a single design philosophy instead of stacked bordered cards:
- One identity strip: job code + description, current cell, and the shared `TerminalEncodingBadges` (status / type / rush). The standalone status badge and op-type chip were removed — the badges already carry both (no double display).
- Dropped `JobFlowProgress` from the panel: the routing/flow was rendered twice (flow progress + the routing list). The route now lives only in the **Steps** tab.
- Reference content moved behind **data-driven, conditional tabs** that take all remaining height: **3D / PDF** (lazy, only mount when opened), **Steps** (flat instructions + routing — no more nested instruction boxes), **Batch**, **Location**, **Info** (resources + dependencies + CNC). Tabs only render when they have data, so there are no empty Batch/Location tabs.

**Finished the location/placement flow:**
- New modular `OperationLocationTab` shows where the part currently is and lets the operator record/move it.
- The Location tab and the completion `PlacementPickerModal` now indicate the **next cell** the part is heading to, and scope the suggested drop-off slot to that cell so the next operator finds it.
- The active-placement read avoids a PostgREST FK embed (the kind that broke the terminal in prod) and reuses the already-fetched slot list.

**New modular components:** `OperationBatchTab`, `OperationLocationTab`.

## Checklist
- [x] Change was prepared on a non-`main` branch; no direct push to `main` was used
- [x] `npm run build` passes
- [x] `npm run test:run` passes (99 files, 999 tests)
- [ ] New tables have RLS policies — n/a (no schema changes)
- [x] New UI text uses i18n keys (EN + NL + DE)
- [ ] Edge functions have `deno.json` with import map — n/a
- [x] Column names verified against actual DB schema (`part_placements.location_id`, `storage_locations`)
- [x] No customer-identifying, credential, or commercial details were added to repo, PR, commit, or synced ticket surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new tabs in the terminal view for steps, batch details, location tracking, and info.
  * Added a location panel to show the current placement and let users update it.
  * Placement dialogs now show where the item is heading next when available.

* **Bug Fixes**
  * Updated the placement flow to better match the next operation, improving location selection during completion.
  * Improved step expansion behavior in the terminal details view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->