### PR TITLE
docs(website): v0.9.0 — release notes, operator-panel blog, refreshed terminal docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to Eryxon Flow are documented here.
 
+## [0.9.0] — 2026-06-28
+
+### Added
+
+- **Booked vs budget in the operator panel** — the detail panel shows time
+  booked so far against the operation's budget, with an over/under chip and a
+  progress bar, plus the operators who worked the job (live dot for anyone
+  running now). Display only — it guides, it does not gate.
+- **Step-by-step checklist** surfaced in the Steps tab while the operator is
+  clocked on.
+
+### Changed
+
+- **Time reads in real units** — operation time is stored in minutes but the
+  terminal labelled it with an `h` (a 90-minute job read "90h"). One shared
+  `formatDuration` helper now renders `45m` / `1h 20m` / `2h` across the
+  operator views; two duplicate inline formatters were folded into it.
+- **Complete while clocked on** — Complete no longer blocks on a running timer;
+  it stops the operator's own timer first ("Stop & complete"). Still blocked
+  only by another operator's timer or a full next cell.
+- **Calmer operator panel** — removed duplicate operation-type and
+  work-readiness pills; instruction note now sits under a clear label.
+- **Location tracking on by default** — the placement/drop-off prompt shipped
+  opt-in and was invisible to most shops; now opt-out, switchable per tenant.
+
+### Fixed
+
+- **Time-tracking correctness** — duplicate clock-entries were stored in seconds
+  instead of minutes (60x inflation) and never added to `actual_time`; the live
+  booked figure ignored pauses and dropped on clock-off. All fixed.
+- **Selection checkboxes invisible on dark theme** in the Operations workspace.
+
 ## [0.8.2] — 2026-06-27
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eryxon-flow",
   "private": true,
-  "version": "0.8.2",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/website/src/content/blog/what-the-operator-panel-should-show.md
+++ b/website/src/content/blog/what-the-operator-panel-should-show.md
@@ -1,0 +1,67 @@
+---
+title: "What the operator panel should show"
+description: "An operator at the machine needs three numbers: how long this job should take, how long it has taken, and whether that's over or under. Here's how Eryxon Flow's detail panel answers them — and why we stopped calling 90 minutes '90h'."
+pubDate: 2026-06-28
+author: "Eryxon"
+authorRole: "Eryxon Flow"
+category: "Shop Floor"
+tags: ["operators", "shop floor", "time tracking"]
+ctaIntent: "trial"
+relatedLinks:
+  - label: "Operator terminal"
+    href: "/features/operator-terminal/"
+  - label: "Operator manual"
+    href: "/guides/operator-manual/"
+  - label: "Release notes"
+    href: "/release-notes/v0-9-0/"
+---
+
+Stand at a machine with a job in front of you. Three questions decide whether you're on track:
+how long is this *supposed* to take, how long has it *actually* taken so far, and does that put
+you **over or under**? A shop-floor terminal that can't answer those three quickly isn't pulling
+its weight.
+
+The v0.9.0 operator panel answers them directly.
+
+## Time, in units a human reads
+
+First, a confession. Operation time in Eryxon Flow is stored in **minutes** — the same unit the
+operator's clock writes when they pause or finish. The terminal, though, was printing those
+minutes with an `h` after them. A 90-minute weld read **"90h"**. Nobody welds a panel for ninety
+hours; the label was simply wrong.
+
+Now every time display in the operator views runs through one shared formatter and reads in plain
+units: **45m**, **1h 20m**, **2h**. One function, one convention, no minutes wearing an hours
+costume.
+
+## Booked versus budget — and who's been on it
+
+The detail panel's Steps tab now opens with the numbers that matter: time **booked so far**
+against the operation's **budget**, an **over/under** chip, and a progress bar. Below it, the
+**operators who worked the job**, each with their own booked time, and a live dot for anyone
+running the clock right now.
+
+![Operator Terminal detail panel showing time booked versus budget, the operation instruction, and the routing for a TIG-welding job.](../../assets/operator-terminal-detail-desktop.png)
+*Booked vs budget leads the Steps tab, the instruction is clearly labelled, and the routing reads in real units — 1h 12m, not "72h" (demo data shown).*
+
+This is a guide, not a gate. It tells a team leader where an operation stands; it never stops the
+operator from working.
+
+## Complete shouldn't fight you
+
+Finishing a job used to take two taps in the wrong order: you couldn't **Complete** while the
+clock was running, so you had to **Pause** first, then Complete. Obvious once you've done it, but
+it's a small daily papercut. Now Complete stops your own timer and finishes in one move — the
+button even relabels itself **Stop & complete** while you're clocked on. It only holds back for a
+real reason: another operator still clocked on, or the next cell at capacity.
+
+## The boring fixes that matter most
+
+Behind the visible changes, v0.9.0 corrects three time-tracking bugs: duplicate clock-entries
+(from the occasional double-tap race) were stored in seconds instead of minutes and their time was
+never added to the job's total, and the *live* booked figure ignored pauses — so it would visibly
+drop the instant you clocked off. Those are the kinds of bugs that quietly erode trust in the
+numbers, which is the one thing a time-tracking system can't afford.
+
+Read the full list in the [v0.9.0 release notes](/release-notes/v0-9-0/), or see the whole
+operator path in [the operator terminal docs](/features/operator-terminal/).

--- a/website/src/content/docs/features/operator-terminal.md
+++ b/website/src/content/docs/features/operator-terminal.md
@@ -5,7 +5,7 @@ description: Touch-friendly workstation view showing what to work on, with live 
 
 The Operator Terminal is the screen operators see at their workstation. It runs on tablets and large touchscreens on the shop floor. Everything is designed for touch — large tap targets, no tiny buttons, no keyboard needed.
 
-The tabbed detail panel below arrived in the [v0.8.0 release](/release-notes/v0-8-0/); the priority chip wording was refined in [v0.8.1](/release-notes/v0-8-1/). All shipped changes live in the [release notes](/release-notes/).
+The tabbed detail panel below arrived in the [v0.8.0 release](/release-notes/v0-8-0/); [v0.9.0](/release-notes/v0-9-0/) added time booked-vs-budget, the operators who worked the job, and a one-tap Complete, and made every time read in plain units. All shipped changes live in the [release notes](/release-notes/).
 
 ## Selecting Your Cell
 
@@ -27,7 +27,7 @@ What is next. These parts have physically arrived at your cell and are ready to 
 
 What is on its way. These operations are planned for your cell but the parts have not arrived yet. Use this to see what is coming later today or tomorrow.
 
-Each section shows **totals** at the bottom: total estimated hours and total pieces. This gives you a quick sense of how much work is ahead.
+Each section shows **totals** at the bottom: total time and total pieces. Time reads in plain units — `45m`, `1h 20m`, `2h` — never minutes mislabelled as hours.
 
 ## POLCA Cell Signal
 
@@ -51,9 +51,9 @@ The backlog column tells you how urgent each operation is:
 
 Combined with the POLCA signal, this helps you decide what to pick up next: overdue GO items first, then today's GO items, then the rest.
 
-## Rush Orders
+## Bullet Cards
 
-Rush orders stand out with a red border and always sort to the top of each section. If you see red, that job jumps the queue. Rush orders override normal POLCA priority — work on them even if the next cell shows PAUSE.
+A [Bullet Card](/features/qrm-cards/) is the one priority signal in Eryxon Flow. Operations carrying one stand out with a red border and always sort to the top of each section. If you see red, that job jumps the queue — work it even if the next cell shows PAUSE.
 
 ## Status Bar
 
@@ -62,9 +62,9 @@ The bar at the bottom of the screen shows your current state:
 - **Your name** — confirms who is logged in
 - **Current operation** — what you are working on
 - **Live timer** — how long you have been on this operation
-- **Operator state** — Active, Idle, or Rush
+- **Operator state** — Active or Idle
 
-The state updates automatically. When you start an operation, it switches to Active. When nothing is in process, it shows Idle. When you are working a rush order, it shows Rush.
+The state updates automatically. When you start an operation, it switches to Active. When nothing is in process, it shows Idle.
 
 ## Detail Panel
 
@@ -72,11 +72,11 @@ Tap any operation to open the detail panel. It is built around one idea: a calm 
 
 ![Operator terminal detail panel on a desktop workstation, showing the Steps tab](../../../assets/operator-terminal-detail-desktop.png)
 
-At the top, the **header** shows the job number, the part, the cell you are at, and a few status chips — whether the operation is active, what kind of work it is (cut, weld, finishing…), and a **Bullet** chip if it carries a [Bullet Card](/features/qrm-cards/) and jumps the queue. Each fact appears once; nothing is repeated.
+At the top, the **header** shows the job number, the part, the cell you are at, and two chips: whether the operation is **active**, and a **Bullet** chip if it carries a [Bullet Card](/features/qrm-cards/) and jumps the queue. Each fact appears once; nothing is repeated.
 
 Below the header, tabs hold the detail (only the ones with something to show appear):
 
-- **Steps** — the work instructions for this cell (optional — if there are none, the routing is your guide), followed by the full production route with completed and remaining steps highlighted. Your current step is called out.
+- **Steps** — opens with **time booked vs budget** for this operation (an over/under chip and a progress bar) and the **operators who worked on it**, with a live dot for anyone running the clock now. Below that, the **instruction** for this cell under a clear label, a **step-by-step checklist** that appears while you are clocked on, and the full production route with completed and remaining steps highlighted. Your current step is called out. Times read in plain units (`1h 12m`, not `72h`).
 - **Batch** — when the part runs as part of a nest or batch, this shows the batch number, type, status, and how many operations move together. Hidden when the part is not batched. See [Batch & nesting](/features/batch-management/).
 - **Location** — where the part physically is and where it is heading next. Shown only when location tracking is on. See [Location tracking](/features/location-tracking/).
 - **Info** — required tools and resources, assembly dependencies, and the CNC program QR code.
@@ -85,7 +85,7 @@ Below the header, tabs hold the detail (only the ones with something to show app
 
 When the part has a 3D model or a drawing, **3D** and **PDF** tabs appear too — they load only when you open them, so the panel stays fast. Tap **Expand** for a full-screen view.
 
-The **action bar** is pinned to the bottom in thumb reach: **Start / Pause**, **Report production**, **Complete**, and **Report issue**.
+The **action bar** is pinned to the bottom in thumb reach: **Start / Pause**, **Report production**, **Complete**, and **Report issue**. You don't have to stop the clock before finishing — while you are clocked on, **Complete** reads **Stop & complete** and does both in one tap.
 
 ### On a phone
 
@@ -107,4 +107,4 @@ The terminal follows the device theme, so a workstation in a bright hall and a t
 - Watch the POLCA signals. Working on GO items keeps the whole shop moving.
 - If everything shows PAUSE, flag your foreman — it usually means a downstream bottleneck.
 - Use the detail panel to double-check dimensions or instructions before starting a cut.
-- Rush orders (red border) always come first, regardless of other signals.
+- Bullet Cards (red border) always come first, regardless of other signals.

--- a/website/src/content/release-notes/v0-9-0.md
+++ b/website/src/content/release-notes/v0-9-0.md
@@ -1,0 +1,53 @@
+---
+title: "The operator panel tells the time — and the truth"
+version: "v0.9.0"
+date: 2026-06-28
+status: "stable"
+summary: "Operation time now reads in plain units (1h 20m, not a mislabelled 90h), the detail panel shows time booked versus budget and who worked on the job, Complete no longer makes you stop the clock first, and a clutch of time-tracking and UI bugs are fixed."
+ctaIntent: "trial"
+items:
+  - type: fixed
+    title: "Time reads in real units everywhere"
+    body: "Operation time is stored in minutes, but the terminal was labelling it with an h — so a 90-minute weld read 90h. Every time display in the operator views now uses one shared formatter: 45m, 1h 20m, 2h. No more minutes dressed up as hours."
+  - type: added
+    title: "Booked vs budget, and who worked on it"
+    body: "The detail panel now shows time booked so far against the operation's budget, with an over/under chip and a progress bar, plus the operators who put time on the job and a live dot for anyone running right now. It guides the team leader; it never blocks the operator."
+  - type: added
+    title: "Step-by-step checklist while you work"
+    body: "When you are clocked on, the operation's sub-steps surface as a checklist in the Steps tab instead of hiding inside the routing list — so you can tick through the work in order."
+  - type: changed
+    title: "Complete without stopping the clock first"
+    body: "Completing an operation while still clocked on used to be blocked — you had to Pause, then Complete. Now Complete stops your own timer and finishes in one tap (the button reads Stop & complete). It only holds back if another operator is still clocked on, or the next cell is at capacity."
+  - type: fixed
+    title: "Operator time tracking corrected"
+    body: "Three bugs in the time chain: duplicate clock-entries from race conditions were stored in seconds instead of minutes (a 60x inflation) and their time was never added to the operation's actual total; and the live booked figure ignored pauses, so it dropped the moment you clocked off. All three are fixed."
+  - type: changed
+    title: "A calmer operator panel"
+    body: "Removed duplicate pills that repeated the operation name and a work-readiness state that was the same on every row. The panel keeps the signals that matter — status and the Bullet Card — and the instruction note now sits under a clear Instruction label."
+  - type: changed
+    title: "Drop-off location prompt on by default"
+    body: "The placement flow — asking where parts were put down and pointing to the next cell — shipped switched off, so most shops never saw it. It is now on by default and still switchable per workshop in Organization Settings."
+  - type: fixed
+    title: "Selection checkboxes are visible again"
+    body: "Row-selection checkboxes in the Operations workspace were drawn with an almost-invisible border on the dark theme. They now have a clear box in both light and dark."
+docsLinks:
+  - label: "Operator terminal"
+    href: "/features/operator-terminal/"
+  - label: "Operator manual"
+    href: "/guides/operator-manual/"
+githubUrl: "https://github.com/SheetMetalConnect/eryxon-flow/releases/tag/v0.9.0"
+---
+
+v0.9.0 is an operator-terminal release. The headline is honesty about time: operation
+estimates and booked time are kept in minutes, and the terminal was rendering them with an
+**h** suffix — so a 90-minute job read "90h". Every operator-facing time display now runs
+through one shared formatter and reads in plain units: **45m**, **1h 20m**, **2h**.
+
+On top of that, the detail panel gained the numbers a team leader actually asks for — **time
+booked versus budget**, an **over/under** indicator, and **who worked on the job** — and the
+workflow got out of its own way: **Complete** now stops your timer and finishes in one step
+instead of refusing until you Pause.
+
+Underneath, three time-tracking bugs are fixed (duplicate entries stored in the wrong unit and
+never totalled; live booked time ignoring pauses), the drop-off **location prompt** is on by
+default, and the **selection checkboxes** in the Operations workspace are visible again.


### PR DESCRIPTION
## Summary
Ships the v0.9.0 story to the website: release notes, a blog post, and the refreshed operator-terminal docs (with the new screenshots from the merged app changes).

## Release Path
- [x] Next biweekly train

## Changes
- **Release notes** `v0-9-0.md` — real-unit time, booked-vs-budget + who-worked, one-tap Complete, the three time-tracking fixes, location default-on, and the checkbox fix.
- **Blog** "What the operator panel should show" — booked vs budget, who worked, and why 90 minutes stopped reading as "90h"; embeds the refreshed detail-panel screenshot.
- **Operator terminal docs** updated to the shipped v0.9.0 panel: removed the now-deleted operation-type chip, Rush→Bullet wording, time in plain units, **Stop & complete**, and the booked/budget/checklist Steps tab.
- **Version** bumped to `0.9.0` + CHANGELOG.

Built locally: `astro build` → 156 pages, content collections valid, screenshots optimised.

## Checklist
- [x] Non-`main` branch
- [x] Website `astro build` passes
- [x] No customer-identifying, credential, or commercial details added (screenshots use the bundled demo dataset)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVuRrje2icP7bPNvnz1iF8)_