### PR TITLE
fix(time): duplicate-entry units, lost time, and live pause handling

### DIFF
--- a/src/hooks/useOperationBookedHours.test.ts
+++ b/src/hooks/useOperationBookedHours.test.ts
@@ -4,22 +4,27 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import { bookedMinutes, type BookedTimeEntry } from '@/lib/admin/bookedHours';
 
-// Rows the mocked supabase query resolves with.
+// Rows the mocked supabase queries resolve with, per table.
 let timeEntryRows: Array<Record<string, unknown>> = [];
+let pauseRows: Array<Record<string, unknown>> = [];
 
-// Chainable supabase mock: from().select().eq().order() resolves to { data, error }.
-const createChain = () => {
+// Chainable supabase mock: from(table).select().eq().order()/.in() resolves to
+// { data, error }, routing by table so the pauses lookup is independent.
+const createChain = (table: string) => {
   const chain: Record<string, unknown> = {};
-  for (const m of ['select', 'eq', 'order']) {
+  for (const m of ['select', 'eq', 'order', 'in']) {
     chain[m] = vi.fn(() => chain);
   }
   (chain as { then: unknown }).then = (resolve: (v: unknown) => unknown) =>
-    Promise.resolve({ data: timeEntryRows, error: null }).then(resolve);
+    Promise.resolve({
+      data: table === 'time_entry_pauses' ? pauseRows : timeEntryRows,
+      error: null,
+    }).then(resolve);
   return chain;
 };
 
 vi.mock('@/integrations/supabase/client', () => ({
-  supabase: { from: vi.fn(() => createChain()) },
+  supabase: { from: vi.fn((table: string) => createChain(table)) },
 }));
 
 vi.mock('@/lib/logger', () => ({
@@ -45,6 +50,7 @@ describe('useOperationBookedHours', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     timeEntryRows = [];
+    pauseRows = [];
     nowSpy = vi.spyOn(Date, 'now').mockReturnValue(NOW);
   });
 
@@ -97,6 +103,25 @@ describe('useOperationBookedHours', () => {
     expect(result.current.totalMinutes).toBe(60);
     expect(result.current.activeCount).toBe(1);
     expect(result.current.entries[0].isActive).toBe(true);
+  });
+
+  it('subtracts an active entry’s pauses from its live booked time', async () => {
+    timeEntryRows = [
+      { id: 't1', operation_id: 'op-1', operator_id: 'u1', duration: null, start_time: '2026-06-22T11:00:00.000Z', end_time: null, operator: { full_name: 'Alice' } },
+    ];
+    // 15 min (900s) of closed pause within the 60-min live window → 45 min.
+    pauseRows = [
+      { time_entry_id: 't1', paused_at: '2026-06-22T11:10:00.000Z', resumed_at: '2026-06-22T11:25:00.000Z', duration: 900 },
+    ];
+
+    const { result } = renderHook(() => useOperationBookedHours('op-1', 30), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.entries).toHaveLength(1));
+
+    expect(result.current.totalMinutes).toBe(45);
+    expect(result.current.activeCount).toBe(1);
   });
 
   it('flags over-planned via plannedVsBooked without gating', async () => {

--- a/src/hooks/useOperationBookedHours.ts
+++ b/src/hooks/useOperationBookedHours.ts
@@ -90,6 +90,33 @@ export function useOperationBookedHours(
       // Capture one `now` for the whole snapshot — fetch is impure already,
       // so live-elapsed for active entries is anchored here, not at render.
       const now = Date.now();
+
+      // For still-running entries, pull their pauses so the live elapsed
+      // subtracts paused time — matching what clock-off stores, so the figure
+      // doesn't drop the moment the operator stops.
+      const activeIds = ((rows ?? []) as TimeEntryRow[])
+        .filter((row) => row.end_time === null)
+        .map((row) => row.id);
+      const pausedSecondsByEntry = new Map<string, number>();
+      if (activeIds.length > 0) {
+        const { data: pauseRows } = await supabase
+          .from("time_entry_pauses")
+          .select("time_entry_id, paused_at, resumed_at, duration")
+          .in("time_entry_id", activeIds);
+        for (const pause of pauseRows ?? []) {
+          const seconds =
+            pause.duration != null
+              ? pause.duration
+              : pause.resumed_at == null
+                ? Math.max(0, (now - Date.parse(pause.paused_at)) / 1000)
+                : 0;
+          pausedSecondsByEntry.set(
+            pause.time_entry_id,
+            (pausedSecondsByEntry.get(pause.time_entry_id) ?? 0) + seconds,
+          );
+        }
+      }
+
       const baseEntries: BookedTimeEntry[] = [];
       const entries = ((rows ?? []) as TimeEntryRow[]).map((row) => {
         const operator = Array.isArray(row.operator) ? row.operator[0] : row.operator;
@@ -98,6 +125,7 @@ export function useOperationBookedHours(
           duration: row.duration,
           start_time: row.start_time,
           end_time: row.end_time,
+          pausedSeconds: pausedSecondsByEntry.get(row.id) ?? 0,
         };
         baseEntries.push(entry);
         return {

--- a/src/lib/admin/bookedHours.test.ts
+++ b/src/lib/admin/bookedHours.test.ts
@@ -22,6 +22,13 @@ describe('entryMinutes', () => {
   it('counts an active entry as live elapsed against now', () => {
     expect(entryMinutes(e({ start_time: '2026-06-22T11:00:00.000Z' }), NOW)).toBe(60);
   });
+  it('subtracts paused seconds from a live active entry', () => {
+    // 60 min elapsed, 15 min (900s) paused → 45 min booked live.
+    expect(entryMinutes(e({ pausedSeconds: 900 }), NOW)).toBe(45);
+  });
+  it('ignores pausedSeconds once a stored duration exists', () => {
+    expect(entryMinutes(e({ duration: 50, pausedSeconds: 900 }), NOW)).toBe(50);
+  });
 });
 
 describe('bookedMinutes / bookedByOperation', () => {

--- a/src/lib/admin/bookedHours.ts
+++ b/src/lib/admin/bookedHours.ts
@@ -13,17 +13,25 @@ export interface BookedTimeEntry {
   duration: number | null; // minutes, set on clock-off
   start_time: string;
   end_time: string | null;
+  /**
+   * Paused time (seconds) for a still-running entry. The stored `duration`
+   * already excludes pauses on clock-off, so the live elapsed calc must
+   * subtract them too — otherwise the booked figure drops when the operator
+   * stops. Ignored once `duration` is set.
+   */
+  pausedSeconds?: number;
 }
 
 const MS_PER_MIN = 60_000;
 
-/** Minutes booked for one entry: stored duration, else end-start, else live elapsed. */
+/** Minutes booked for one entry: stored duration, else live elapsed minus pauses. */
 export function entryMinutes(e: BookedTimeEntry, now: number): number {
   if (e.duration != null) return Math.max(0, e.duration);
   const start = Date.parse(e.start_time);
   if (Number.isNaN(start)) return 0;
   const end = e.end_time ? Date.parse(e.end_time) : now;
-  return Math.max(0, (end - start) / MS_PER_MIN);
+  const pausedMs = (e.pausedSeconds ?? 0) * 1000;
+  return Math.max(0, (end - start - pausedMs) / MS_PER_MIN);
 }
 
 /** Total booked minutes across entries (active entries counted live against `now`). */

--- a/src/lib/db/time-tracking.ts
+++ b/src/lib/db/time-tracking.ts
@@ -15,16 +15,24 @@ export async function stopTimeTracking(operationId: string, operatorId: string) 
 
   const entry = entries[0];
 
+  // Duplicate open entries (race conditions) are closed too. Their duration is
+  // in MINUTES — the unit time_entries.duration uses everywhere — not seconds,
+  // and is folded into actual_time below so the time isn't silently lost.
+  let duplicateMinutes = 0;
   if (entries.length > 1) {
     logger.debug('Database', `Found ${entries.length} duplicate time entries, closing all`);
     const now = new Date();
     for (let i = 1; i < entries.length; i++) {
       const dupEntry = entries[i];
       const startTime = new Date(dupEntry.start_time);
-      const duration = Math.round((now.getTime() - startTime.getTime()) / 1000);
+      const dupMinutes = Math.max(
+        0,
+        Math.round((now.getTime() - startTime.getTime()) / 60000),
+      );
+      duplicateMinutes += dupMinutes;
       const { error: dupError } = await supabase
         .from("time_entries")
-        .update({ end_time: now.toISOString(), duration })
+        .update({ end_time: now.toISOString(), duration: dupMinutes })
         .eq("id", dupEntry.id);
       if (dupError) throw dupError;
     }
@@ -89,7 +97,7 @@ export async function stopTimeTracking(operationId: string, operatorId: string) 
   if (operation) {
     const { error: actualTimeError } = await supabase
       .from("operations")
-      .update({ actual_time: (operation.actual_time || 0) + duration })
+      .update({ actual_time: (operation.actual_time || 0) + duration + duplicateMinutes })
       .eq("id", operationId);
     if (actualTimeError) throw actualTimeError;
   }


### PR DESCRIPTION
## Summary
Three correctness bugs in the operator time chain, found while tracing how times are handled. Everything is in **minutes** (the unit `operations.estimated_time`, `actual_time`, and `time_entries.duration` all use).

## Release Path
- [x] Next biweekly train

## Changes
- **Duplicate entries stored in seconds → minutes** (`time-tracking.ts`): when `stopTimeTracking` closes duplicate open entries (race conditions), their duration was computed in **seconds** and written to `time_entries.duration`, which is minutes everywhere else — a 60× inflation when those rows were later summed. Now computed in minutes.
- **Duplicate time was lost**: only the primary entry's duration was added to `operations.actual_time`; the duplicates' time was recorded but never accumulated. It's now folded in (`+ duplicateMinutes`).
- **Live booked ignored pauses** (`bookedHours.ts` + `useOperationBookedHours.ts`): an active entry counted raw start→now, while clock-off subtracts paused time — so the booked figure dropped the instant the operator stopped. `entryMinutes` now subtracts an active entry's `pausedSeconds`, and the hook fetches pauses for active entries to supply it.

## Checklist
- [x] Non-`main` branch
- [x] `npm run build` passes
- [x] `npm run test:run` passes — new tests for the pause-aware calc (`bookedHours.test.ts`) and the hook's pause subtraction (`useOperationBookedHours.test.ts`)
- [ ] New tables have RLS policies — n/a
- [ ] Edge functions — n/a
- [x] Column names verified against actual DB schema (`time_entries.duration` minutes, `time_entry_pauses.duration` seconds, `operations.actual_time` minutes)
- [x] No customer-identifying, credential, or commercial details added

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVuRrje2icP7bPNvnz1iF8)_