### PR TITLE
fix(terminal): QRM cards as formatting + restore Yellow Card standstill flow (v0.8.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Eryxon Flow are documented here.
 
-## [0.9.0] — 2026-06-28
+## [0.8.3] — 2026-06-28
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ All notable changes to Eryxon Flow are documented here.
 
 ### Fixed
 
+- **Yellow Card standstill flow** — reporting an issue now offers a "standstill?"
+  toggle; turning it on parks the operation under a Yellow Card (`on_hold`) via an
+  `issues` trigger, and the card auto-clears when the issue leaves `pending`.
+  Parked operations stay visible in the queue instead of disappearing. Bullet and
+  Yellow cards are now row formatting + sorting, not pills; the redundant status
+  and operation-type pills are gone from the terminal.
 - **Time-tracking correctness** — duplicate clock-entries were stored in seconds
   instead of minutes (60x inflation) and never added to `actual_time`; the live
   booked figure ignored pauses and dropped on clock-off. All fixed.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eryxon-flow",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.8.3",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/src/components/operator/IssueForm.tsx
+++ b/src/components/operator/IssueForm.tsx
@@ -8,6 +8,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { toast } from "sonner";
 import { Camera, AlertTriangle, Package } from "lucide-react";
@@ -72,6 +73,7 @@ export default function IssueForm({ operationId, open, onOpenChange, onSuccess, 
   const [issueType, setIssueType] = useState<IssueType>("general");
   const [ncrCategory, setNcrCategory] = useState<NcrCategory | "">("");
   const [affectedQuantity, setAffectedQuantity] = useState<number | "">("");
+  const [standstill, setStandstill] = useState(false);
 
   const isShortfall = prefilledData?.isShortfall ?? false;
 
@@ -181,6 +183,8 @@ export default function IssueForm({ operationId, open, onOpenChange, onSuccess, 
         affected_quantity: affectedQuantity !== "" ? affectedQuantity : null,
         current_cell_id: currentCellId,
         intended_next_cell_id: intendedNextCellId,
+        // Parks the operation under a Yellow Card via the issues trigger.
+        causes_standstill: standstill,
       });
 
       if (error) throw error;
@@ -260,6 +264,7 @@ export default function IssueForm({ operationId, open, onOpenChange, onSuccess, 
     setIssueType("general");
     setNcrCategory("");
     setAffectedQuantity("");
+    setStandstill(false);
   };
 
   const handleClose = () => {
@@ -385,6 +390,18 @@ export default function IssueForm({ operationId, open, onOpenChange, onSuccess, 
               className="mt-1"
               required
             />
+          </div>
+
+          <div className="flex items-center justify-between rounded-lg border border-amber-500/30 bg-amber-500/5 p-3">
+            <div className="space-y-0.5 pr-3">
+              <Label htmlFor="standstill" className="text-sm font-medium text-foreground">
+                {t("issues.standstill", "Is the work at a standstill?")}
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                {t("issues.standstillDesc", "Parks this operation under a Yellow Card until the issue is resolved.")}
+              </p>
+            </div>
+            <Switch id="standstill" checked={standstill} onCheckedChange={setStandstill} />
           </div>
 
           <div>

--- a/src/components/terminal/DetailPanel.tsx
+++ b/src/components/terminal/DetailPanel.tsx
@@ -42,10 +42,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { IconDisplay } from "@/components/ui/icon-picker";
 import { useTranslation } from "react-i18next";
 import { logger } from "@/lib/logger";
-import {
-  TerminalEncodingBadges,
-  TerminalInstructionFallback,
-} from "./terminalEncoding";
+import { TerminalInstructionFallback } from "./terminalEncoding";
 import { OperationBatchTab } from "./OperationBatchTab";
 import { OperationLocationTab } from "./OperationLocationTab";
 import { OperationTimeSummary } from "./OperationTimeSummary";
@@ -407,7 +404,6 @@ export function DetailPanel({
             />
             {job.cellName || t("terminal.columns.cell")}
           </span>
-          <TerminalEncodingBadges job={job} t={t} />
         </div>
       </div>
 

--- a/src/components/terminal/DetailPanel.tsx
+++ b/src/components/terminal/DetailPanel.tsx
@@ -387,7 +387,15 @@ export function DetailPanel({
   return (
     <div className="flex h-full flex-col overflow-hidden bg-card text-card-foreground">
       {/* ── Identity strip: one calm row, status/type/rush via the shared badges only ── */}
-      <div className="shrink-0 space-y-2 border-b border-border px-4 py-3">
+      <div
+        className={cn(
+          "shrink-0 space-y-2 border-b border-l-4 border-border px-4 py-3",
+          // Card state as formatting, not a chip: amber = Yellow Card (on hold),
+          // red = Bullet Card (priority).
+          job.status === "on_hold" && "border-l-amber-500",
+          job.isBulletCard && job.status !== "on_hold" && "border-l-destructive",
+        )}
+      >
         <div className="min-w-0">
           <h2 className="truncate font-mono text-base font-semibold text-foreground">
             {String(job.jobCode ?? "")}

--- a/src/components/terminal/JobRow.test.tsx
+++ b/src/components/terminal/JobRow.test.tsx
@@ -33,7 +33,7 @@ const baseJob = {
 };
 
 describe("JobRow", () => {
-  it("renders blocked precedence with bullet badge preserved", () => {
+  it("shows QRM cards as row formatting, not chips", () => {
     render(
       <table>
         <tbody>
@@ -47,9 +47,10 @@ describe("JobRow", () => {
       </table>,
     );
 
-    // Status lives in the section + left border, not a pill. Only Bullet shows.
-    expect(screen.getByText(/terminal\.encoding\.priority\.bullet/)).toBeInTheDocument();
-    expect(screen.queryByText(/terminal\.encoding\.status\./)).not.toBeInTheDocument();
-    expect(screen.getByRole("row")).toHaveClass("border-l-[hsl(var(--status-blocked))]");
+    // No encoding pills any more — status/bullet/yellow are row formatting.
+    expect(screen.queryByText(/terminal\.encoding\./)).not.toBeInTheDocument();
+    // On-hold job = Yellow Card → amber row formatting.
+    expect(screen.getByRole("row")).toHaveClass("border-l-amber-500");
+    expect(screen.getByRole("row")).toHaveClass("bg-amber-500/10");
   });
 });

--- a/src/components/terminal/JobRow.test.tsx
+++ b/src/components/terminal/JobRow.test.tsx
@@ -47,8 +47,9 @@ describe("JobRow", () => {
       </table>,
     );
 
-    expect(screen.getByText(/terminal\.encoding\.status\.blocked/)).toBeInTheDocument();
+    // Status lives in the section + left border, not a pill. Only Bullet shows.
     expect(screen.getByText(/terminal\.encoding\.priority\.bullet/)).toBeInTheDocument();
+    expect(screen.queryByText(/terminal\.encoding\.status\./)).not.toBeInTheDocument();
     expect(screen.getByRole("row")).toHaveClass("border-l-[hsl(var(--status-blocked))]");
   });
 });

--- a/src/components/terminal/JobRow.tsx
+++ b/src/components/terminal/JobRow.tsx
@@ -6,7 +6,7 @@ import { TerminalJob } from "@/types/terminal";
 import { getDueUrgency, dueUrgencyTextClass } from "@/lib/due-date";
 import { formatDuration } from "@/lib/time-utils";
 import { TerminalCellInfo } from "./TerminalCellInfo";
-import { getTerminalStatusTone, TerminalEncodingBadges } from "./terminalEncoding";
+import { getTerminalStatusTone } from "./terminalEncoding";
 
 interface JobRowProps {
   job: TerminalJob;
@@ -48,7 +48,10 @@ export function JobRow({ job, isSelected, onClick, variant }: JobRowProps) {
         isSelected && "bg-accent/50 ring-1 ring-primary",
         variant === "process" && "bg-status-active/5",
         job.isCurrentUserClocked && "bg-primary/10 ring-1 ring-primary/50",
-        job.isBulletCard && job.status !== "on_hold" && "bg-destructive/5",
+        // QRM cards are row formatting, not chips: Yellow Card (on hold /
+        // standstill) is amber; Bullet Card (priority) is red and sorts to top.
+        job.status === "on_hold" && "border-l-amber-500 bg-amber-500/10",
+        job.isBulletCard && job.status !== "on_hold" && "border-l-destructive bg-destructive/5",
       )}
     >
       {/* Job Number */}
@@ -84,17 +87,14 @@ export function JobRow({ job, isSelected, onClick, variant }: JobRowProps) {
 
       {/* Operation */}
       <td className="px-2 py-1.5">
-        <div className="space-y-1">
-          <Badge
-            className={cn(
-              "whitespace-nowrap px-2 py-0.5 text-xs font-semibold text-primary-foreground",
-              getOperationBadgeColor(job.currentOp),
-            )}
-          >
-            {job.currentOp}
-          </Badge>
-          <TerminalEncodingBadges job={job} t={t} compact />
-        </div>
+        <Badge
+          className={cn(
+            "whitespace-nowrap px-2 py-0.5 text-xs font-semibold text-primary-foreground",
+            getOperationBadgeColor(job.currentOp),
+          )}
+        >
+          {job.currentOp}
+        </Badge>
       </td>
 
       {/* Cell — POLCA signal: current → next cell with GO/PAUSE */}

--- a/src/components/terminal/terminalEncoding.tsx
+++ b/src/components/terminal/terminalEncoding.tsx
@@ -143,8 +143,10 @@ export function TerminalEncodingBadges({
   t: TFunction;
   compact?: boolean;
 }) {
-  const statusTone = getTerminalStatusTone(job);
-  const StatusIcon = statusTone.icon;
+  // Status (active/waiting/expected) is already carried by the section the row
+  // sits in and the coloured left border — a status pill here is pure
+  // duplication. Only the Bullet Card, the one priority signal, gets a chip.
+  if (!job.isBulletCard) return null;
   const bulletIsSubdued = job.status === "on_hold";
 
   return (
@@ -153,26 +155,14 @@ export function TerminalEncodingBadges({
         variant="outline"
         className={cn(
           "min-h-6 rounded-full px-2 py-0 text-[10px] font-semibold uppercase tracking-wide",
-          statusTone.chipClassName,
+          bulletIsSubdued
+            ? "border-red-500/30 bg-transparent text-red-500"
+            : "border-red-500/30 bg-red-500/10 text-red-600 dark:text-red-400",
         )}
       >
-        <StatusIcon className="mr-1 h-3 w-3" />
-        {t(statusTone.labelKey, statusTone.fallbackLabel)}
+        <Zap className="mr-1 h-3 w-3" />
+        {t("terminal.encoding.priority.bullet", "Bullet")}
       </Badge>
-      {job.isBulletCard ? (
-        <Badge
-          variant="outline"
-          className={cn(
-            "min-h-6 rounded-full px-2 py-0 text-[10px] font-semibold uppercase tracking-wide",
-            bulletIsSubdued
-              ? "border-red-500/30 bg-transparent text-red-500"
-              : "border-red-500/30 bg-red-500/10 text-red-600 dark:text-red-400",
-          )}
-        >
-          <Zap className="mr-1 h-3 w-3" />
-          {t("terminal.encoding.priority.bullet", "Bullet")}
-        </Badge>
-      ) : null}
     </div>
   );
 }

--- a/src/components/terminal/terminalEncoding.tsx
+++ b/src/components/terminal/terminalEncoding.tsx
@@ -1,6 +1,5 @@
-import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
-import { Clock3, Info, PauseCircle, PlayCircle, ShieldCheck, Zap } from "lucide-react";
+import { Clock3, Info, PauseCircle, PlayCircle, ShieldCheck } from "lucide-react";
 import type { TFunction } from "i18next";
 import type { TerminalJob } from "@/types/terminal";
 
@@ -132,39 +131,6 @@ export function getTerminalOperationType(job: Pick<TerminalJob, "operationType" 
     chipClassName: operationTypeToneByKey[key] || "border-border bg-muted/50 text-muted-foreground",
     label: operationTypeLabelByKey[key] || { key: "terminal.encoding.type.operation", fallback: "Operation" },
   };
-}
-
-export function TerminalEncodingBadges({
-  job,
-  t,
-  compact = false,
-}: {
-  job: TerminalJob;
-  t: TFunction;
-  compact?: boolean;
-}) {
-  // Status (active/waiting/expected) is already carried by the section the row
-  // sits in and the coloured left border — a status pill here is pure
-  // duplication. Only the Bullet Card, the one priority signal, gets a chip.
-  if (!job.isBulletCard) return null;
-  const bulletIsSubdued = job.status === "on_hold";
-
-  return (
-    <div className={cn("flex flex-wrap items-center gap-1.5", compact && "gap-1")}>
-      <Badge
-        variant="outline"
-        className={cn(
-          "min-h-6 rounded-full px-2 py-0 text-[10px] font-semibold uppercase tracking-wide",
-          bulletIsSubdued
-            ? "border-red-500/30 bg-transparent text-red-500"
-            : "border-red-500/30 bg-red-500/10 text-red-600 dark:text-red-400",
-        )}
-      >
-        <Zap className="mr-1 h-3 w-3" />
-        {t("terminal.encoding.priority.bullet", "Bullet")}
-      </Badge>
-    </div>
-  );
 }
 
 export function TerminalInstructionFallback({

--- a/src/hooks/useOperatorTerminal.ts
+++ b/src/hooks/useOperatorTerminal.ts
@@ -413,7 +413,9 @@ export function useOperatorTerminal() {
       else if (op.status === "not_started") status = "in_buffer";
       else if (op.status === "completed") status = "expected";
 
-      if (op.active_time_entry) status = "in_progress";
+      // A clocked-on operation reads as in progress — unless it's parked under a
+      // Yellow Card (on_hold), which must win so the standstill stays visible.
+      if (op.active_time_entry && op.status !== "on_hold") status = "in_progress";
 
       const estimated = op.estimated_time || 0;
       const actual = op.actual_time || 0;

--- a/src/hooks/useOperatorTerminal.ts
+++ b/src/hooks/useOperatorTerminal.ts
@@ -492,7 +492,8 @@ export function useOperatorTerminal() {
   }, [allJobs, selectedCellId]);
 
   const inProcessJobs = filteredJobs.filter(
-    (job) => job.status === "in_progress",
+    // Parked Yellow Card (on_hold) operations stay visible at the cell, not lost.
+    (job) => job.status === "in_progress" || job.status === "on_hold",
   );
   const notStartedJobs = filteredJobs.filter(
     (job) => job.status === "in_buffer" || job.status === "expected",

--- a/src/i18n/locales/de/jobs.json
+++ b/src/i18n/locales/de/jobs.json
@@ -485,6 +485,8 @@
     "createIssue": "Problem melden",
     "critical": "Kritisch",
     "describeIssue": "Beschreiben Sie das Problem...",
+    "standstill": "Steht die Arbeit still?",
+    "standstillDesc": "Stellt diesen Arbeitsgang unter eine Gelbe Karte, bis das Problem gelöst ist.",
     "description": "Beschreibung",
     "editIssue": "Problem bearbeiten",
     "deleteIssue": "Problem löschen",

--- a/src/i18n/locales/de/jobs.json
+++ b/src/i18n/locales/de/jobs.json
@@ -486,7 +486,7 @@
     "critical": "Kritisch",
     "describeIssue": "Beschreiben Sie das Problem...",
     "standstill": "Steht die Arbeit still?",
-    "standstillDesc": "Stellt diesen Arbeitsgang unter eine Gelbe Karte, bis das Problem gelöst ist.",
+    "standstillDesc": "Stellt diesen Arbeitsgang unter eine Gelbe Karte, bis das Problem abgeschlossen ist.",
     "description": "Beschreibung",
     "editIssue": "Problem bearbeiten",
     "deleteIssue": "Problem löschen",

--- a/src/i18n/locales/en/jobs.json
+++ b/src/i18n/locales/en/jobs.json
@@ -488,6 +488,8 @@
     "createIssue": "Report Issue",
     "critical": "Critical",
     "describeIssue": "Describe the issue...",
+    "standstill": "Is the work at a standstill?",
+    "standstillDesc": "Parks this operation under a Yellow Card until the issue is resolved.",
     "description": "Description",
     "editIssue": "Edit Issue",
     "deleteIssue": "Delete Issue",

--- a/src/i18n/locales/en/jobs.json
+++ b/src/i18n/locales/en/jobs.json
@@ -489,7 +489,7 @@
     "critical": "Critical",
     "describeIssue": "Describe the issue...",
     "standstill": "Is the work at a standstill?",
-    "standstillDesc": "Parks this operation under a Yellow Card until the issue is resolved.",
+    "standstillDesc": "Parks this operation under a Yellow Card until the issue is handled.",
     "description": "Description",
     "editIssue": "Edit Issue",
     "deleteIssue": "Delete Issue",

--- a/src/i18n/locales/nl/jobs.json
+++ b/src/i18n/locales/nl/jobs.json
@@ -485,6 +485,8 @@
     "createIssue": "Probleem melden",
     "critical": "Kritiek",
     "describeIssue": "Beschrijf het probleem...",
+    "standstill": "Ligt het werk stil?",
+    "standstillDesc": "Zet deze bewerking onder een Gele Kaart tot het probleem is opgelost.",
     "description": "Beschrijving",
     "editIssue": "Probleem bewerken",
     "deleteIssue": "Probleem verwijderen",

--- a/src/i18n/locales/nl/jobs.json
+++ b/src/i18n/locales/nl/jobs.json
@@ -486,7 +486,7 @@
     "critical": "Kritiek",
     "describeIssue": "Beschrijf het probleem...",
     "standstill": "Ligt het werk stil?",
-    "standstillDesc": "Zet deze bewerking onder een Gele Kaart tot het probleem is opgelost.",
+    "standstillDesc": "Zet deze bewerking onder een Gele Kaart tot het probleem is afgehandeld.",
     "description": "Beschrijving",
     "editIssue": "Probleem bewerken",
     "deleteIssue": "Probleem verwijderen",

--- a/src/integrations/supabase/types/tables/issues.ts
+++ b/src/integrations/supabase/types/tables/issues.ts
@@ -28,6 +28,7 @@ export type IssuesTable = {
     reviewed_by: string | null
     root_cause: string | null
     search_vector: unknown
+    causes_standstill: boolean
     severity: DatabaseEnums["issue_severity"]
     status: DatabaseEnums["issue_status"] | null
     tenant_id: string
@@ -37,6 +38,7 @@ export type IssuesTable = {
   }
   Insert: {
     affected_quantity?: number | null
+    causes_standstill?: boolean
     corrective_action?: string | null
     created_at?: string | null
     created_by: string
@@ -65,6 +67,7 @@ export type IssuesTable = {
   }
   Update: {
     affected_quantity?: number | null
+    causes_standstill?: boolean
     corrective_action?: string | null
     created_at?: string | null
     created_by?: string

--- a/supabase/migrations/20260628223000_yellow_card_standstill.sql
+++ b/supabase/migrations/20260628223000_yellow_card_standstill.sql
@@ -1,0 +1,69 @@
+-- Yellow Card = an operation parked (status 'on_hold') because of a standstill
+-- reported with an issue. Previously the operator could never raise one and a
+-- resolved issue never released the operation. This wires the lifecycle:
+--   report issue + "standstill?" -> operation parked (Yellow Card on)
+--   the issue is resolved/closed -> operation released (Yellow Card off)
+-- driven by a trigger so it holds no matter which path resolves the issue.
+
+-- Mark the issues that put the floor at a standstill.
+ALTER TABLE public.issues
+  ADD COLUMN IF NOT EXISTS causes_standstill boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.issues.causes_standstill IS
+  'True when the reported issue parks its operation under a Yellow Card until resolved.';
+
+-- Remember what the operation was doing before it was parked, so releasing it
+-- restores the right state instead of guessing 'in_progress'.
+ALTER TABLE public.operations
+  ADD COLUMN IF NOT EXISTS status_before_hold text;
+
+COMMENT ON COLUMN public.operations.status_before_hold IS
+  'Operation status captured when a Yellow Card parked it, restored on release.';
+
+CREATE OR REPLACE FUNCTION public.sync_yellow_card_from_standstill()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  open_standstills integer;
+BEGIN
+  -- Open standstill (issue is pending) -> park the operation.
+  IF NEW.causes_standstill AND NEW.status = 'pending' THEN
+    UPDATE public.operations
+      SET status_before_hold = CASE WHEN status <> 'on_hold' THEN status ELSE status_before_hold END,
+          status = 'on_hold'
+      WHERE id = NEW.operation_id AND status <> 'completed';
+    RETURN NEW;
+  END IF;
+
+  -- A standstill issue leaving 'pending' (resolved/closed) -> release the
+  -- operation, but only once no other standstill is still open on it.
+  IF TG_OP = 'UPDATE'
+     AND OLD.causes_standstill AND OLD.status = 'pending'
+     AND NEW.status IS DISTINCT FROM 'pending' THEN
+    SELECT count(*) INTO open_standstills
+      FROM public.issues
+      WHERE operation_id = NEW.operation_id
+        AND causes_standstill
+        AND status = 'pending'
+        AND id <> NEW.id;
+
+    IF open_standstills = 0 THEN
+      UPDATE public.operations
+        SET status = COALESCE(status_before_hold, 'in_progress'),
+            status_before_hold = NULL
+        WHERE id = NEW.operation_id AND status = 'on_hold';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_sync_yellow_card ON public.issues;
+CREATE TRIGGER trg_sync_yellow_card
+  AFTER INSERT OR UPDATE OF status, causes_standstill ON public.issues
+  FOR EACH ROW
+  EXECUTE FUNCTION public.sync_yellow_card_from_standstill();

--- a/supabase/migrations/20260628223000_yellow_card_standstill.sql
+++ b/supabase/migrations/20260628223000_yellow_card_standstill.sql
@@ -38,11 +38,12 @@ BEGIN
     RETURN NEW;
   END IF;
 
-  -- A standstill issue leaving 'pending' (resolved/closed) -> release the
-  -- operation, but only once no other standstill is still open on it.
+  -- A standstill clearing -> release the operation, but only once no other
+  -- standstill is still open on it. This covers the issue leaving 'pending'
+  -- (resolved/closed) and the standstill flag being turned off while pending.
   IF TG_OP = 'UPDATE'
      AND OLD.causes_standstill AND OLD.status = 'pending'
-     AND NEW.status IS DISTINCT FROM 'pending' THEN
+     AND (NEW.status IS DISTINCT FROM 'pending' OR NOT NEW.causes_standstill) THEN
     SELECT count(*) INTO open_standstills
       FROM public.issues
       WHERE operation_id = NEW.operation_id

--- a/website/src/content/blog/what-the-operator-panel-should-show.md
+++ b/website/src/content/blog/what-the-operator-panel-should-show.md
@@ -13,7 +13,7 @@ relatedLinks:
   - label: "Operator manual"
     href: "/guides/operator-manual/"
   - label: "Release notes"
-    href: "/release-notes/v0-9-0/"
+    href: "/release-notes/v0-8-3/"
 ---
 
 Stand at a machine with a job in front of you. Three questions decide whether you're on track:
@@ -21,7 +21,7 @@ how long is this *supposed* to take, how long has it *actually* taken so far, an
 you **over or under**? A shop-floor terminal that can't answer those three quickly isn't pulling
 its weight.
 
-The v0.9.0 operator panel answers them directly.
+The v0.8.3 operator panel answers them directly.
 
 ## Time, in units a human reads
 
@@ -57,11 +57,11 @@ real reason: another operator still clocked on, or the next cell at capacity.
 
 ## The boring fixes that matter most
 
-Behind the visible changes, v0.9.0 corrects three time-tracking bugs: duplicate clock-entries
+Behind the visible changes, v0.8.3 corrects three time-tracking bugs: duplicate clock-entries
 (from the occasional double-tap race) were stored in seconds instead of minutes and their time was
 never added to the job's total, and the *live* booked figure ignored pauses — so it would visibly
 drop the instant you clocked off. Those are the kinds of bugs that quietly erode trust in the
 numbers, which is the one thing a time-tracking system can't afford.
 
-Read the full list in the [v0.9.0 release notes](/release-notes/v0-9-0/), or see the whole
+Read the full list in the [v0.8.3 release notes](/release-notes/v0-8-3/), or see the whole
 operator path in [the operator terminal docs](/features/operator-terminal/).

--- a/website/src/content/docs/features/operator-terminal.md
+++ b/website/src/content/docs/features/operator-terminal.md
@@ -5,7 +5,7 @@ description: Touch-friendly workstation view showing what to work on, with live 
 
 The Operator Terminal is the screen operators see at their workstation. It runs on tablets and large touchscreens on the shop floor. Everything is designed for touch — large tap targets, no tiny buttons, no keyboard needed.
 
-The tabbed detail panel below arrived in the [v0.8.0 release](/release-notes/v0-8-0/); [v0.9.0](/release-notes/v0-9-0/) added time booked-vs-budget, the operators who worked the job, and a one-tap Complete, and made every time read in plain units. All shipped changes live in the [release notes](/release-notes/).
+The tabbed detail panel below arrived in the [v0.8.0 release](/release-notes/v0-8-0/); [v0.8.3](/release-notes/v0-8-3/) added time booked-vs-budget, the operators who worked the job, and a one-tap Complete, and made every time read in plain units. All shipped changes live in the [release notes](/release-notes/).
 
 ## Selecting Your Cell
 

--- a/website/src/content/release-notes/v0-8-3.md
+++ b/website/src/content/release-notes/v0-8-3.md
@@ -1,9 +1,9 @@
 ---
-title: "The operator panel tells the time — and the truth"
-version: "v0.9.0"
+title: "Operator terminal: real-unit time and time-tracking fixes"
+version: "v0.8.3"
 date: 2026-06-28
 status: "stable"
-summary: "Operation time now reads in plain units (1h 20m, not a mislabelled 90h), the detail panel shows time booked versus budget and who worked on the job, Complete no longer makes you stop the clock first, and a clutch of time-tracking and UI bugs are fixed."
+summary: "A maintenance release for the operator terminal. Time now reads in plain units (1h 20m, not a mislabelled 90h), the detail panel adds time booked versus budget and who worked on the job, Complete no longer makes you stop the clock first, and several time-tracking and UI bugs are fixed."
 ctaIntent: "trial"
 items:
   - type: fixed
@@ -35,13 +35,14 @@ docsLinks:
     href: "/features/operator-terminal/"
   - label: "Operator manual"
     href: "/guides/operator-manual/"
-githubUrl: "https://github.com/SheetMetalConnect/eryxon-flow/releases/tag/v0.9.0"
+githubUrl: "https://github.com/SheetMetalConnect/eryxon-flow/releases/tag/v0.8.3"
 ---
 
-v0.9.0 is an operator-terminal release. The headline is honesty about time: operation
-estimates and booked time are kept in minutes, and the terminal was rendering them with an
-**h** suffix — so a 90-minute job read "90h". Every operator-facing time display now runs
-through one shared formatter and reads in plain units: **45m**, **1h 20m**, **2h**.
+v0.8.3 is a maintenance release for the operator terminal — fixes and small panel
+improvements, no new module. The main one is honesty about time: operation estimates and
+booked time are kept in minutes, and the terminal was rendering them with an **h** suffix —
+so a 90-minute job read "90h". Every operator-facing time display now runs through one shared
+formatter and reads in plain units: **45m**, **1h 20m**, **2h**.
 
 On top of that, the detail panel gained the numbers a team leader actually asks for — **time
 booked versus budget**, an **over/under** indicator, and **who worked on the job** — and the

--- a/website/src/content/release-notes/v0-8-3.md
+++ b/website/src/content/release-notes/v0-8-3.md
@@ -9,6 +9,12 @@ items:
   - type: fixed
     title: "Time reads in real units everywhere"
     body: "Operation time is stored in minutes, but the terminal was labelling it with an h — so a 90-minute weld read 90h. Every time display in the operator views now uses one shared formatter: 45m, 1h 20m, 2h. No more minutes dressed up as hours."
+  - type: fixed
+    title: "Yellow Card standstill flow restored"
+    body: "Reporting an issue now asks whether the work is at a standstill. Saying yes parks the operation under a Yellow Card so the floor sees it is interrupted, and the card clears automatically when the issue is resolved. Parked operations stay visible at the cell instead of dropping out of the queue."
+  - type: changed
+    title: "Bullet and Yellow cards are formatting, not pills"
+    body: "The priority Bullet Card (red) and the Yellow Card (amber, on hold) now show as row styling and sorting rather than extra chips, and the redundant status and operation-type pills are gone from the queue and detail panel."
   - type: added
     title: "Booked vs budget, and who worked on it"
     body: "The detail panel now shows time booked so far against the operation's budget, with an over/under chip and a progress bar, plus the operators who put time on the job and a live dot for anyone running right now. It guides the team leader; it never blocks the operator."


### PR DESCRIPTION
## Summary
Fixes the operator-terminal "card" design and the broken Yellow Card feature, and corrects the version to a patch.

## Changes
**Pills removed / cards as formatting**
- Dropped the `ACTIEF`/`WACHTEND` status pill and the operation-type pill from the queue grid and detail panel — duplicated the section header + row border.
- **Bullet Card** = red row (border + tint) + sorts to top. **Yellow Card** (`on_hold`) = amber row. No card chips. (Pill ban scoped to the terminal slop, per request.)

**Yellow Card standstill lifecycle (was unimplemented)**
- Migration: new `issues.causes_standstill` flag + `operations.status_before_hold`, and a `sync_yellow_card_from_standstill` trigger — opening a standstill issue **parks** the operation (`on_hold`); it is **released automatically** once no standstill issue is still `pending`, restoring the pre-park status.
- Report issue now offers a **"standstill?"** toggle (i18n EN/NL/DE) that sets the flag. Resolution needs no extra UI — the trigger handles release.
- Parked (`on_hold`) operations were filtered into **no** queue section and disappeared; they now stay visible in the In-Process section with the amber treatment.

**Versioning**
- `0.9.0 → 0.8.3` (a fix, not a new module) across package.json, CHANGELOG, the renamed release-notes entry, doc link, and blog cross-links.

## Checklist
- [x] Non-`main` branch
- [x] `npm run build` + `astro build` pass
- [x] `npm run test:run` passes (terminal + operator suites green)
- [x] New table column has no RLS concern (flag on existing `issues`); trigger is `SECURITY DEFINER` with fixed `search_path`
- [x] New UI text uses i18n keys (EN + NL + DE)
- [x] Column names verified against actual DB schema (`issues`, `operations`)
- [x] No customer-identifying, credential, or commercial details added

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standstill option when logging issues, letting work be marked as on hold.
  * Yellow Card items now appear as rows with clearer status-based styling and sorting.

* **Bug Fixes**
  * Work items marked on hold now stay visible in active processing views.
  * Operations are automatically parked and restored when standstill-related issues are opened or resolved.
  * Removed redundant status badges from the operator terminal for a cleaner display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->