### PR TITLE
fix(ui): visible selection checkboxes + location prompt on by default

### DIFF
--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -11,7 +11,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+      "peer h-4 w-4 shrink-0 rounded-sm border-2 border-primary bg-background ring-offset-background hover:bg-primary/10 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
       className,
     )}
     {...props}

--- a/supabase/migrations/20260628210000_location_tracking_default_on.sql
+++ b/supabase/migrations/20260628210000_location_tracking_default_on.sql
@@ -1,0 +1,18 @@
+-- Location tracking: default on (opt-out) instead of opt-in.
+--
+-- The placement / drop-off prompt (and Location tab) is gated by
+-- tenants.location_tracking_enabled, which shipped DEFAULT false — so operators
+-- never saw the prompt unless an admin found and flipped the toggle. Make it
+-- available out of the box; shops that don't track physical locations can still
+-- turn it off in Organization Settings.
+
+ALTER TABLE public.tenants
+  ALTER COLUMN location_tracking_enabled SET DEFAULT true;
+
+-- Enable for existing tenants that still carry the old opt-in default.
+UPDATE public.tenants
+  SET location_tracking_enabled = true
+  WHERE location_tracking_enabled IS DISTINCT FROM true;
+
+COMMENT ON COLUMN public.tenants.location_tracking_enabled IS
+  'Enables the location/placement module (operators pick a drop-off slot when reporting work done). Default on; opt-out per tenant.';


### PR DESCRIPTION
## Summary
Two reported bugs from operator/admin testing.

## Release Path
- [x] Next biweekly train

## Changes
- **Invisible selection checkboxes** (`components/ui/checkbox.tsx`): the unchecked box had a 1px `border-primary` on a transparent fill — effectively invisible on the dark theme, so the Operations ("Bewerkingen") workspace looked like it had no row-selection boxes even though selection worked (the count incremented). Now `border-2`, a defined `bg-background`, and a hover tint. Shared component, so every checkbox in the app gets the fix.
- **Location prompt never appeared** (`migrations/…_location_tracking_default_on.sql`): the placement/drop-off flow is gated by `tenants.location_tracking_enabled`, which shipped `DEFAULT false`. The flow itself works end-to-end; it was simply never enabled. Default it **on (opt-out)** and backfill existing tenants. Shops that don't track physical locations can still turn it off in Organization Settings.

> ⚠️ **Behaviour change to flag:** the migration enables the placement prompt for existing tenants. It's reversible per-tenant via the settings toggle — call it out in review if any tenant should stay opt-in.

## Checklist
- [x] Non-`main` branch
- [x] `npm run build` passes
- [x] `npm run test:run` passes (no test changes; checkbox is visual, migration is SQL)
- [x] Column names verified against actual DB schema (`tenants.location_tracking_enabled`)
- [x] No customer-identifying, credential, or commercial details added

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVuRrje2icP7bPNvnz1iF8)_