### PR TITLE
Cell-aware drop-off picker + demo slots + setup nudge (v0.8.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to Eryxon Flow are documented here.
 
+## [0.8.5] — 2026-06-29
+
+### Added
+
+- **Demo workspaces seed example drop-off slots** — generating demo data now
+  creates a few drop-off slots per cell, so location tracking (on by default)
+  shows working data instead of an empty picker.
+- **Setup reminder for drop-off locations** — Organization Settings shows a
+  suggestion with a link to Configuration → Locations when location tracking is
+  on but no slots exist yet. A nudge, not a block.
+
+### Changed
+
+- **Drop-off slot picker is cell-aware** — the picker now shows the slots for
+  the cell the part heads to next (plus unassigned general slots) instead of
+  every cell's slots, falling back to all slots if that cell has none. The
+  suggestion prefers the cell's own slots, then a general slot.
+
 ## [0.8.4] — 2026-06-29
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eryxon-flow",
   "private": true,
-  "version": "0.8.4",
+  "version": "0.8.5",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/src/components/locations/PlacementPickerModal.tsx
+++ b/src/components/locations/PlacementPickerModal.tsx
@@ -58,13 +58,19 @@ export function PlacementPickerModal({
     if (!open) setSelectedId(null)
   }, [open])
 
+  // Scope the grid to the target cell's slots plus unassigned (general) slots,
+  // falling back to all slots if the cell has none — never leave nothing to pick.
   const sorted = useMemo(() => {
-    return [...occupancy].sort(
-      (a, b) =>
-        (a.location.sort_order ?? 0) - (b.location.sort_order ?? 0) ||
-        a.location.code.localeCompare(b.location.code),
-    )
-  }, [occupancy])
+    const byOrder = (a: LocationOccupancy, b: LocationOccupancy) =>
+      (a.location.sort_order ?? 0) - (b.location.sort_order ?? 0) ||
+      a.location.code.localeCompare(b.location.code)
+    const scoped = cellId
+      ? occupancy.filter(
+          (o) => o.location.cell_id === cellId || o.location.cell_id == null,
+        )
+      : occupancy
+    return [...(scoped.length > 0 ? scoped : occupancy)].sort(byOrder)
+  }, [occupancy, cellId])
 
   const handleConfirm = () => {
     if (selectedId) onConfirm(selectedId)

--- a/src/i18n/locales/de/admin.json
+++ b/src/i18n/locales/de/admin.json
@@ -657,7 +657,9 @@
       "enableLabel": "Standortverfolgung aktivieren",
       "enableDescription": "Wenn aktiv, wählt ein Bediener nach Abschluss eines Arbeitsgangs einen Ablageplatz.",
       "updated": "Standortverfolgung aktualisiert",
-      "updateFailed": "Standortverfolgung konnte nicht aktualisiert werden"
+      "updateFailed": "Standortverfolgung konnte nicht aktualisiert werden",
+      "noSlotsHint": "Die Standortverfolgung ist aktiv, aber es sind noch keine Ablageplätze eingerichtet — Bediener sehen eine leere Auswahl. Fügen Sie Plätze hinzu, damit sie nützlich ist.",
+      "setupSlots": "Ablageorte einrichten"
     },
     "config": {
       "navTitle": "Standorte",
@@ -701,7 +703,7 @@
       "suggested": "Vorgeschlagen",
       "full": "Voll",
       "occupancy": "{{occupied}}/{{capacity}} belegt",
-      "noSlots": "Es sind keine Ablageplätze konfiguriert. Bitten Sie einen Administrator, sie einzurichten.",
+      "noSlots": "Noch keine Ablageplätze eingerichtet — Sie können ohne Auswahl abschließen. Ein Administrator kann Plätze in den Einstellungen hinzufügen.",
       "confirm": "Ablage bestätigen",
       "skip": "Überspringen",
       "recorded": "Ablage erfasst",

--- a/src/i18n/locales/en/admin.json
+++ b/src/i18n/locales/en/admin.json
@@ -657,7 +657,9 @@
       "enableLabel": "Enable location tracking",
       "enableDescription": "When on, operators pick a drop-off slot after completing an operation.",
       "updated": "Location tracking updated",
-      "updateFailed": "Could not update location tracking"
+      "updateFailed": "Could not update location tracking",
+      "noSlotsHint": "Location tracking is on, but no drop-off slots are set up yet — operators see an empty picker. Add slots to make it useful.",
+      "setupSlots": "Set up drop-off locations"
     },
     "config": {
       "navTitle": "Locations",
@@ -701,7 +703,7 @@
       "suggested": "Suggested",
       "full": "Full",
       "occupancy": "{{occupied}}/{{capacity}} used",
-      "noSlots": "No drop-off slots are configured. Ask an admin to set them up.",
+      "noSlots": "No drop-off slots set up yet — you can finish without recording one. An admin can add slots in Settings.",
       "confirm": "Confirm placement",
       "skip": "Skip",
       "recorded": "Placement recorded",

--- a/src/i18n/locales/nl/admin.json
+++ b/src/i18n/locales/nl/admin.json
@@ -813,7 +813,9 @@
       "enableLabel": "Locatieregistratie inschakelen",
       "enableDescription": "Indien aan kiest een operator een neerlegvak na het afronden van een bewerking.",
       "updated": "Locatieregistratie bijgewerkt",
-      "updateFailed": "Locatieregistratie kon niet worden bijgewerkt"
+      "updateFailed": "Locatieregistratie kon niet worden bijgewerkt",
+      "noSlotsHint": "Locatieregistratie staat aan, maar er zijn nog geen neerlegvakken ingesteld — operators zien een leeg keuzemenu. Voeg vakken toe om het bruikbaar te maken.",
+      "setupSlots": "Neerleglocaties instellen"
     },
     "config": {
       "navTitle": "Locaties",
@@ -857,7 +859,7 @@
       "suggested": "Voorgesteld",
       "full": "Vol",
       "occupancy": "{{occupied}}/{{capacity}} gebruikt",
-      "noSlots": "Er zijn geen neerlegvakken ingesteld. Vraag een beheerder om ze aan te maken.",
+      "noSlots": "Nog geen neerlegvakken ingesteld — je kunt afronden zonder er een te kiezen. Een beheerder kan vakken toevoegen in Instellingen.",
       "confirm": "Plaatsing bevestigen",
       "skip": "Overslaan",
       "recorded": "Plaatsing vastgelegd",

--- a/src/lib/locations/placement.test.ts
+++ b/src/lib/locations/placement.test.ts
@@ -60,6 +60,28 @@ describe('suggestLocation', () => {
     const s = suggestLocation(occ);
     expect(s?.location.code).toBe('B01'); // only open slot left, available 3
   });
+
+  it('falls back to a general (unassigned) slot when the cell has none open', () => {
+    const withGeneral: StorageLocation[] = [
+      ...locs,
+      { id: 'g', code: 'GEN1', cell_id: null, capacity: 5, sort_order: 1 },
+    ];
+    // Both 'cut' slots full → should pick the general slot, not a 'weld' slot.
+    const occ = summarizeOccupancy(withGeneral, [
+      { location_id: 'a' }, { location_id: 'a' }, { location_id: 'b' },
+    ]);
+    expect(suggestLocation(occ, { cellId: 'cut' })?.location.code).toBe('GEN1');
+  });
+
+  it('prefers the cell own slot over a general slot when both are open', () => {
+    const withGeneral: StorageLocation[] = [
+      ...locs,
+      { id: 'g', code: 'GEN1', cell_id: null, capacity: 99, sort_order: 1 },
+    ];
+    const occ = summarizeOccupancy(withGeneral, []);
+    // 'cut' has open slots → pick A01 even though GEN1 has far more space.
+    expect(suggestLocation(occ, { cellId: 'cut' })?.location.code).toBe('A01');
+  });
 });
 
 describe('canPlace', () => {

--- a/src/lib/locations/placement.ts
+++ b/src/lib/locations/placement.ts
@@ -48,8 +48,11 @@ export function summarizeOccupancy(
 }
 
 /**
- * Suggest where to drop the part: the open slot with the most free space, then
- * by configured order, then code. Scoped to a cell when given. Null if all full.
+ * Suggest where to drop the part. When a cell is given, prefer that cell's own
+ * slots, then fall back to unassigned (general, cell_id null) slots — a slot
+ * with no cell belongs to no lane in particular, so it's a valid catch-all.
+ * Within that, pick the most free space, then configured order, then code.
+ * Null if everything in scope is full.
  */
 export function suggestLocation(
   occupancy: LocationOccupancy[],
@@ -57,11 +60,19 @@ export function suggestLocation(
 ): LocationOccupancy | null {
   const cellId = opts?.cellId ?? null;
   const candidates = occupancy.filter(
-    (o) => !o.isFull && (cellId == null || o.location.cell_id === cellId)
+    (o) =>
+      !o.isFull &&
+      (cellId == null ||
+        o.location.cell_id === cellId ||
+        o.location.cell_id == null)
   );
   if (candidates.length === 0) return null;
+  // The cell's own slots rank ahead of general slots.
+  const cellRank = (o: LocationOccupancy) =>
+    cellId != null && o.location.cell_id === cellId ? 0 : 1;
   candidates.sort(
     (a, b) =>
+      cellRank(a) - cellRank(b) ||
       b.available - a.available ||
       (a.location.sort_order ?? 0) - (b.location.sort_order ?? 0) ||
       a.location.code.localeCompare(b.location.code)

--- a/src/lib/mockDataGenerator.ts
+++ b/src/lib/mockDataGenerator.ts
@@ -179,6 +179,32 @@ export async function generateMockData(
       });
 
       logger.debug('MockData', 'Created 6 QRM cells with WIP limits');
+
+      // Example drop-off slots per cell. Location tracking is on by default, so
+      // a fresh demo tenant otherwise opens an empty placement picker. Four
+      // slots per cell (A1–A4, B1–B4, …) give the module working data to show.
+      const slotLetters = ["A", "B", "C", "D", "E", "F"];
+      const storageLocations = (cellData ?? []).flatMap((c, idx) => {
+        const letter = slotLetters[idx] ?? `Z${idx}`;
+        return [1, 2, 3, 4].map((n) => ({
+          tenant_id: tenantId,
+          cell_id: c.id,
+          code: `${letter}${n}`,
+          label: `${c.name} ${n}`,
+          capacity: 2,
+          sort_order: n,
+          active: true,
+        }));
+      });
+      if (storageLocations.length > 0) {
+        const { error: slotError } = await supabase
+          .from("storage_locations")
+          .insert(storageLocations);
+        if (slotError)
+          logger.warn('MockData', 'Storage locations seed warning:', slotError);
+        else
+          logger.debug('MockData', `Created ${storageLocations.length} demo drop-off slots`);
+      }
     }
 
     reportProgress(2, 'calendar');
@@ -2139,6 +2165,21 @@ export async function clearMockData(
       .delete()
       .eq("tenant_id", tenantId);
     if (opsErr) logger.warn('MockData', 'Operations deletion warning:', opsErr);
+
+    // part_placements + storage_locations: storage_locations survives cell
+    // deletion (its cell FK is ON DELETE SET NULL), so clear it explicitly.
+    // part_placements cascades from parts, but delete it first to be explicit.
+    const { error: placementsErr } = await supabase
+      .from("part_placements")
+      .delete()
+      .eq("tenant_id", tenantId);
+    if (placementsErr) logger.warn('MockData', 'Part placements deletion warning:', placementsErr);
+
+    const { error: slotsErr } = await supabase
+      .from("storage_locations")
+      .delete()
+      .eq("tenant_id", tenantId);
+    if (slotsErr) logger.warn('MockData', 'Storage locations deletion warning:', slotsErr);
 
     const { error: partsErr } = await supabase
       .from("parts")

--- a/src/pages/admin/OrganizationSettings.tsx
+++ b/src/pages/admin/OrganizationSettings.tsx
@@ -8,11 +8,13 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
-import { Loader2, Building2, Save, Clock, Paintbrush, Crown, X, Workflow, CheckCircle2, XCircle, MapPin } from 'lucide-react';
+import { Loader2, Building2, Save, Clock, Paintbrush, Crown, X, Workflow, CheckCircle2, XCircle, MapPin, ArrowRight } from 'lucide-react';
 import { toast } from 'sonner';
+import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { FeatureFlagsSettings } from '@/components/admin/FeatureFlagsSettings';
 import { useLocationTracking } from '@/hooks/locations/useLocationTracking';
+import { useStorageLocations } from '@/hooks/locations/useStorageLocations';
 import { logger } from '@/lib/logger';
 import type { PlanningAdapterType } from '@/lib/planning';
 import {
@@ -44,6 +46,7 @@ export default function OrganizationSettings() {
     setEnabled: setLocationTrackingEnabled,
     isUpdating: locationTrackingUpdating,
   } = useLocationTracking();
+  const { locations: storageSlots, isLoading: storageSlotsLoading } = useStorageLocations();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [formData, setFormData] = useState({
@@ -849,6 +852,22 @@ export default function OrganizationSettings() {
               onCheckedChange={(checked) => setLocationTrackingEnabled(checked)}
             />
           </div>
+
+          {/* Guide, don't gate: tracking is on but no slots exist yet, so the
+              operator placement picker is empty. Suggest setting slots up. */}
+          {locationTrackingEnabled && !storageSlotsLoading && storageSlots.length === 0 ? (
+            <div className="mt-4 flex flex-col gap-3 rounded-lg border border-dashed border-border bg-muted/20 p-4 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-sm text-muted-foreground">
+                {t('locations.tracking.noSlotsHint')}
+              </p>
+              <Button asChild variant="outline" size="sm" className="shrink-0">
+                <Link to="/admin/config/locations">
+                  {t('locations.tracking.setupSlots')}
+                  <ArrowRight className="ml-1.5 h-4 w-4" />
+                </Link>
+              </Button>
+            </div>
+          ) : null}
         </CardContent>
       </Card>
 

--- a/website/src/content/docs/features/location-tracking.md
+++ b/website/src/content/docs/features/location-tracking.md
@@ -11,14 +11,14 @@ Recent changes to this area are in the [release notes](/release-notes/).
 
 A part finishes at one cell and waits for the next. On a busy floor, finding that part again costs time. Location tracking records the drop-off slot at the moment the operator reports the work done, so the next person walks straight to it and the planner can see what space is left.
 
-If your floor does not move parts between buffers, leave it off. When off, the terminal does not touch any of it.
+It is on by default. If your floor does not move parts between buffers, turn it off in **Organization Settings → Location tracking** — when off, the terminal does not touch any of it.
 
 ## Admin setup
 
-Turn it on in **Organization Settings → Location tracking**. Then lay out your physical drop-off slots at **Configuration → Locations**:
+Location tracking is on out of the box, so lay out your physical drop-off slots at **Configuration → Locations** (Organization Settings reminds you with a link while no slots exist). A fresh demo workspace already comes with a few example slots per cell so you can see it work:
 
 - Give each slot a **code** (for example `A01`) and an optional label.
-- Tie a slot to a **cell** so suggestions stay close to where the work is.
+- Tie a slot to a **cell** so the picker shows that cell's slots first; leave the cell blank for a general slot any cell can use.
 - Set a **capacity** — how many parts the slot holds.
 
 A slot can be a rack position, a floor zone, a trolley — whatever your floor already uses.
@@ -26,7 +26,7 @@ A slot can be a rack position, a floor zone, a trolley — whatever your floor a
 ## Operator flow
 
 1. The operator finishes an operation and taps complete.
-2. A slot picker opens, pre-selecting the most open slot near the **cell the part heads to next**, and naming that cell so the part lands in the right lane.
+2. A slot picker opens, scoped to the **cell the part heads to next** (plus any general slots), pre-selecting the most open one and naming that cell so the part lands in the right lane.
 3. The operator confirms (or picks a different slot). Full slots are marked so nothing gets double-stacked.
 
 That is the whole interaction — one tap on the slot, one to confirm. A part is only ever in one place: recording a new slot clears the old one automatically.

--- a/website/src/content/release-notes/v0-8-5.md
+++ b/website/src/content/release-notes/v0-8-5.md
@@ -1,0 +1,34 @@
+---
+title: "Location tracking that works out of the box"
+version: "v0.8.5"
+date: 2026-06-29
+status: "stable"
+summary: "Follow-up to v0.8.4 for the drop-off location module. The slot picker now shows the slots for the cell a part heads to next instead of every cell's slots, demo workspaces come with example slots so the feature shows working data, and Organization Settings reminds you to set slots up when tracking is on but none exist."
+ctaIntent: "trial"
+items:
+  - type: changed
+    title: "The slot picker shows the right lane"
+    body: "When an operator records where a part went, the picker now shows the drop-off slots for the cell the part heads to next, plus any general slots, instead of listing every cell's slots. If that cell has none set up, it falls back to showing all of them so there is always somewhere to pick."
+  - type: added
+    title: "Example slots in demo workspaces"
+    body: "Location tracking is on by default. A fresh demo workspace now comes with a few drop-off slots per cell, so the feature shows real, working data the first time you open it instead of an empty picker."
+  - type: added
+    title: "A reminder to set slots up"
+    body: "If location tracking is on but you have not added any slots yet, Organization Settings now shows a short reminder with a link to set them up. It guides; it never blocks an operator from finishing."
+docsLinks:
+  - label: "Location tracking"
+    href: "/features/location-tracking/"
+githubUrl: "https://github.com/SheetMetalConnect/eryxon-flow/releases/tag/v0.8.5"
+---
+
+v0.8.5 follows up on the v0.8.4 drop-off location module. With location tracking
+now on by default, the rough edges showed: a brand-new workspace opened an empty
+slot picker, and the picker listed every cell's slots instead of the lane the part
+was actually heading to.
+
+Three fixes. The picker is now **cell-aware** — it shows the slots for the next
+cell (plus any general, unassigned slots), and only falls back to the full list if
+that cell has none. Demo workspaces **seed example slots** per cell, so the feature
+shows working data from the first click. And Organization Settings shows a **setup
+reminder** with a link when tracking is on but no slots exist yet — a nudge, never
+a block.


### PR DESCRIPTION
Follow-up to the v0.8.4 location module. Location tracking is on by default, but a fresh tenant had no slots and the picker showed every cell's slots regardless of where the part was heading.

## Changes
- **Cell-aware picker** — `PlacementPickerModal` scopes the grid to the target cell's slots plus unassigned (general) slots, falling back to all slots if that cell has none. `suggestLocation` prefers the cell's own slot, then a general slot (+2 tests).
- **Demo seeding** — `generateMockData` creates example drop-off slots per cell; `clearMockData` removes `storage_locations` + `part_placements` (they survive cell deletion: cell FK is `ON DELETE SET NULL`).
- **Setup nudge** — Organization Settings shows a reminder + link to Configuration → Locations when tracking is on but no slots exist. Guide, don't gate.
- i18n en/nl/de, docs refresh, v0.8.5 changelog + release note.

## Verification
- `tsc --noEmit`, `npm run lint`, `npm run test:run` (1011 passing), `npm run build`, and website `npm run build` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)