### PR TITLE
fix(terminal): cell selector never mounts on cached-chunk loads

### DIFF
--- a/src/pages/operator/OperatorView.tsx
+++ b/src/pages/operator/OperatorView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useLayoutEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { ChevronLeft, GripVertical } from "lucide-react";
@@ -24,9 +24,13 @@ import {
 
 export default function OperatorView() {
   const { t } = useTranslation();
-  const [headerSlot, setHeaderSlot] = useState<HTMLElement | null>(
-    () => document.getElementById("terminal-header-slot"),
-  );
+  // Resolve the portal target after commit — reading it during render races the
+  // layout's own render, so on cached-chunk loads the slot isn't in the DOM yet
+  // and the cell selector silently never mounts.
+  const [headerSlot, setHeaderSlot] = useState<HTMLElement | null>(null);
+  useLayoutEffect(() => {
+    setHeaderSlot(document.getElementById("terminal-header-slot"));
+  }, []);
 
   const {
     containerRef,


### PR DESCRIPTION
## Summary
- The cell-selection dropdown in the terminal header (`OperatorView`) intermittently fails to appear, leaving only the operator switcher.
- Root cause: the portal target (`#terminal-header-slot`) was resolved with a `useState` initializer that runs **during render**, racing the layout that owns the slot.

## Release Path
- [x] Next biweekly train
- [ ] Critical hotfix exception

Planned train date (`YYYY-MM-DD`) or hotfix issue: next train

## Changes
`src/pages/operator/OperatorView.tsx` portals the cell selector into `#terminal-header-slot`, a div rendered by `OperatorLayout`. The slot was read via `useState(() => document.getElementById("terminal-header-slot"))`, which executes during OperatorView's render.

When the lazy `OperatorView` chunk is already cached (i.e. after the first load, or navigating in from admin), `Layout` flips from `null`→content and both the layout and `OperatorView` render in the *same commit*. The initializer therefore calls `getElementById` before the slot is in the DOM, gets `null`, and — because the value is captured once and never re-read — the cell selector silently never mounts. It only worked on the first uncached load, where Suspense commits the layout before OperatorView renders.

Fix: resolve the portal target in a `useLayoutEffect` (runs post-commit, before paint), so the slot is guaranteed present and the dropdown renders reliably.

## Checklist
- [x] Change was prepared on a non-`main` branch; no direct push to `main` was used
- [x] `npm run build` passes
- [x] `npm run test:run` passes (OperatorView + useOperatorTerminal suites verified)
- [ ] New tables have RLS policies — n/a
- [ ] New UI text uses i18n keys (EN + NL + DE) — n/a, no new strings
- [ ] Edge functions have `deno.json` with import map — n/a
- [ ] Column names verified against actual DB schema — n/a
- [x] No customer-identifying, credential, or commercial details were added to repo, PR, commit, or synced ticket surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FzPu4ccjfjncF9KAsGnn9

---
_Generated by [Claude Code](https://claude.ai/code/session_018FzPu4ccjfjncF9KAsGnn9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the terminal header portal so it now mounts correctly even when the target element is not immediately available.
  * Prevented a render timing issue that could cause the header slot to fail to appear in some cached-content situations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->