### PR TITLE
fix(time): self-healing actual_time + don't double-count pieces

### DIFF
--- a/src/components/operator/OperatorWorkQueue.tsx
+++ b/src/components/operator/OperatorWorkQueue.tsx
@@ -85,9 +85,15 @@ interface OperatorWorkQueueProps {
 function sumJobs(jobs: TerminalJob[]) {
   let hours = 0;
   let qty = 0;
+  // Count each part's quantity once — a part with several operations in the
+  // same section would otherwise inflate the piece total.
+  const countedParts = new Set<string>();
   for (const j of jobs) {
     hours += j.hours;
-    qty += j.quantity;
+    if (!countedParts.has(j.partId)) {
+      countedParts.add(j.partId);
+      qty += j.quantity;
+    }
   }
   return { hours, qty };
 }

--- a/src/lib/db/time-tracking.ts
+++ b/src/lib/db/time-tracking.ts
@@ -16,9 +16,9 @@ export async function stopTimeTracking(operationId: string, operatorId: string) 
   const entry = entries[0];
 
   // Duplicate open entries (race conditions) are closed too. Their duration is
-  // in MINUTES — the unit time_entries.duration uses everywhere — not seconds,
-  // and is folded into actual_time below so the time isn't silently lost.
-  let duplicateMinutes = 0;
+  // in MINUTES — the unit time_entries.duration uses everywhere — not seconds.
+  // actual_time is recomputed from the closed-entry sum below, so every closed
+  // duplicate is counted without being added twice.
   if (entries.length > 1) {
     logger.debug('Database', `Found ${entries.length} duplicate time entries, closing all`);
     const now = new Date();
@@ -29,7 +29,6 @@ export async function stopTimeTracking(operationId: string, operatorId: string) 
         0,
         Math.round((now.getTime() - startTime.getTime()) / 60000),
       );
-      duplicateMinutes += dupMinutes;
       const { error: dupError } = await supabase
         .from("time_entries")
         .update({ end_time: now.toISOString(), duration: dupMinutes })
@@ -88,19 +87,25 @@ export async function stopTimeTracking(operationId: string, operatorId: string) 
     .eq("id", entry.id);
   if (updateEntryError) throw updateEntryError;
 
-  const { data: operation } = await supabase
-    .from("operations")
-    .select("actual_time")
-    .eq("id", operationId)
-    .single();
+  // Recompute actual_time from the sum of all closed entries for this operation
+  // rather than incrementing — self-healing against duplicate / lost / crashed
+  // writes, so the stored total never drifts from time_entries (the booked truth).
+  const { data: closedEntries, error: closedError } = await supabase
+    .from("time_entries")
+    .select("duration")
+    .eq("operation_id", operationId)
+    .not("end_time", "is", null);
+  if (closedError) throw closedError;
 
-  if (operation) {
-    const { error: actualTimeError } = await supabase
-      .from("operations")
-      .update({ actual_time: (operation.actual_time || 0) + duration + duplicateMinutes })
-      .eq("id", operationId);
-    if (actualTimeError) throw actualTimeError;
-  }
+  const actualTotal = (closedEntries ?? []).reduce(
+    (sum, e) => sum + (e.duration || 0),
+    0,
+  );
+  const { error: actualTimeError } = await supabase
+    .from("operations")
+    .update({ actual_time: actualTotal })
+    .eq("id", operationId);
+  if (actualTimeError) throw actualTimeError;
 }
 
 /**
@@ -166,19 +171,24 @@ export async function adminStopTimeTracking(timeEntryId: string) {
     .eq("id", entry.id);
   if (adminUpdateEntryError) throw adminUpdateEntryError;
 
-  const { data: operation } = await supabase
-    .from("operations")
-    .select("actual_time")
-    .eq("id", entry.operation_id)
-    .single();
+  // Recompute from the closed-entry sum (same self-healing approach as
+  // stopTimeTracking) so actual_time can't drift from time_entries.
+  const { data: closedEntries, error: closedError } = await supabase
+    .from("time_entries")
+    .select("duration")
+    .eq("operation_id", entry.operation_id)
+    .not("end_time", "is", null);
+  if (closedError) throw closedError;
 
-  if (operation) {
-    const { error: adminActualTimeError } = await supabase
-      .from("operations")
-      .update({ actual_time: (operation.actual_time || 0) + duration })
-      .eq("id", entry.operation_id);
-    if (adminActualTimeError) throw adminActualTimeError;
-  }
+  const actualTotal = (closedEntries ?? []).reduce(
+    (sum, e) => sum + (e.duration || 0),
+    0,
+  );
+  const { error: adminActualTimeError } = await supabase
+    .from("operations")
+    .update({ actual_time: actualTotal })
+    .eq("id", entry.operation_id);
+  if (adminActualTimeError) throw adminActualTimeError;
 }
 
 /**


### PR DESCRIPTION
## Summary
Closes the last two items from the time-handling investigation.

## Release Path
- [x] Next biweekly train

## Changes
- **#35 — `actual_time` can no longer drift from `time_entries`.** `stopTimeTracking` / `adminStopTimeTracking` now **recompute** `operations.actual_time` from the sum of all closed `time_entries` for the operation, instead of incrementing the stored value. Any prior divergence (duplicate/lost/crashed writes) self-heals on the next clock-off — `time_entries` stays the single source of truth.
- **#32 — section piece totals no longer double-count.** The queue section header summed each part's quantity once *per operation* in the section, inflating the `pcs` total for a part that revisits a cell. It now counts each part once.

Note on **#25** (route chevron vs routing list): analysed — there's no remaining within-screen duplication. The terminal detail panel shows the route as a list; other surfaces (the operation modal, admin tables) show it once as a compact chevron. The #919/#925 redesign already removed the chevron-vs-list overlap, so nothing to delete here.

## Checklist
- [x] Non-`main` branch
- [x] `npm run build` passes
- [x] `npm run test:run` passes (terminal + booked-hours suites green)
- [x] Column names verified against actual DB schema (`time_entries.duration`, `operations.actual_time`)
- [x] No customer-identifying, credential, or commercial details added

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVuRrje2icP7bPNvnz1iF8)_