### PR TITLE
fix(terminal): bullets always on top, drop empty instruction box, fix part-complete crash

### DIFF
--- a/src/components/terminal/DetailPanel.test.tsx
+++ b/src/components/terminal/DetailPanel.test.tsx
@@ -137,14 +137,17 @@ const operations = [
 ];
 
 describe("DetailPanel", () => {
-  it("shows missing-instruction fallback when no notes are available", async () => {
+  it("omits the instruction section entirely when there are no notes", async () => {
     substepRows.splice(0, substepRows.length);
 
     render(<DetailPanel job={baseJob} operations={operations as any} />);
 
+    // No empty placeholder — the Instruction label/section is simply not shown.
     await waitFor(() => {
-      expect(screen.getByText(/terminal\.instructions\.missingTitle/)).toBeInTheDocument();
+      expect(screen.getByText(/terminal\.routing/)).toBeInTheDocument();
     });
+    expect(screen.queryByText(/terminal\.instructions\.missingTitle/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/terminal\.instructionLabel/)).not.toBeInTheDocument();
   });
 
   it("expands routing substeps from the Steps tab", async () => {

--- a/src/components/terminal/DetailPanel.tsx
+++ b/src/components/terminal/DetailPanel.tsx
@@ -42,7 +42,6 @@ import { supabase } from "@/integrations/supabase/client";
 import { IconDisplay } from "@/components/ui/icon-picker";
 import { useTranslation } from "react-i18next";
 import { logger } from "@/lib/logger";
-import { TerminalInstructionFallback } from "./terminalEncoding";
 import { OperationBatchTab } from "./OperationBatchTab";
 import { OperationLocationTab } from "./OperationLocationTab";
 import { OperationTimeSummary } from "./OperationTimeSummary";
@@ -497,29 +496,25 @@ export function DetailPanel({
                 plannedQuantity={job.quantity}
               />
 
-              {/* Instruction — the operation's note, clearly labelled so its source is obvious */}
-              <div className="space-y-2">
-                <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
-                  {t("terminal.instructionLabel", "Instruction")}
+              {/* Instruction — only when there is one. No empty placeholder. */}
+              {hasInstructions ? (
+                <div className="space-y-2">
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                    {t("terminal.instructionLabel", "Instruction")}
+                  </div>
+                  {instructionPreview ? (
+                    <p className="whitespace-pre-wrap text-sm leading-6 text-foreground">
+                      {instructionPreview}
+                    </p>
+                  ) : null}
+                  {currentOperationInstructionSteps.map((substep) => (
+                    <p key={substep.id} className="text-sm leading-6 text-muted-foreground">
+                      <span className="font-medium text-foreground">{substep.name}:</span>{" "}
+                      {substep.notes}
+                    </p>
+                  ))}
                 </div>
-                {hasInstructions ? (
-                  <>
-                    {instructionPreview ? (
-                      <p className="whitespace-pre-wrap text-sm leading-6 text-foreground">
-                        {instructionPreview}
-                      </p>
-                    ) : null}
-                    {currentOperationInstructionSteps.map((substep) => (
-                      <p key={substep.id} className="text-sm leading-6 text-muted-foreground">
-                        <span className="font-medium text-foreground">{substep.name}:</span>{" "}
-                        {substep.notes}
-                      </p>
-                    ))}
-                  </>
-                ) : (
-                  <TerminalInstructionFallback t={t} />
-                )}
-              </div>
+              ) : null}
 
               {/* Step-by-step checklist — surfaced while the operator is clocked on */}
               {job.isCurrentUserClocked && currentOperationSubsteps.length > 0 ? (

--- a/src/components/terminal/JobRow.tsx
+++ b/src/components/terminal/JobRow.tsx
@@ -51,7 +51,7 @@ export function JobRow({ job, isSelected, onClick, variant }: JobRowProps) {
         // QRM cards are row formatting, not chips: Yellow Card (on hold /
         // standstill) is amber; Bullet Card (priority) is red and sorts to top.
         job.status === "on_hold" && "border-l-amber-500 bg-amber-500/10",
-        job.isBulletCard && job.status !== "on_hold" && "border-l-destructive bg-destructive/5",
+        job.isBulletCard && job.status !== "on_hold" && "border-l-destructive bg-destructive/10",
       )}
     >
       {/* Job Number */}

--- a/src/hooks/useOperatorTerminal.ts
+++ b/src/hooks/useOperatorTerminal.ts
@@ -493,13 +493,18 @@ export function useOperatorTerminal() {
     return allJobs.filter((job) => job.cellId === selectedCellId);
   }, [allJobs, selectedCellId]);
 
-  const inProcessJobs = filteredJobs.filter(
+  // Bullet Cards always sort to the top of their section — that is the whole
+  // point of a Bullet Card. Stable for everything else.
+  const bulletFirst = (a: TerminalJob, b: TerminalJob) =>
+    (b.isBulletCard ? 1 : 0) - (a.isBulletCard ? 1 : 0);
+
+  const inProcessJobs = filteredJobs
     // Parked Yellow Card (on_hold) operations stay visible at the cell, not lost.
-    (job) => job.status === "in_progress" || job.status === "on_hold",
-  );
-  const notStartedJobs = filteredJobs.filter(
-    (job) => job.status === "in_buffer" || job.status === "expected",
-  );
+    .filter((job) => job.status === "in_progress" || job.status === "on_hold")
+    .sort(bulletFirst);
+  const notStartedJobs = filteredJobs
+    .filter((job) => job.status === "in_buffer" || job.status === "expected")
+    .sort(bulletFirst);
   const inBufferJobs = notStartedJobs
     .slice(0, 5)
     .map((job) => ({ ...job, status: "in_buffer" as const }));

--- a/supabase/migrations/20260628230000_fix_notify_part_completed_field.sql
+++ b/supabase/migrations/20260628230000_fix_notify_part_completed_field.sql
@@ -1,0 +1,49 @@
+-- notify_part_completed() referenced NEW.name, but the parts table has no
+-- `name` column — it's `part_number`. So every update that set a part to
+-- 'completed' raised `record "new" has no field "name"`, which 400-ed the
+-- completion request and made finishing a job crash. Use part_number.
+
+CREATE OR REPLACE FUNCTION "public"."notify_part_completed"() RETURNS "trigger"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+DECLARE
+  v_admin_ids UUID[];
+  v_admin_id UUID;
+  v_job_number TEXT;
+BEGIN
+  -- Only notify when status changes to completed
+  IF NEW.status = 'completed' AND (OLD.status IS NULL OR OLD.status != 'completed') THEN
+    -- Get job number for context
+    SELECT job_number INTO v_job_number
+    FROM public.jobs
+    WHERE id = NEW.job_id;
+
+    -- Get all admin user IDs for the tenant
+    SELECT array_agg(id) INTO v_admin_ids
+    FROM public.profiles
+    WHERE tenant_id = NEW.tenant_id AND role = 'admin';
+
+    -- Create notification for each admin
+    IF v_admin_ids IS NOT NULL THEN
+      FOREACH v_admin_id IN ARRAY v_admin_ids
+      LOOP
+        PERFORM public.create_notification(
+          NEW.tenant_id,
+          v_admin_id,
+          'part_completed',
+          'low',
+          'Part Completed',
+          'Part ' || COALESCE(NEW.part_number, 'Unnamed') || ' for Job ' || COALESCE(v_job_number::TEXT, 'Unknown') || ' has been completed',
+          '/admin/jobs',
+          'part',
+          NEW.id,
+          jsonb_build_object('part_id', NEW.id, 'job_id', NEW.job_id, 'part_name', NEW.part_number)
+        );
+      END LOOP;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;


### PR DESCRIPTION
## Summary
Three fixes found while testing the live terminal.

## Changes
- **Bullet Cards always sort to the top** of every queue section. There was **no priority sort at all** — bullets just sat wherever they fell. Added a `bulletFirst` comparator to the In-Process and buffer/expected lists.
- **Bullet row styling is more visible** (`bg-destructive/10` instead of `/5`), matching the Yellow Card amber treatment.
- **No empty "Instructions optional" box.** When an operation has no instructions, the Steps tab now omits the Instruction section entirely instead of rendering a placeholder.
- **Fix the completion crash** (migration): `notify_part_completed()` referenced `NEW.name`, but `parts` has no `name` column — it's `part_number`. Every part marked `completed` raised `record "new" has no field "name"`, which 400-ed the completion request. Corrected to `part_number`.

## ⚠️ Deploy note — prod is missing migrations
`list_migrations` shows prod stops at **2026‑06‑22**. The merged migrations from #927 (location default) and #931 (Yellow Card `causes_standstill` / trigger) are **not applied**, which is why report‑issue and completion currently 400 in prod. Apply these three in order (`supabase db push` or SQL editor):
1. `20260628210000_location_tracking_default_on.sql` (#927)
2. `20260628223000_yellow_card_standstill.sql` (#931)
3. `20260628230000_fix_notify_part_completed_field.sql` (this PR)

## Checklist
- [x] Non-`main` branch
- [x] `npm run build` passes
- [x] `npm run test:run` passes (terminal suite green; updated the instruction-fallback test)
- [x] Trigger fix is a `CREATE OR REPLACE FUNCTION` — idempotent, `SECURITY DEFINER` with fixed `search_path` (unchanged from original)
- [x] No customer-identifying, credential, or commercial details added

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVuRrje2icP7bPNvnz1iF8)_